### PR TITLE
Implement RFC 8707 Resource Indicators for OAuth 2.0

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -274,7 +274,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 
 	// Initialize OAuth services.
 	err = oauth.Initialize(mux, applicationService, authnProvider, jwtService, flowExecService, observabilitySvc,
-		pkiService, ouService, attributeCacheService, authZService, entityProvider)
+		pkiService, ouService, attributeCacheService, authZService, entityProvider, resourceService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/dbscripts/configdb/postgres.sql
+++ b/backend/dbscripts/configdb/postgres.sql
@@ -174,7 +174,8 @@ CREATE TABLE RESOURCE_SERVER (
     OU_ID VARCHAR(36) NOT NULL,
     NAME VARCHAR(100) NOT NULL,
     DESCRIPTION TEXT,
-    IDENTIFIER VARCHAR(100),
+    HANDLE VARCHAR(100),
+    IDENTIFIER VARCHAR(2048),
     PROPERTIES JSONB,
     CREATED_AT TIMESTAMPTZ DEFAULT NOW(),
     UPDATED_AT TIMESTAMPTZ DEFAULT NOW(),
@@ -183,6 +184,11 @@ CREATE TABLE RESOURCE_SERVER (
 
 -- Composite index for name-based resource server lookups
 CREATE INDEX idx_resource_server_name_deployment ON RESOURCE_SERVER (DEPLOYMENT_ID, NAME);
+
+-- Unique constraint: Resource server handle must be unique per deployment (when not null)
+CREATE UNIQUE INDEX uq_resource_server_handle
+    ON RESOURCE_SERVER(HANDLE, DEPLOYMENT_ID)
+    WHERE HANDLE IS NOT NULL;
 
 -- Unique constraint: Resource server identifier must be unique per deployment (when not null)
 CREATE UNIQUE INDEX uq_resource_server_identifier

--- a/backend/dbscripts/configdb/sqlite.sql
+++ b/backend/dbscripts/configdb/sqlite.sql
@@ -174,7 +174,8 @@ CREATE TABLE RESOURCE_SERVER (
     OU_ID VARCHAR(36) NOT NULL,
     NAME VARCHAR(100) NOT NULL,
     DESCRIPTION TEXT,
-    IDENTIFIER VARCHAR(100),
+    HANDLE VARCHAR(100),
+    IDENTIFIER VARCHAR(2048),
     PROPERTIES TEXT,
     CREATED_AT TEXT DEFAULT (datetime('now')),
     UPDATED_AT TEXT DEFAULT (datetime('now')),
@@ -183,6 +184,11 @@ CREATE TABLE RESOURCE_SERVER (
 
 -- Composite index for name-based resource server lookups
 CREATE INDEX idx_resource_server_name_deployment ON RESOURCE_SERVER (DEPLOYMENT_ID, NAME);
+
+-- Unique constraint: Resource server handle must be unique per deployment (when not null)
+CREATE UNIQUE INDEX uq_resource_server_handle
+    ON RESOURCE_SERVER(HANDLE, DEPLOYMENT_ID)
+    WHERE HANDLE IS NOT NULL;
 
 -- Unique constraint: Resource server identifier must be unique per deployment (when not null)
 CREATE UNIQUE INDEX uq_resource_server_identifier

--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -316,8 +316,9 @@ func (s *consentEnforcerService) createConsentSessionToken(promptData *ConsentPr
 		consentSessionClaimKey: json.RawMessage(sessionJSON),
 	}
 
+	claims["aud"] = consentSessionTokenAudience
 	token, _, svcErr := s.jwtService.GenerateJWT(
-		"", consentSessionTokenAudience, issuer,
+		"", issuer,
 		consentSessionTokenValidityPeriod, claims, "")
 	if svcErr != nil {
 		return "", errors.New("failed to generate consent session token: " + svcErr.Error.DefaultValue)

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -248,7 +248,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PromptNeeded() {
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -281,7 +281,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_RequiredAttributesF
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	// Only request "email" — "phone" and "address" should be filtered out
@@ -317,7 +317,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_UserProfileFilter()
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -360,7 +360,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PartialConsentsExis
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(existingConsents, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -418,7 +418,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_CreateConsentSessio
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},
@@ -437,7 +437,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestCreateConsentSessionToken_Generate
 		Purposes: []ConsentPurposePrompt{{PurposeName: "purpose-1", Essential: []string{"email"}}},
 	}
 
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -424,7 +424,8 @@ func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *co
 
 	// Generate auth assertion JWT
 	jwtConfig := config.GetThunderRuntime().Config.JWT
-	token, _, err := as.jwtService.GenerateJWT(user.ID, jwtConfig.Audience, jwtConfig.Issuer,
+	jwtClaims["aud"] = jwtConfig.Audience
+	token, _, err := as.jwtService.GenerateJWT(user.ID, jwtConfig.Issuer,
 		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT)
 	if err != nil {
 		logger.Error("Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
@@ -694,7 +695,8 @@ func (as *authenticationService) createSessionToken(idpID string, idpType idp.ID
 	}
 
 	jwtConfig := config.GetThunderRuntime().Config.JWT
-	token, _, err := as.jwtService.GenerateJWT("auth-svc", "auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT)
+	claims["aud"] = "auth-svc"
+	token, _, err := as.jwtService.GenerateJWT("auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -207,7 +207,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
@@ -243,7 +243,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
@@ -319,8 +319,8 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsJWTG
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "JWT_GENERATION_FAILED",
@@ -515,7 +515,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
@@ -544,7 +544,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
@@ -599,7 +599,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -621,7 +621,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSucce
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -642,7 +642,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -663,7 +663,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -728,7 +728,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -748,7 +748,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -853,7 +853,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
 					mock.Anything, mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
@@ -881,7 +881,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
@@ -1395,8 +1395,8 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
 		Return(testJWTToken, int64(3600), nil).Once()
 
 	// Test with empty existingAssertion
@@ -1592,8 +1592,8 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTPJWTGenerationError() {
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "JWT_GENERATION_FAILED",
@@ -1955,7 +1955,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Suc
 		return len(refs) == 1 && refs[0].Authenticator == common.AuthenticatorPasskey
 	})).Return(mockAssertionResult, nil).Once()
 
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["userType"] == "person" && claims["ouId"] == testOrgUnit
 		}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
@@ -2037,7 +2037,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Wit
 	suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).
 		Return(mockUpdatedResult, nil).Once()
 
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -205,7 +205,8 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		}
 	}
 
-	token, _, err := a.jwtService.GenerateJWT(tokenSub, ctx.AppID, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT)
+	jwtClaims["aud"] = ctx.AppID
+	token, _, err := a.jwtService.GenerateJWT(tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT)
 	if err != nil {
 		logger.Error("Failed to generate JWT token", log.String("error", err.Error.DefaultValue))
 		return "", errors.New("failed to generate JWT token: " + err.Error.DefaultValue)

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -159,7 +159,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 		Context: &authnassert.AssuranceContext{},
 	}, nil)
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
@@ -208,7 +208,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions(
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			perms, ok := claims["authorized_permissions"]
 			return ok && perms == "read:documents write:documents"
@@ -250,7 +250,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["email"] == testEmail && claims["phone"] == "1234567890"
 		}), mock.Anything).Return("jwt-token", int64(3600), nil)
@@ -277,7 +277,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",
@@ -546,7 +546,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 		},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimUserType] == "EXTERNAL" && claims[oauth2const.ClaimOUID] == "ou-456"
 		}), mock.Anything).Return("jwt-token", int64(3600), nil)
@@ -580,7 +580,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 		},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", "https://test.thunder.io", int64(7200),
+	suite.mockJWTService.On("GenerateJWT", "user-123", "https://test.thunder.io", int64(7200),
 		mock.Anything, mock.Anything).Return("jwt-token", int64(7200), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -615,7 +615,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 		Handle: "eng",
 	}, nil)
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimOUID] == testAssertOUID &&
 				claims[oauth2const.ClaimOUName] == "Engineering" &&
@@ -689,7 +689,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 
 	existingUser.Attributes = attrsJSON
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -824,7 +824,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should contain the configured user attributes from the user store
 			hasEmail := claims["email"] == testEmail
@@ -867,7 +867,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 
 	suite.mockEntityProvider.On("GetTransitiveEntityGroups", "user-123").
 		Return(userGroups, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should contain groups claim
 			groups, ok := claims[oauth2const.UserAttributeGroups].([]string)
@@ -905,7 +905,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 
 	suite.mockEntityProvider.On("GetTransitiveEntityGroups", "user-123").
 		Return([]entityprovider.EntityGroup{}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should NOT contain groups claim when groups list is empty
 			_, ok := claims[oauth2const.UserAttributeGroups]
@@ -1076,7 +1076,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should only have email and name (consented), NOT phone
 			_, hasPhone := claims["phone"]
@@ -1111,7 +1111,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithEmptyConsentedAttribut
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1135,7 +1135,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithoutConsentedAttributes
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1183,7 +1183,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_AttrsSt
 				cache.Attributes["phone"] == "1234567890"
 		})).Return(&attributecache.AttributeCache{ID: "cache-abc"}, nil)
 	// In the OAuth cache path, only aci goes into the JWT; individual attrs go to cache.
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
@@ -1234,7 +1234,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilUser
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
 	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
 		Return(&attributecache.AttributeCache{ID: "cache-xyz"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// aci present, but no individual attribute claims
 			_, hasEmail := claims["email"]
@@ -1287,7 +1287,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OnlyRes
 			return cache.Attributes["email"] == testEmail && !hasPhone
 		})).Return(&attributecache.AttributeCache{ID: "cache-def"}, nil)
 	// JWT should only contain aci, not individual attrs
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
@@ -1335,7 +1335,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAsse
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
 	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
 		Return(&attributecache.AttributeCache{ID: "cache-nil"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			return claims["aci"] == "cache-nil" && !hasEmail
@@ -1561,7 +1561,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsI
 			groups, ok := cache.Attributes[oauth2const.UserAttributeGroups].([]string)
 			return ok && len(groups) == 2
 		})).Return(&attributecache.AttributeCache{ID: "cache-groups"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasGroups := claims[oauth2const.UserAttributeGroups]
 			return claims["aci"] == "cache-groups" && !hasGroups
@@ -1602,7 +1602,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTyp
 		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
 			return cache.Attributes[oauth2const.ClaimUserType] == "EXTERNAL"
 		})).Return(&attributecache.AttributeCache{ID: "cache-usertype"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserType := claims[oauth2const.ClaimUserType]
 			return claims["aci"] == "cache-usertype" && !hasUserType
@@ -1645,7 +1645,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OUDetai
 			return cache.Attributes[oauth2const.ClaimOUID] == testAuthOUID &&
 				cache.Attributes[oauth2const.ClaimOUName] == "Engineering"
 		})).Return(&attributecache.AttributeCache{ID: "cache-ou"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasOUID := claims[oauth2const.ClaimOUID]
 			return claims["aci"] == "cache-ou" && !hasOUID
@@ -1689,7 +1689,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithRuntimeRequiredEssenti
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasPhone := claims["phone"]
 			return claims["email"] == testEmail && claims["name"] == testNameValue && !hasPhone

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -291,8 +291,9 @@ func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (stri
 	validityPeriod := (sessionData.ExpiryTime - time.Now().UnixMilli()) / 1000
 	jwtConfig := config.GetThunderRuntime().Config.JWT
 
+	claims["aud"] = "otp-svc"
 	token, _, err := s.jwtService.GenerateJWT(
-		"otp-svc", "otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT)
+		"otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %v", err)
 	}

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -330,7 +330,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
@@ -385,7 +385,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.InternalServerError).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
@@ -642,7 +642,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_TemplateRenderSuccess_UsesRendered
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("token", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -38,6 +38,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/userinfo"
 	"github.com/asgardeo/thunder/internal/oauth/scope"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -57,6 +58,7 @@ func Initialize(
 	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	authzService authz.AuthorizationServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
+	resourceService resource.ResourceServiceInterface,
 ) error {
 	// Fetch runtime transactioner for OAuth services.
 	transactioner, err := provider.GetDBProvider().GetRuntimeDBTransactioner()
@@ -68,7 +70,7 @@ func Initialize(
 	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService)
 	grantHandlerProvider, err := granthandlers.Initialize(
 		mux, jwtService, applicationService, flowExecService, tokenBuilder, tokenValidator,
-		attributeCacheSvc, ouService, authzService, entityProvider)
+		attributeCacheSvc, ouService, authzService, entityProvider, resourceService)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -140,7 +140,7 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 		jsonDataKeyScopes:              authzCode.Scopes,
 		jsonDataKeyCodeChallenge:       authzCode.CodeChallenge,
 		jsonDataKeyCodeChallengeMethod: authzCode.CodeChallengeMethod,
-		jsonDataKeyResource:            authzCode.Resource,
+		jsonDataKeyResource:            authzCode.Resources,
 		jsonDataKeyClaimsLocales:       authzCode.ClaimsLocales,
 		jsonDataKeyNonce:               authzCode.Nonce,
 	}
@@ -251,8 +251,14 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 	if codeChallengeMethod, ok := authzData[jsonDataKeyCodeChallengeMethod].(string); ok {
 		authzCode.CodeChallengeMethod = codeChallengeMethod
 	}
-	if resource, ok := authzData[jsonDataKeyResource].(string); ok {
-		authzCode.Resource = resource
+	if rawResources, ok := authzData[jsonDataKeyResource].([]interface{}); ok {
+		resources := make([]string, 0, len(rawResources))
+		for _, r := range rawResources {
+			if s, ok := r.(string); ok {
+				resources = append(resources, s)
+			}
+		}
+		authzCode.Resources = resources
 	}
 	if claimsLocales, ok := authzData[jsonDataKeyClaimsLocales].(string); ok {
 		authzCode.ClaimsLocales = claimsLocales

--- a/backend/internal/oauth/oauth2/authz/auth_req_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store.go
@@ -151,7 +151,7 @@ func (authzRS *authorizationRequestStore) getJSONDataBytes(authRequestCtx authRe
 		jsonKeyPermissionScopes:    authRequestCtx.OAuthParameters.PermissionScopes,
 		jsonKeyCodeChallenge:       authRequestCtx.OAuthParameters.CodeChallenge,
 		jsonKeyCodeChallengeMethod: authRequestCtx.OAuthParameters.CodeChallengeMethod,
-		jsonKeyResource:            authRequestCtx.OAuthParameters.Resource,
+		jsonKeyResource:            authRequestCtx.OAuthParameters.Resources,
 		jsonKeyClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
 		jsonKeyNonce:               authRequestCtx.OAuthParameters.Nonce,
 	}
@@ -225,8 +225,10 @@ func (authzRS *authorizationRequestStore) buildAuthRequestContextFromResultRow(
 	if codeChallengeMethod, ok := requestDataMap[jsonKeyCodeChallengeMethod].(string); ok {
 		oauthParams.CodeChallengeMethod = codeChallengeMethod
 	}
-	if resource, ok := requestDataMap[jsonKeyResource].(string); ok {
-		oauthParams.Resource = resource
+	if rawResources, ok := requestDataMap[jsonKeyResource].([]interface{}); ok {
+		oauthParams.Resources = convertToStringArray(rawResources)
+	} else if resources, ok := requestDataMap[jsonKeyResource].([]string); ok {
+		oauthParams.Resources = resources
 	}
 	if claimsLocales, ok := requestDataMap[jsonKeyClaimsLocales].(string); ok {
 		oauthParams.ClaimsLocales = claimsLocales

--- a/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
@@ -81,7 +81,7 @@ func (suite *AuthorizationRequestStoreTestSuite) SetupTest() {
 			PermissionScopes:    []string{"read", "write"},
 			CodeChallenge:       "test-challenge",
 			CodeChallengeMethod: "S256",
-			Resource:            "https://api.example.com/resource",
+			Resources:           []string{"https://api.example.com/resource"},
 		},
 	}
 }
@@ -184,7 +184,7 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_Success() {
 		"permission_scopes":     []interface{}{"read", "write"},
 		"code_challenge":        "test-challenge",
 		"code_challenge_method": "S256",
-		"resource":              "https://api.example.com/resource",
+		"resource":              []interface{}{"https://api.example.com/resource"},
 	}
 	requestDataJSON, _ := json.Marshal(requestData)
 
@@ -213,7 +213,7 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_Success() {
 	assert.Equal(suite.T(), []string{"read", "write"}, result.OAuthParameters.PermissionScopes)
 	assert.Equal(suite.T(), "test-challenge", result.OAuthParameters.CodeChallenge)
 	assert.Equal(suite.T(), "S256", result.OAuthParameters.CodeChallengeMethod)
-	assert.Equal(suite.T(), "https://api.example.com/resource", result.OAuthParameters.Resource)
+	assert.Equal(suite.T(), []string{"https://api.example.com/resource"}, result.OAuthParameters.Resources)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -142,6 +142,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 	}
 
 	if err != nil {
+		ah.logger.Debug("Invalid authorize request", log.Error(err))
 		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
@@ -150,21 +151,34 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 }
 
 // getOAuthMessageForGetRequest extracts the OAuth message from an authorization GET request.
+// Only the resource parameter is permitted to be repeated (RFC 8707 §2). Any other parameter
+// appearing more than once is rejected with invalid_request per RFC 6749 §3.1.
 func (ah *authorizeHandler) getOAuthMessageForGetRequest(r *http.Request) (*OAuthMessage, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, fmt.Errorf("failed to parse form data: %w", err)
 	}
 
 	queryParams := make(map[string]string)
+	var resources []string
 	for key, values := range r.URL.Query() {
-		if len(values) > 0 {
-			queryParams[key] = values[0]
+		if len(values) == 0 {
+			continue
 		}
+		if key == oauth2const.RequestParamResource {
+			resources = values
+			queryParams[key] = values[0]
+			continue
+		}
+		if len(values) > 1 {
+			return nil, fmt.Errorf("query parameter %q must not be repeated", key)
+		}
+		queryParams[key] = values[0]
 	}
 
 	return &OAuthMessage{
 		RequestType:        oauth2const.TypeInitialAuthorizationRequest,
 		RequestQueryParams: queryParams,
+		Resources:          resources,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -134,6 +134,60 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_WithCla
 	}
 }
 
+// §8 — only the resource parameter is permitted to be repeated.
+
+func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_DuplicateNonResourceParam() {
+	// Repeated client_id must be rejected with an error.
+	req := httptest.NewRequest(http.MethodGet, "/auth?client_id=a&client_id=b", nil)
+
+	msg, err := suite.handler.getOAuthMessageForGetRequest(req)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), msg)
+	assert.Contains(suite.T(), err.Error(), "client_id")
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_MultipleResourceValues() {
+	// Repeated resource is allowed; both values must appear in msg.Resources.
+	req := httptest.NewRequest(http.MethodGet,
+		"/auth?client_id=test-client&resource=https%3A%2F%2Frs1.example.com&resource=https%3A%2F%2Frs2.example.com",
+		nil)
+
+	msg, err := suite.handler.getOAuthMessageForGetRequest(req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), msg)
+	if msg != nil {
+		assert.Equal(suite.T(), 2, len(msg.Resources))
+		assert.Contains(suite.T(), msg.Resources, "https://rs1.example.com")
+		assert.Contains(suite.T(), msg.Resources, "https://rs2.example.com")
+		assert.Equal(suite.T(), "test-client", msg.RequestQueryParams["client_id"])
+	}
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_DuplicateScopeParam() {
+	// Repeated scope must be rejected — only resource may repeat.
+	req := httptest.NewRequest(http.MethodGet,
+		"/auth?client_id=test-client&resource=https%3A%2F%2Frs1.example.com&scope=openid&scope=profile",
+		nil)
+
+	msg, err := suite.handler.getOAuthMessageForGetRequest(req)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), msg)
+	assert.Contains(suite.T(), err.Error(), "scope")
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestHandleAuthorizeGetRequest_DuplicateNonResourceParamReturns400() {
+	// End-to-end: repeated non-resource query param must produce HTTP 400 invalid_request.
+	req := httptest.NewRequest("GET", "/oauth2/authorize?client_id=a&client_id=b", nil)
+	rr := httptest.NewRecorder()
+
+	suite.handler.HandleAuthorizeGetRequest(rr, req)
+
+	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
+}
+
 func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForPostRequest_MissingAuthID() {
 	postData := AuthZPostRequest{
 		AuthID:    "",

--- a/backend/internal/oauth/oauth2/authz/init.go
+++ b/backend/internal/oauth/oauth2/authz/init.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
@@ -36,6 +37,7 @@ import (
 func Initialize(
 	mux *http.ServeMux,
 	applicationService application.ApplicationServiceInterface,
+	resourceService resource.ResourceServiceInterface,
 	jwtService jwt.JWTServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 ) (AuthorizeServiceInterface, error) {
@@ -45,7 +47,8 @@ func Initialize(
 	}
 
 	authzService := newAuthorizeService(
-		applicationService, jwtService, flowExecService, authzCodeStore, authzReqStore, transactioner,
+		applicationService, resourceService, jwtService, flowExecService,
+		authzCodeStore, authzReqStore, transactioner,
 	)
 	authzHandler := newAuthorizeHandler(authzService)
 	registerRoutes(mux, authzHandler)

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -31,11 +31,13 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/flowexecmock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 type InitTestSuite struct {
 	suite.Suite
 	mockAppService      *applicationmock.ApplicationServiceInterfaceMock
+	mockResourceService *resourcemock.ResourceServiceInterfaceMock
 	mockJWTService      *jwtmock.JWTServiceInterfaceMock
 	mockFlowExecService *flowexecmock.FlowExecServiceInterfaceMock
 }
@@ -71,6 +73,7 @@ func (suite *InitTestSuite) SetupTest() {
 	_ = config.InitializeThunderRuntime("", testConfig)
 
 	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockFlowExecService = flowexecmock.NewFlowExecServiceInterfaceMock(suite.T())
 }
@@ -82,7 +85,10 @@ func (suite *InitTestSuite) TearDownTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service, err := Initialize(mux, suite.mockAppService, suite.mockJWTService, suite.mockFlowExecService)
+	service, err := Initialize(
+		mux, suite.mockAppService, suite.mockResourceService,
+		suite.mockJWTService, suite.mockFlowExecService,
+	)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
@@ -92,7 +98,10 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	_, err := Initialize(mux, suite.mockAppService, suite.mockJWTService, suite.mockFlowExecService)
+	_, err := Initialize(
+		mux, suite.mockAppService, suite.mockResourceService,
+		suite.mockJWTService, suite.mockFlowExecService,
+	)
 	assert.NoError(suite.T(), err)
 
 	// Verify that the routes are registered by attempting to get a handler for them.
@@ -110,7 +119,10 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 	mux := http.NewServeMux()
 
-	_, err := Initialize(mux, suite.mockAppService, suite.mockJWTService, suite.mockFlowExecService)
+	_, err := Initialize(
+		mux, suite.mockAppService, suite.mockResourceService,
+		suite.mockJWTService, suite.mockFlowExecService,
+	)
 	assert.NoError(suite.T(), err)
 
 	testCases := []struct {
@@ -157,7 +169,10 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 func (suite *InitTestSuite) TestRegisterRoutes_CORSHeaders() {
 	mux := http.NewServeMux()
 
-	_, err := Initialize(mux, suite.mockAppService, suite.mockJWTService, suite.mockFlowExecService)
+	_, err := Initialize(
+		mux, suite.mockAppService, suite.mockResourceService,
+		suite.mockJWTService, suite.mockFlowExecService,
+	)
 	assert.NoError(suite.T(), err)
 
 	testCases := []struct {

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -29,6 +29,7 @@ type OAuthMessage struct {
 	RequestType        string
 	AuthID             string
 	RequestQueryParams map[string]string
+	Resources          []string
 	RequestBodyParams  map[string]string
 }
 
@@ -46,7 +47,7 @@ type AuthorizationCode struct {
 	State               string
 	CodeChallenge       string
 	CodeChallengeMethod string
-	Resource            string
+	Resources           []string
 	ClaimsRequest       *oauth2model.ClaimsRequest
 	ClaimsLocales       string
 	Nonce               string

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -36,6 +36,7 @@ import (
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -56,6 +57,7 @@ type AuthorizeServiceInterface interface {
 // authorizeService implements the AuthorizeService for managing OAuth2 authorization flows.
 type authorizeService struct {
 	appService      application.ApplicationServiceInterface
+	resourceService resource.ResourceServiceInterface
 	authZValidator  AuthorizationValidatorInterface
 	authCodeStore   AuthorizationCodeStoreInterface
 	authReqStore    authorizationRequestStoreInterface
@@ -68,6 +70,7 @@ type authorizeService struct {
 // newAuthorizeService creates a new instance of authorizeService with injected dependencies.
 func newAuthorizeService(
 	appService application.ApplicationServiceInterface,
+	resourceService resource.ResourceServiceInterface,
 	jwtService jwt.JWTServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 	authCodeStore AuthorizationCodeStoreInterface,
@@ -76,6 +79,7 @@ func newAuthorizeService(
 ) AuthorizeServiceInterface {
 	return &authorizeService{
 		appService:      appService,
+		resourceService: resourceService,
 		authZValidator:  newAuthorizationValidator(),
 		authCodeStore:   authCodeStore,
 		authReqStore:    authReqStore,
@@ -135,8 +139,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	codeChallenge := msg.RequestQueryParams[oauth2const.RequestParamCodeChallenge]
 	codeChallengeMethod := msg.RequestQueryParams[oauth2const.RequestParamCodeChallengeMethod]
 
-	// Extract resource parameter.
-	resource := msg.RequestQueryParams[oauth2const.RequestParamResource]
+	resources := msg.Resources
 
 	// Extract claims parameter.
 	claimsParam := msg.RequestQueryParams[oauth2const.RequestParamClaims]
@@ -205,7 +208,40 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		return nil, authErr
 	}
 
+	// Resolve each resource identifier to its registered Resource Server; unknown identifiers
+	// cause a 400 invalid_target.
+	resolvedRSes := make([]*resource.ResourceServer, 0, len(resources))
+	for _, identifier := range resources {
+		rs, svcErr := as.resourceService.GetResourceServerByIdentifier(ctx, identifier)
+		if svcErr != nil {
+			return nil, &AuthorizationError{
+				Code:              oauth2const.ErrorInvalidTarget,
+				Message:           "The resource parameter does not match any registered resource server",
+				SendErrorToClient: true,
+				ClientRedirectURI: redirectURI,
+				State:             state,
+			}
+		}
+		resolvedRSes = append(resolvedRSes, rs)
+	}
+
 	oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(scope, app.ScopeClaims)
+
+	// Downscope non-OIDC scopes against the union of permissions defined on the requested
+	// Resource Servers. Scopes not defined on any RS are silently dropped.
+	if len(resolvedRSes) > 0 && len(nonOidcScopes) > 0 {
+		downscoped, svcErr := as.downscopeAgainstResourceServers(ctx, resolvedRSes, nonOidcScopes)
+		if svcErr != nil {
+			return nil, &AuthorizationError{
+				Code:              oauth2const.ErrorServerError,
+				Message:           "Failed to validate permissions",
+				SendErrorToClient: true,
+				ClientRedirectURI: redirectURI,
+				State:             state,
+			}
+		}
+		nonOidcScopes = downscoped
+	}
 
 	// Construct authorization request context.
 	oauthParams := oauth2model.OAuthParameters{
@@ -217,7 +253,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		PermissionScopes:    nonOidcScopes,
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod,
-		Resource:            resource,
+		Resources:           resources,
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       claimsLocales,
 		Nonce:               nonce,
@@ -587,7 +623,7 @@ func createAuthorizationCode(
 	standardScopes := authRequestCtx.OAuthParameters.StandardScopes
 	permissionScopes := authRequestCtx.OAuthParameters.PermissionScopes
 	allScopes := append(append([]string{}, standardScopes...), permissionScopes...)
-	resource := authRequestCtx.OAuthParameters.Resource
+	resources := authRequestCtx.OAuthParameters.Resources
 
 	oauthConfig := config.GetThunderRuntime().Config.OAuth
 	validityPeriod := oauthConfig.AuthorizationCode.ValidityPeriod
@@ -616,11 +652,46 @@ func createAuthorizationCode(
 		State:               AuthCodeStateActive,
 		CodeChallenge:       authRequestCtx.OAuthParameters.CodeChallenge,
 		CodeChallengeMethod: authRequestCtx.OAuthParameters.CodeChallengeMethod,
-		Resource:            resource,
+		Resources:           resources,
 		ClaimsRequest:       authRequestCtx.OAuthParameters.ClaimsRequest,
 		ClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
 		Nonce:               authRequestCtx.OAuthParameters.Nonce,
 	}, nil
+}
+
+// downscopeAgainstResourceServers returns the subset of requested non-OIDC scopes that are
+// defined as permissions on at least one of the supplied Resource Servers. Scopes not defined
+// on any RS are silently dropped.
+func (as *authorizeService) downscopeAgainstResourceServers(
+	ctx context.Context, resolvedRSes []*resource.ResourceServer, requestedScopes []string,
+) ([]string, error) {
+	if len(requestedScopes) == 0 || len(resolvedRSes) == 0 {
+		return requestedScopes, nil
+	}
+	allowed := make(map[string]struct{}, len(requestedScopes))
+	for _, rs := range resolvedRSes {
+		invalid, valErr := as.resourceService.ValidatePermissions(ctx, rs.ID, requestedScopes)
+		if valErr != nil {
+			return nil, errors.New("failed to validate permissions")
+		}
+		invalidSet := make(map[string]struct{}, len(invalid))
+		for _, p := range invalid {
+			invalidSet[p] = struct{}{}
+		}
+		for _, s := range requestedScopes {
+			if _, isInvalid := invalidSet[s]; !isInvalid {
+				allowed[s] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(allowed))
+	for _, s := range requestedScopes {
+		if _, ok := allowed[s]; ok {
+			out = append(out, s)
+			delete(allowed, s)
+		}
+	}
+	return out, nil
 }
 
 // getRequiredAttributes determines the essential and optional user attributes required based on OIDC scopes,

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -19,14 +19,13 @@
 package authz
 
 import (
-	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/resourceindicators"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
@@ -109,34 +108,11 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 		return true, constants.ErrorInvalidRequest, "nonce exceeds maximum allowed length"
 	}
 
-	// Validate resource parameter if present
-	resource := msg.RequestQueryParams[constants.RequestParamResource]
-	if resource != "" {
-		if err := validateResourceParameter(resource); err != nil {
-			return true, constants.ErrorInvalidTarget, "Invalid resource parameter"
-		}
+	if errResp := resourceindicators.ValidateResourceURIs(msg.Resources); errResp != nil {
+		return true, errResp.Error, errResp.ErrorDescription
 	}
 
 	return false, "", ""
-}
-
-// validateResourceParameter validates the resource parameter.
-// TODO: Need to add other validations after introducing resources.
-func validateResourceParameter(resource string) error {
-	parsedURL, err := url.Parse(resource)
-	if err != nil {
-		return fmt.Errorf("resource parameter must be a valid absolute URI: %w", err)
-	}
-
-	if parsedURL.Scheme == "" {
-		return fmt.Errorf("resource parameter must be an absolute URI with a scheme")
-	}
-
-	if parsedURL.Fragment != "" {
-		return fmt.Errorf("resource parameter must not include a fragment component")
-	}
-
-	return nil
 }
 
 // validatePromptParameter validates the OIDC prompt parameter.

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -204,6 +204,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "https://api.example.com/resource",
 		},
+		Resources: []string{"https://api.example.com/resource"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -222,6 +223,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "https://mcp.example.com/mcp",
 		},
+		Resources: []string{"https://mcp.example.com/mcp"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -240,6 +242,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "https://mcp.example.com:8443",
 		},
+		Resources: []string{"https://mcp.example.com:8443"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -276,6 +279,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "api.example.com/resource",
 		},
+		Resources: []string{"api.example.com/resource"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -283,7 +287,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
+	assert.Contains(suite.T(), errorMessage, "must be an absolute URI")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceWithFragment() {
@@ -294,6 +298,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "https://api.example.com/resource#fragment",
 		},
+		Resources: []string{"https://api.example.com/resource#fragment"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -301,7 +306,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
+	assert.Contains(suite.T(), errorMessage, "must not contain a fragment component")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceRelativeURI() {
@@ -312,6 +317,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "/api/resource",
 		},
+		Resources: []string{"/api/resource"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -319,7 +325,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
+	assert.Contains(suite.T(), errorMessage, "must be an absolute URI")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceInvalidURI() {
@@ -330,6 +336,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "not a valid uri format",
 		},
+		Resources: []string{"not a valid uri format"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
@@ -337,7 +344,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
+	assert.Contains(suite.T(), errorMessage, "must be an absolute URI")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceParameterWithQuery() {
@@ -349,6 +356,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
 			constants.RequestParamResource:     "https://api.example.com/resource?param=value",
 		},
+		Resources: []string{"https://api.example.com/resource?param=value"},
 	}
 
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -20,8 +20,8 @@ package granthandlers
 
 import (
 	"context"
-	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -30,16 +30,19 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/resourceindicators"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/log"
-	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // authorizationCodeGrantHandler handles the authorization code grant type.
 type authorizationCodeGrantHandler struct {
-	authzService   authz.AuthorizeServiceInterface
-	tokenBuilder   tokenservice.TokenBuilderInterface
-	attributeCache attributecache.AttributeCacheServiceInterface
+	authzService    authz.AuthorizeServiceInterface
+	tokenBuilder    tokenservice.TokenBuilderInterface
+	attributeCache  attributecache.AttributeCacheServiceInterface
+	resourceService resource.ResourceServiceInterface
 }
 
 // newAuthorizationCodeGrantHandler creates a new instance of AuthorizationCodeGrantHandler.
@@ -47,11 +50,13 @@ func newAuthorizationCodeGrantHandler(
 	authzService authz.AuthorizeServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	attributeCache attributecache.AttributeCacheServiceInterface,
+	resourceService resource.ResourceServiceInterface,
 ) GrantHandlerInterface {
 	return &authorizationCodeGrantHandler{
-		authzService:   authzService,
-		tokenBuilder:   tokenBuilder,
-		attributeCache: attributeCache,
+		authzService:    authzService,
+		tokenBuilder:    tokenBuilder,
+		attributeCache:  attributeCache,
+		resourceService: resourceService,
 	}
 }
 
@@ -92,21 +97,8 @@ func (h *authorizationCodeGrantHandler) ValidateGrant(ctx context.Context, token
 		}
 	}
 
-	// The resource parameter must be an absolute URI without a fragment component
-	if tokenRequest.Resource != "" {
-		if !utils.IsValidURI(tokenRequest.Resource) {
-			return &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: "Invalid resource parameter: must be an absolute URI",
-			}
-		}
-		parsedURI, err := url.Parse(tokenRequest.Resource)
-		if err != nil || parsedURI.Fragment != "" {
-			return &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: "Invalid resource parameter: must not contain a fragment component",
-			}
-		}
+	if errResp := resourceindicators.ValidateResourceURIs(tokenRequest.Resources); errResp != nil {
+		return errResp
 	}
 
 	return nil
@@ -141,14 +133,62 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 		attrs = userAttributes.Attributes
 	}
 
-	audience := tokenservice.DetermineAudience("", authCode.Resource, "", authCode.ClientID)
+	// Always resolve the full set of resources authorized by the authz code. This is used to
+	// compute the full audiences for the refresh token (RFC 8707 §5).
+	fullRSes, errResp := resourceindicators.ResolveResourceServers(ctx, h.resourceService, authCode.Resources)
+	if errResp != nil {
+		return nil, errResp
+	}
+	fullAudiences, errResp := resourceindicators.ComposeAudiences(ctx, h.resourceService, authCode.ClientID,
+		fullRSes, authorizedScopes)
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	// Default: access token carries the full audiences and all authorized scopes.
+	accessTokenAudiences := fullAudiences
+	accessTokenScopes := authorizedScopes
+
+	// Per RFC 8707 §2.1, the token request MAY narrow the resource set. When narrowing occurs,
+	// audiences and scopes are downscoped to the requested subset.
+	if len(tokenRequest.Resources) > 0 {
+		// When the auth code had explicit resources, narrow by filtering the already-resolved full set.
+		// When the auth code had no explicit resources, resolve the token-request resources directly.
+		var narrowedRSes []*resource.ResourceServer
+		if len(authCode.Resources) > 0 {
+			narrowedRSes = resourceindicators.FilterByIdentifiers(fullRSes, tokenRequest.Resources)
+		} else {
+			narrowedRSes, errResp = resourceindicators.ResolveResourceServers(
+				ctx, h.resourceService, tokenRequest.Resources)
+			if errResp != nil {
+				return nil, errResp
+			}
+		}
+		accessTokenAudiences, errResp = resourceindicators.ComposeAudiences(ctx, h.resourceService,
+			authCode.ClientID, narrowedRSes, authorizedScopes)
+		if errResp != nil {
+			return nil, errResp
+		}
+
+		// Downscope: retain OIDC scopes unchanged; filter non-OIDC scopes to only those valid on
+		// the narrowed RS set.
+		oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(
+			strings.Join(authorizedScopes, " "), oauthApp.ScopeClaims)
+		rsValidScopes, rsErr := resourceindicators.ComputeRSValidScopes(
+			ctx, h.resourceService, narrowedRSes, nonOidcScopes)
+		if rsErr != nil {
+			return nil, rsErr
+		}
+		oidcScopes = append(oidcScopes, resourceindicators.UnionScopes(rsValidScopes)...)
+		accessTokenScopes = oidcScopes
+	}
 
 	// Generate access token using tokenBuilder (attributes will be filtered in BuildAccessToken)
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
 		Subject:          authCode.AuthorizedUserID,
-		Audience:         audience,
+		Audiences:        accessTokenAudiences,
 		ClientID:         tokenRequest.ClientID,
-		Scopes:           authorizedScopes,
+		Scopes:           accessTokenScopes,
 		UserAttributes:   attrs,
 		AttributeCacheID: authCode.AttributeCacheID,
 		GrantType:        string(constants.GrantTypeAuthorizationCode),
@@ -163,17 +203,21 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 		}
 	}
 
+	// Carry the full (un-narrowed) audiences in OriginalAudiences so the token service can
+	// pass them to IssueRefreshToken (RFC 8707 §5 — refresh token preserves original audience).
+	accessToken.OriginalAudiences = fullAudiences
+
 	// Build token response
 	tokenResponse := &model.TokenResponseDTO{
 		AccessToken: *accessToken,
 	}
 
 	// Generate ID token if 'openid' scope is present
-	if slices.Contains(authorizedScopes, constants.ScopeOpenID) {
+	if slices.Contains(accessTokenScopes, constants.ScopeOpenID) {
 		idToken, err := h.tokenBuilder.BuildIDToken(&tokenservice.IDTokenBuildContext{
 			Subject:        authCode.AuthorizedUserID,
 			Audience:       tokenRequest.ClientID,
-			Scopes:         authorizedScopes,
+			Scopes:         accessTokenScopes,
 			UserAttributes: attrs,
 			AuthTime:       authCode.TimeCreated.Unix(),
 			OAuthApp:       oauthApp,
@@ -253,11 +297,16 @@ func validateAuthorizationCode(tokenRequest *model.TokenRequest,
 		}
 	}
 
-	// Validate resource parameter consistency with authorization code
-	if code.Resource != "" && code.Resource != tokenRequest.Resource {
-		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidTarget,
-			ErrorDescription: "Resource parameter mismatch",
+	// If the authorization request included resources, the token request may either omit
+	// resources entirely or supply a subset of those previously authorized.
+	if len(code.Resources) > 0 && len(tokenRequest.Resources) > 0 {
+		for _, r := range tokenRequest.Resources {
+			if !slices.Contains(code.Resources, r) {
+				return &model.ErrorResponse{
+					Error:            constants.ErrorInvalidTarget,
+					ErrorDescription: "Resource parameter mismatch",
+				}
+			}
 		}
 	}
 

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
@@ -41,6 +42,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 const (
@@ -79,6 +81,7 @@ type AuthorizationCodeGrantHandlerTestSuite struct {
 	mockTokenBuilder     *tokenservicemock.TokenBuilderInterfaceMock
 	mockAuthzService     *authzmock.AuthorizeServiceInterfaceMock
 	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	mockResourceService  *resourcemock.ResourceServiceInterfaceMock
 	oauthApp             *appmodel.OAuthAppConfigProcessedDTO
 	testAuthzCode        authz.AuthorizationCode
 	testTokenReq         *model.TokenRequest
@@ -101,11 +104,24 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) SetupTest() {
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockAuthzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
 	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, mock.Anything).
+		Return(func(_ context.Context, identifier string) *resource.ResourceServer {
+			return &resource.ResourceServer{ID: identifier, Identifier: identifier}
+		}, func(_ context.Context, _ string) *serviceerror.ServiceError {
+			return nil
+		}).Maybe()
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{}, nil).Maybe()
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
 
 	suite.handler = &authorizationCodeGrantHandler{
-		tokenBuilder:   suite.mockTokenBuilder,
-		authzService:   suite.mockAuthzService,
-		attributeCache: suite.mockAttrCacheService,
+		tokenBuilder:    suite.mockTokenBuilder,
+		authzService:    suite.mockAuthzService,
+		attributeCache:  suite.mockAttrCacheService,
+		resourceService: suite.mockResourceService,
 	}
 
 	suite.oauthApp = &appmodel.OAuthAppConfigProcessedDTO{
@@ -145,7 +161,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) SetupTest() {
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestNewAuthorizationCodeGrantHandler() {
 	handler := newAuthorizationCodeGrantHandler(
-		suite.mockAuthzService, suite.mockTokenBuilder, suite.mockAttrCacheService)
+		suite.mockAuthzService, suite.mockTokenBuilder, suite.mockAttrCacheService, suite.mockResourceService)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -224,7 +240,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_MissingRe
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_Success() {
 	// Create authorization code with resource
 	authCodeWithResource := suite.testAuthzCode
-	authCodeWithResource.Resource = testResourceURL
+	authCodeWithResource.Resources = []string{testResourceURL}
 
 	// Mock authorization code store to return valid code with resource
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
@@ -233,7 +249,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_Success() {
 	// Mock token builder to generate access token
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		return ctx.Subject == testUserID &&
-			ctx.Audience == testResourceURL &&
+			len(ctx.Audiences) == 1 &&
+			ctx.Audiences[0] == testResourceURL &&
 			ctx.ClientID == testClientID &&
 			ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
 	})).Return(&model.TokenDTO{
@@ -244,12 +261,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_Success() {
 		Scopes:    []string{"read", "write"},
 		ClientID:  testClientID,
 		Subject:   testUserID,
-		Audience:  testResourceURL,
+		Audiences: []string{testResourceURL},
 	}, nil)
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -263,7 +280,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_Success() {
 
 	// Check token attributes
 	assert.Equal(suite.T(), testUserID, result.AccessToken.Subject)
-	assert.Equal(suite.T(), testResourceURL, result.AccessToken.Audience)
+	assert.Contains(suite.T(), result.AccessToken.Audiences, testResourceURL)
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
@@ -276,7 +293,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_InvalidAuth
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -298,7 +315,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_JWTGenerati
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -330,7 +347,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_EmptyScopes
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -355,12 +372,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 		Scopes:    []string{"read", "write"},
 		ClientID:  testClientID,
 		Subject:   testUserID,
-		Audience:  testClientID,
+		Audiences: []string{testClientID},
 	}, nil)
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -369,7 +386,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 
 	// Check token attributes
 	assert.Equal(suite.T(), testUserID, result.AccessToken.Subject)
-	assert.Equal(suite.T(), testClientID, result.AccessToken.Audience)
+	assert.Contains(suite.T(), result.AccessToken.Audiences, testClientID)
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
@@ -465,10 +482,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 			suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 			suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+			suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+			suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+				Return([]resource.ResourceServer{}, nil).Maybe()
 			suite.handler = &authorizationCodeGrantHandler{
-				tokenBuilder:   suite.mockTokenBuilder,
-				authzService:   suite.mockAuthzService,
-				attributeCache: suite.mockAttrCacheService,
+				tokenBuilder:    suite.mockTokenBuilder,
+				authzService:    suite.mockAuthzService,
+				attributeCache:  suite.mockAttrCacheService,
+				resourceService: suite.mockResourceService,
 			}
 
 			accessTokenAttrs := []string{"email", "username"}
@@ -658,10 +679,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 			suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 			suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+			suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+			suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+				Return([]resource.ResourceServer{}, nil).Maybe()
 			suite.handler = &authorizationCodeGrantHandler{
-				tokenBuilder:   suite.mockTokenBuilder,
-				authzService:   suite.mockAuthzService,
-				attributeCache: suite.mockAttrCacheService,
+				tokenBuilder:    suite.mockTokenBuilder,
+				authzService:    suite.mockAuthzService,
+				attributeCache:  suite.mockAttrCacheService,
+				resourceService: suite.mockResourceService,
 			}
 
 			accessTokenAttrs := []string{"email", "username"}
@@ -799,14 +824,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_ResourceParameterMismatch() {
 	// Set up auth code with different resource than token request
 	authCodeWithResource := suite.testAuthzCode
-	authCodeWithResource.Resource = "https://api.example.com/resource"
+	authCodeWithResource.Resources = []string{"https://api.example.com/resource"}
 
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&authCodeWithResource, nil)
 
 	// Create token request with different resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
@@ -819,14 +844,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_ResourcePar
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_ResourceParameterMatch() {
 	// Set up auth code with resource parameter
 	authCodeWithResource := suite.testAuthzCode
-	authCodeWithResource.Resource = testResourceURL
+	authCodeWithResource.Resources = []string{testResourceURL}
 
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&authCodeWithResource, nil)
 
-	var capturedAudience string
+	var capturedAudiences []string
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudience = ctx.Audience
+		capturedAudiences = ctx.Audiences
 		return true
 	})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
@@ -839,23 +864,24 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_ResourcePar
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
+	tokenReqWithResource.Resources = []string{testResourceURL}
 
 	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), testResourceURL, capturedAudience)
+	assert.Equal(suite.T(), []string{testResourceURL}, capturedAudiences)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NoResourceParameter() {
-	// Auth code without resource parameter
+	// Auth code without resource parameter, token request also sends no resource.
+	// Audience falls back to clientID (no RS contributes).
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&suite.testAuthzCode, nil)
 
-	var capturedAudience string
+	var capturedAudiences []string
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudience = ctx.Audience
+		capturedAudiences = ctx.Audiences
 		return true
 	})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
@@ -866,17 +892,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NoResourceP
 		ClientID:  testClientID,
 	}, nil)
 
-	// Create token request with matching resource
-	tokenReqWithResource := *suite.testTokenReq
-	tokenReqWithResource.Resource = testResourceURL
-
-	result, err := suite.handler.HandleGrant(context.Background(), &tokenReqWithResource, suite.oauthApp)
+	// Token request sends no resource parameter.
+	result, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
 
-	// Verify audience defaults to client ID when no resource parameter
-	assert.Equal(suite.T(), testClientID, capturedAudience)
+	// Audience falls back to clientID when no RS contributes.
+	assert.Equal(suite.T(), []string{testClientID}, capturedAudiences)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserOUFailed() {
@@ -924,12 +947,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_ResourceW
 		ClientID:    testClientID,
 		Code:        "test-code",
 		RedirectURI: "https://client.example.com/callback",
-		Resource:    "https://api.example.com/resource#fragment", // Fragment not allowed
+		Resources:   []string{"https://api.example.com/resource#fragment"}, // Fragment not allowed
 	}
 
 	err := suite.handler.ValidateGrant(context.Background(), tokenReq, suite.oauthApp)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
 	assert.Contains(suite.T(), err.ErrorDescription, "fragment component")
 }
 
@@ -940,12 +963,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_ResourceP
 		ClientID:    testClientID,
 		Code:        "test-code",
 		RedirectURI: "https://client.example.com/callback",
-		Resource:    "://invalid-uri", // Invalid URI format
+		Resources:   []string{"://invalid-uri"}, // Invalid URI format
 	}
 
 	err := suite.handler.ValidateGrant(context.Background(), tokenReq, suite.oauthApp)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserGroupsError() {
@@ -1129,13 +1152,13 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestRetrieveAndValidateAuth
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_ResourceMismatch() {
 	// Test resource parameter mismatch
 	authCodeWithResource := suite.testAuthzCode
-	authCodeWithResource.Resource = "https://api.example.com/resource"
+	authCodeWithResource.Resources = []string{"https://api.example.com/resource"}
 	authCodeWithResource.RedirectURI = testClientCallbackURL
 
 	tokenReq := &model.TokenRequest{
 		ClientID:    testClientID,
 		RedirectURI: "https://client.example.com/callback", // Must match auth code
-		Resource:    testResourceURL,                       // Different resource
+		Resources:   []string{testResourceURL},             // Different resource
 	}
 
 	err := validateAuthorizationCode(tokenReq, authCodeWithResource)
@@ -1147,13 +1170,13 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCo
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_ResourceMatch() {
 	// Test resource parameter match
 	authCodeWithResource := suite.testAuthzCode
-	authCodeWithResource.Resource = testResourceURL
+	authCodeWithResource.Resources = []string{testResourceURL}
 	authCodeWithResource.RedirectURI = testClientCallbackURL // Must match
 
 	tokenReq := &model.TokenRequest{
 		ClientID:    testClientID,
 		RedirectURI: "https://client.example.com/callback", // Must match auth code
-		Resource:    testResourceURL,                       // Matching resource
+		Resources:   []string{testResourceURL},             // Matching resource
 	}
 
 	err := validateAuthorizationCode(tokenReq, authCodeWithResource)
@@ -1162,15 +1185,173 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCo
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_EmptyResourceInCode() {
 	authCodeWithEmptyResource := suite.testAuthzCode
-	authCodeWithEmptyResource.Resource = ""
+	authCodeWithEmptyResource.Resources = nil
 	authCodeWithEmptyResource.RedirectURI = "https://client.example.com/callback" // Must match
 
 	tokenReq := &model.TokenRequest{
 		ClientID:    testClientID,
 		RedirectURI: "https://client.example.com/callback", // Must match auth code
-		Resource:    testResourceURL,                       // Any resource should be OK
+		Resources:   []string{testResourceURL},             // Any resource should be OK
 	}
 
 	err := validateAuthorizationCode(tokenReq, authCodeWithEmptyResource)
 	assert.Nil(suite.T(), err)
+}
+
+// §3 — token-request resource subset narrows the issued aud (RFC 8707 §2.1).
+
+const testResourceURL2 = "https://api2.example.com/api"
+
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenRequestNarrowsResourceSubset() {
+	// Authz code has two resources; token request sends only one.
+	// Issued aud must contain only the narrowed RS, not both.
+	authCodeWithTwoResources := suite.testAuthzCode
+	authCodeWithTwoResources.Resources = []string{testResourceURL, testResourceURL2}
+
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testResourceURL2).
+		Return(&resource.ResourceServer{ID: testResourceURL2, Identifier: testResourceURL2}, nil).Maybe()
+
+	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
+		Return(&authCodeWithTwoResources, nil)
+
+	var capturedAudiences []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		return true
+	})).Return(&model.TokenDTO{
+		Token:     "mock-jwt-token",
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	tokenReq := *suite.testTokenReq
+	tokenReq.Resources = []string{testResourceURL}
+
+	result, err := suite.handler.HandleGrant(context.Background(), &tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{testResourceURL}, capturedAudiences)
+}
+
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenRequestNoResourceUsesBothFromCode() {
+	// Authz code has two resources; token request sends no resource.
+	// Issued aud must contain both RS identifiers from the auth code.
+	authCodeWithTwoResources := suite.testAuthzCode
+	authCodeWithTwoResources.Resources = []string{testResourceURL, testResourceURL2}
+
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testResourceURL2).
+		Return(&resource.ResourceServer{ID: testResourceURL2, Identifier: testResourceURL2}, nil).Maybe()
+
+	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
+		Return(&authCodeWithTwoResources, nil)
+
+	var capturedAudiences []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		return true
+	})).Return(&model.TokenDTO{
+		Token:     "mock-jwt-token",
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), 2, len(capturedAudiences))
+	assert.Contains(suite.T(), capturedAudiences, testResourceURL)
+	assert.Contains(suite.T(), capturedAudiences, testResourceURL2)
+}
+
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenRequestNarrows_ScopesDownscoped() {
+	// Authz code has two resources [rs1, rs2] with scopes ["read", "write"].
+	// Token request narrows to rs1 only; rs1 only supports "read" (ValidatePermissions returns "write" as invalid).
+	// Access token must carry only "read" (scope downscoped) and aud=[rs1].
+	// OriginalAudiences must carry both [rs1, rs2] for the refresh token.
+	authCodeWithTwoResources := suite.testAuthzCode
+	authCodeWithTwoResources.Resources = []string{testResourceURL, testResourceURL2}
+	authCodeWithTwoResources.Scopes = "read write"
+
+	suite.mockResourceService.ExpectedCalls = nil
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testResourceURL).
+		Return(&resource.ResourceServer{ID: testResourceURL, Identifier: testResourceURL}, nil)
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testResourceURL2).
+		Return(&resource.ResourceServer{ID: testResourceURL2, Identifier: testResourceURL2}, nil)
+	// rs1 only supports "read"; "write" is invalid.
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, testResourceURL, mock.Anything).
+		Return([]string{"write"}, nil)
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+
+	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
+		Return(&authCodeWithTwoResources, nil)
+
+	var capturedAudiences []string
+	var capturedScopes []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		capturedScopes = ctx.Scopes
+		return true
+	})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+		return &model.TokenDTO{
+			Token:     "mock-jwt-token",
+			TokenType: constants.TokenTypeBearer,
+			IssuedAt:  time.Now().Unix(),
+			ExpiresIn: 3600,
+			Scopes:    ctx.Scopes,
+			ClientID:  testClientID,
+		}, nil
+	})
+
+	tokenReq := *suite.testTokenReq
+	tokenReq.Resources = []string{testResourceURL}
+
+	result, err := suite.handler.HandleGrant(context.Background(), &tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{testResourceURL}, capturedAudiences)
+	assert.Equal(suite.T(), []string{"read"}, capturedScopes)
+	assert.Equal(suite.T(), []string{testResourceURL, testResourceURL2}, result.AccessToken.OriginalAudiences)
+}
+
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenRequestNarrowsFromImplicitAllRSSet() {
+	// When the auth code carried no resources, all registered RSes are implicitly authorized.
+	// The token request may then narrow to any registered RS; unknown RS identifiers are rejected
+	// upstream by ResolveResourceServers with invalid_target.
+	authCodeNoResources := suite.testAuthzCode
+	authCodeNoResources.Resources = nil
+
+	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
+		Return(&authCodeNoResources, nil)
+
+	var capturedAudiences []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		return true
+	})).Return(&model.TokenDTO{
+		Token:     "mock-jwt-token",
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	tokenReq := *suite.testTokenReq
+	tokenReq.Resources = []string{testResourceURL}
+
+	result, err := suite.handler.HandleGrant(context.Background(), &tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{testResourceURL}, capturedAudiences)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -27,17 +27,20 @@ import (
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/resourceindicators"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
 // clientCredentialsGrantHandler handles the client credentials grant type.
 type clientCredentialsGrantHandler struct {
-	tokenBuilder tokenservice.TokenBuilderInterface
-	ouService    ou.OrganizationUnitServiceInterface
-	authzService authz.AuthorizationServiceInterface
-	entityProv   entityprovider.EntityProviderInterface
+	tokenBuilder    tokenservice.TokenBuilderInterface
+	ouService       ou.OrganizationUnitServiceInterface
+	authzService    authz.AuthorizationServiceInterface
+	entityProv      entityprovider.EntityProviderInterface
+	resourceService resource.ResourceServiceInterface
 }
 
 // newClientCredentialsGrantHandler creates a new instance of ClientCredentialsGrantHandler.
@@ -46,12 +49,14 @@ func newClientCredentialsGrantHandler(
 	ouService ou.OrganizationUnitServiceInterface,
 	authzService authz.AuthorizationServiceInterface,
 	entityProv entityprovider.EntityProviderInterface,
+	resourceService resource.ResourceServiceInterface,
 ) GrantHandlerInterface {
 	return &clientCredentialsGrantHandler{
-		tokenBuilder: tokenBuilder,
-		ouService:    ouService,
-		authzService: authzService,
-		entityProv:   entityProv,
+		tokenBuilder:    tokenBuilder,
+		ouService:       ouService,
+		authzService:    authzService,
+		entityProv:      entityProv,
+		resourceService: resourceService,
 	}
 }
 
@@ -65,6 +70,10 @@ func (h *clientCredentialsGrantHandler) ValidateGrant(ctx context.Context, token
 		}
 	}
 
+	if errResp := resourceindicators.ValidateResourceURIs(tokenRequest.Resources); errResp != nil {
+		return errResp
+	}
+
 	return nil
 }
 
@@ -75,6 +84,25 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ClientCredentialsGrantHandler"))
 
 	scopes := tokenservice.ParseScopes(tokenRequest.Scope)
+	hasResourceParam := len(tokenRequest.Resources) > 0
+
+	// Resolve each requested resource identifier to an internal Resource Server.
+	// Unknown identifiers cause a 400 invalid_target.
+	resolvedRSes, errResp := resourceindicators.ResolveResourceServers(ctx, h.resourceService, tokenRequest.Resources)
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	// Per-RS valid scopes (intersection of requested scopes with the RS's defined permissions).
+	// Scopes not defined on any requested RS are silently dropped.
+	rsValidScopes, errResp := resourceindicators.ComputeRSValidScopes(ctx, h.resourceService, resolvedRSes, scopes)
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	if hasResourceParam {
+		scopes = resourceindicators.UnionScopes(rsValidScopes)
+	}
 
 	if len(scopes) > 0 {
 		var groupIDs []string
@@ -116,7 +144,13 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 		scopes = authzResp.AuthorizedPermissions
 	}
 
-	finalAudience := tokenservice.DetermineAudience("", tokenRequest.Resource, "", tokenRequest.ClientID)
+	// aud is composed by resourceindicators.ComposeAudiences: RS identifiers when any RS contributes
+	// (explicit resource params or implicit discovery via granted scopes), else clientID fallback.
+	audiences, errResp := resourceindicators.ComposeAudiences(ctx, h.resourceService, tokenRequest.ClientID,
+		resolvedRSes, scopes)
+	if errResp != nil {
+		return nil, errResp
+	}
 
 	clientAttributes, clientAttrErr := tokenservice.BuildClientAttributes(ctx, oauthApp, h.ouService)
 	if clientAttrErr != nil {
@@ -128,7 +162,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
 		Subject:          tokenRequest.ClientID,
-		Audience:         finalAudience,
+		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,
 		Scopes:           scopes,
 		UserAttributes:   make(map[string]interface{}),

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/tests/mocks/authzmock"
@@ -44,6 +45,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 // nolint:gosec // Test token, not a real credential
@@ -52,13 +54,14 @@ const testResourceURL = "https://mcp.example.com/mcp"
 
 type ClientCredentialsGrantHandlerTestSuite struct {
 	suite.Suite
-	mockJWTService   *jwtmock.JWTServiceInterfaceMock
-	mockTokenBuilder *tokenservicemock.TokenBuilderInterfaceMock
-	mockOUService    *oumock.OrganizationUnitServiceInterfaceMock
-	mockAuthzService *authzmock.AuthorizationServiceInterfaceMock
-	mockEntityProv   *entityprovidermock.EntityProviderInterfaceMock
-	handler          *clientCredentialsGrantHandler
-	oauthApp         *appmodel.OAuthAppConfigProcessedDTO
+	mockJWTService      *jwtmock.JWTServiceInterfaceMock
+	mockTokenBuilder    *tokenservicemock.TokenBuilderInterfaceMock
+	mockOUService       *oumock.OrganizationUnitServiceInterfaceMock
+	mockAuthzService    *authzmock.AuthorizationServiceInterfaceMock
+	mockEntityProv      *entityprovidermock.EntityProviderInterfaceMock
+	mockResourceService *resourcemock.ResourceServiceInterfaceMock
+	handler             *clientCredentialsGrantHandler
+	oauthApp            *appmodel.OAuthAppConfigProcessedDTO
 }
 
 func TestClientCredentialsGrantHandlerSuite(t *testing.T) {
@@ -81,11 +84,24 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) SetupTest() {
 	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
 	suite.mockAuthzService = authzmock.NewAuthorizationServiceInterfaceMock(suite.T())
 	suite.mockEntityProv = entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, mock.Anything).
+		Return(func(_ context.Context, identifier string) *resource.ResourceServer {
+			return &resource.ResourceServer{ID: identifier, Identifier: identifier}
+		}, func(_ context.Context, _ string) *serviceerror.ServiceError {
+			return nil
+		}).Maybe()
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{}, nil).Maybe()
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+
 	suite.handler = &clientCredentialsGrantHandler{
-		tokenBuilder: suite.mockTokenBuilder,
-		ouService:    suite.mockOUService,
-		authzService: suite.mockAuthzService,
-		entityProv:   suite.mockEntityProv,
+		tokenBuilder:    suite.mockTokenBuilder,
+		ouService:       suite.mockOUService,
+		authzService:    suite.mockAuthzService,
+		entityProv:      suite.mockEntityProv,
+		resourceService: suite.mockResourceService,
 	}
 	suite.mockEntityProv.On("GetTransitiveEntityGroups", mock.Anything).
 		Return([]entityprovider.EntityGroup{}, nil).Maybe()
@@ -102,7 +118,8 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) SetupTest() {
 
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestNewClientCredentialsGrantHandler() {
 	handler := newClientCredentialsGrantHandler(
-		suite.mockTokenBuilder, suite.mockOUService, suite.mockAuthzService, suite.mockEntityProv)
+		suite.mockTokenBuilder, suite.mockOUService, suite.mockAuthzService,
+		suite.mockEntityProv, suite.mockResourceService)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -187,7 +204,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			suite.mockTokenBuilder.On("BuildAccessToken",
 				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 					return ctx.Subject == testClientID &&
-						ctx.Audience == testClientID &&
+						(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 						ctx.ClientID == testClientID &&
 						tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes(tc.expectedScopes)
 				})).Return(&model.TokenDTO{
@@ -198,7 +215,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 				Scopes:    tc.expectedScopes,
 				ClientID:  testClientID,
 				Subject:   testClientID,
-				Audience:  testClientID,
+				Audiences: []string{testClientID},
 			}, nil)
 
 			result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -213,7 +230,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 
 			// Verify token attributes
 			assert.Equal(t, testClientID, result.AccessToken.Subject)
-			assert.Equal(t, testClientID, result.AccessToken.Audience)
+			assert.Contains(t, result.AccessToken.Audiences, testClientID)
 
 			suite.mockTokenBuilder.AssertExpectations(t)
 		})
@@ -267,7 +284,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 
 	expectedToken := testJWTToken
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testClientID && ctx.Audience == testClientID &&
+		return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 			tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
 	})).Return(&model.TokenDTO{
 		Token:     expectedToken,
@@ -277,7 +294,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
 		Subject:   testClientID,
-		Audience:  testClientID,
+		Audiences: []string{testClientID},
 	}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -288,7 +305,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 
 	// Verify token attributes
 	assert.Equal(suite.T(), testClientID, result.AccessToken.Subject)
-	assert.Equal(suite.T(), testClientID, result.AccessToken.Audience)
+	assert.Contains(suite.T(), result.AccessToken.Audiences, testClientID)
 
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
 }
@@ -383,7 +400,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
 		Scope:        "read",
-		Resource:     "https://mcp.example.com/mcp",
+		Resources:    []string{"https://mcp.example.com/mcp"},
 	}
 
 	suite.mockAuthzService.On("GetAuthorizedPermissions", mock.Anything,
@@ -394,10 +411,12 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 		AuthorizedPermissions: []string{"read"},
 	}, nil)
 
-	var capturedAudience string
+	var capturedAudiences []string
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudience = ctx.Audience
-		return ctx.Subject == testClientID && ctx.Audience == "https://mcp.example.com/mcp"
+		capturedAudiences = ctx.Audiences
+		return ctx.Subject == testClientID &&
+			len(ctx.Audiences) == 1 &&
+			ctx.Audiences[0] == "https://mcp.example.com/mcp"
 	})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
@@ -406,7 +425,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
 		Subject:   testClientID,
-		Audience:  "https://mcp.example.com/mcp",
+		Audiences: []string{"https://mcp.example.com/mcp"},
 	}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -414,11 +433,8 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)
 
-	// Verify resource was included in audience
-	assert.Equal(suite.T(), "https://mcp.example.com/mcp", capturedAudience)
-
-	// Verify token attributes use resource as audience
-	assert.Equal(suite.T(), "https://mcp.example.com/mcp", result.AccessToken.Audience)
+	// When RS contributes, clientID is NOT included; aud contains only the RS identifier.
+	assert.Equal(suite.T(), []string{"https://mcp.example.com/mcp"}, capturedAudiences)
 }
 
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutResourceParameter() {
@@ -439,8 +455,10 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 
 	var capturedAudience string
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudience = ctx.Audience
-		return ctx.Subject == testClientID && ctx.Audience == testClientID
+		if len(ctx.Audiences) > 0 {
+			capturedAudience = ctx.Audiences[0]
+		}
+		return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID)
 	})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
@@ -449,7 +467,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
 		Subject:   testClientID,
-		Audience:  testClientID,
+		Audiences: []string{testClientID},
 	}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -461,7 +479,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 	assert.Equal(suite.T(), testClientID, capturedAudience)
 
 	// Verify token attributes use client ID as audience when no resource
-	assert.Equal(suite.T(), testClientID, result.AccessToken.Audience)
+	assert.Contains(suite.T(), result.AccessToken.Audiences, testClientID)
 }
 
 // App Authorization Integration Tests — verify scope filtering via RBAC roles
@@ -591,4 +609,145 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_EmptyScope_
 	assert.NotNil(suite.T(), result)
 	// Verify authz service was NOT called when no scopes requested.
 	suite.mockAuthzService.AssertNotCalled(suite.T(), "GetAuthorizedPermissions", mock.Anything, mock.Anything)
+}
+
+// QA §4 — Implicit RS discovery: no resource param + scope maps to a registered RS.
+//
+// These tests use fresh mocks (not the suite defaults) so that FindResourceServersByPermissions
+// can be configured to return a non-empty result without conflicting with the suite-level
+// catch-all .Maybe() registration.
+
+func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSDiscovery_NoResourceScopeMapsToRS() {
+	// When no resource parameter is supplied but the granted scope maps to a registered RS,
+	// ComposeAudiences discovers it via FindResourceServersByPermissions and aud contains the RS
+	// identifier rather than the clientID fallback.
+	const rsIdentifier = "https://rs01.example.com"
+
+	mockTokenBuilder := tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
+	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(suite.T())
+	mockResourceService := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	mockEntityProv := entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+
+	handler := &clientCredentialsGrantHandler{
+		tokenBuilder:    mockTokenBuilder,
+		ouService:       suite.mockOUService,
+		authzService:    mockAuthzService,
+		entityProv:      mockEntityProv,
+		resourceService: mockResourceService,
+	}
+
+	mockEntityProv.On("GetTransitiveEntityGroups", mock.Anything).
+		Return([]entityprovider.EntityGroup{}, nil).Maybe()
+
+	// No resource param — ResolveResourceServers returns nil (no explicit identifiers).
+	// GetResourceServerByIdentifier is not called.
+	// ValidatePermissions is not called (no explicit RS).
+
+	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything,
+		authz.GetAuthorizedPermissionsRequest{
+			EntityID:             suite.oauthApp.AppID,
+			RequestedPermissions: []string{"r1:s1"},
+		}).Return(&authz.GetAuthorizedPermissionsResponse{
+		AuthorizedPermissions: []string{"r1:s1"},
+	}, nil)
+
+	mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"r1:s1"}).
+		Return([]resource.ResourceServer{
+			{ID: "rs01", Identifier: rsIdentifier},
+		}, nil)
+
+	var capturedAudiences []string
+	mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		return true
+	})).Return(&model.TokenDTO{
+		Token:     testJWTToken,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  int64(1234567890),
+		ExpiresIn: 3600,
+		Scopes:    []string{"r1:s1"},
+		ClientID:  testClientID,
+		Subject:   testClientID,
+		Audiences: []string{rsIdentifier},
+	}, nil)
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
+		Scope:        "r1:s1",
+	}
+
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{rsIdentifier}, capturedAudiences)
+}
+
+func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSDiscovery_MultipleRSes() {
+	// When the granted scope maps to two registered RSes, both identifiers appear in aud (sorted).
+	const rsIdentifier1 = "https://rs01.example.com"
+	const rsIdentifier2 = "https://rs02.example.com"
+
+	mockTokenBuilder := tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
+	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(suite.T())
+	mockResourceService := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	mockEntityProv := entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+
+	handler := &clientCredentialsGrantHandler{
+		tokenBuilder:    mockTokenBuilder,
+		ouService:       suite.mockOUService,
+		authzService:    mockAuthzService,
+		entityProv:      mockEntityProv,
+		resourceService: mockResourceService,
+	}
+
+	mockEntityProv.On("GetTransitiveEntityGroups", mock.Anything).
+		Return([]entityprovider.EntityGroup{}, nil).Maybe()
+
+	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything,
+		authz.GetAuthorizedPermissionsRequest{
+			EntityID:             suite.oauthApp.AppID,
+			RequestedPermissions: []string{"r1:s1"},
+		}).Return(&authz.GetAuthorizedPermissionsResponse{
+		AuthorizedPermissions: []string{"r1:s1"},
+	}, nil)
+
+	// Both RSes own the granted scope — ComposeAudiences includes both identifiers.
+	mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"r1:s1"}).
+		Return([]resource.ResourceServer{
+			{ID: "rs01", Identifier: rsIdentifier1},
+			{ID: "rs02", Identifier: rsIdentifier2},
+		}, nil)
+
+	var capturedAudiences []string
+	mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		capturedAudiences = ctx.Audiences
+		return true
+	})).Return(&model.TokenDTO{
+		Token:     testJWTToken,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  int64(1234567890),
+		ExpiresIn: 3600,
+		Scopes:    []string{"r1:s1"},
+		ClientID:  testClientID,
+		Subject:   testClientID,
+		Audiences: []string{rsIdentifier1, rsIdentifier2},
+	}, nil)
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
+		Scope:        "r1:s1",
+	}
+
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), capturedAudiences, 2)
+	assert.Contains(suite.T(), capturedAudiences, rsIdentifier1)
+	assert.Contains(suite.T(), capturedAudiences, rsIdentifier2)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -44,7 +44,7 @@ type RefreshTokenGrantHandlerInterface interface {
 		ctx context.Context,
 		tokenResponse *model.TokenResponseDTO,
 		oauthApp *appmodel.OAuthAppConfigProcessedDTO,
-		subject, audience, grantType string,
+		subject string, audiences []string, grantType string,
 		scopes []string,
 		claimsRequest *model.ClaimsRequest,
 		claimsLocales string,

--- a/backend/internal/oauth/oauth2/granthandlers/init.go
+++ b/backend/internal/oauth/oauth2/granthandlers/init.go
@@ -29,6 +29,7 @@ import (
 	oauth2authz "github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 )
 
@@ -44,8 +45,11 @@ func Initialize(
 	ouService ou.OrganizationUnitServiceInterface,
 	authzService authz.AuthorizationServiceInterface,
 	entityProv entityprovider.EntityProviderInterface,
+	resourceService resource.ResourceServiceInterface,
 ) (GrantHandlerProviderInterface, error) {
-	oauthAuthzService, err := oauth2authz.Initialize(mux, applicationService, jwtService, flowExecService)
+	oauthAuthzService, err := oauth2authz.Initialize(
+		mux, applicationService, resourceService, jwtService, flowExecService,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +62,7 @@ func Initialize(
 		ouService,
 		authzService,
 		entityProv,
+		resourceService,
 	)
 	return grantHandlerProvider, nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 )
 
@@ -52,15 +53,17 @@ func newGrantHandlerProvider(
 	ouService ou.OrganizationUnitServiceInterface,
 	rbacAuthzService rbacauthz.AuthorizationServiceInterface,
 	entityProv entityprovider.EntityProviderInterface,
+	resourceService resource.ResourceServiceInterface,
 ) GrantHandlerProviderInterface {
 	return &GrantHandlerProvider{
 		clientCredentialsGrantHandler: newClientCredentialsGrantHandler(
-			tokenBuilder, ouService, rbacAuthzService, entityProv),
+			tokenBuilder, ouService, rbacAuthzService, entityProv, resourceService),
 		authorizationCodeGrantHandler: newAuthorizationCodeGrantHandler(
-			authzService, tokenBuilder, attrCacheService),
+			authzService, tokenBuilder, attrCacheService, resourceService),
 		refreshTokenGrantHandler: newRefreshTokenGrantHandler(
-			jwtService, tokenBuilder, tokenValidator, attrCacheService),
-		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(tokenBuilder, tokenValidator),
+			jwtService, tokenBuilder, tokenValidator, attrCacheService, resourceService),
+		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(
+			tokenBuilder, tokenValidator, resourceService),
 	}
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 type GrantHandlerProviderTestSuite struct {
@@ -45,6 +46,7 @@ type GrantHandlerProviderTestSuite struct {
 	mockOUService        *oumock.OrganizationUnitServiceInterfaceMock
 	mockRBACAuthzService *rbacauthzmock.AuthorizationServiceInterfaceMock
 	mockEntityProvider   *entityprovidermock.EntityProviderInterfaceMock
+	mockResourceService  *resourcemock.ResourceServiceInterfaceMock
 }
 
 func TestGrantHandlerProviderSuite(t *testing.T) {
@@ -60,6 +62,7 @@ func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
 	suite.mockRBACAuthzService = rbacauthzmock.NewAuthorizationServiceInterfaceMock(suite.T())
 	suite.mockEntityProvider = entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
 	suite.provider = newGrantHandlerProvider(
 		suite.mockJWTService,
 		suite.authzService,
@@ -69,6 +72,7 @@ func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 		suite.mockOUService,
 		suite.mockRBACAuthzService,
 		suite.mockEntityProvider,
+		suite.mockResourceService,
 	)
 }
 
@@ -82,6 +86,7 @@ func (suite *GrantHandlerProviderTestSuite) TestNewGrantHandlerProvider() {
 		suite.mockOUService,
 		suite.mockRBACAuthzService,
 		suite.mockEntityProvider,
+		suite.mockResourceService,
 	)
 	assert.NotNil(suite.T(), provider)
 	assert.Implements(suite.T(), (*GrantHandlerProviderInterface)(nil), provider)

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -19,16 +19,19 @@
 package granthandlers
 
 import (
-	"slices"
-	"time"
-
 	"context"
+	"slices"
+	"strings"
+	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/resourceindicators"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -41,6 +44,7 @@ type refreshTokenGrantHandler struct {
 	tokenBuilder     tokenservice.TokenBuilderInterface
 	tokenValidator   tokenservice.TokenValidatorInterface
 	attrCacheService attributecache.AttributeCacheServiceInterface
+	resourceService  resource.ResourceServiceInterface
 }
 
 // newRefreshTokenGrantHandler creates a new instance of RefreshTokenGrantHandler.
@@ -49,12 +53,14 @@ func newRefreshTokenGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	attrCacheService attributecache.AttributeCacheServiceInterface,
+	resourceService resource.ResourceServiceInterface,
 ) RefreshTokenGrantHandlerInterface {
 	return &refreshTokenGrantHandler{
 		jwtService:       jwtService,
 		tokenBuilder:     tokenBuilder,
 		tokenValidator:   tokenValidator,
 		attrCacheService: attrCacheService,
+		resourceService:  resourceService,
 	}
 }
 
@@ -80,6 +86,10 @@ func (h *refreshTokenGrantHandler) ValidateGrant(ctx context.Context, tokenReque
 		}
 	}
 
+	if errResp := resourceindicators.ValidateResourceURIs(tokenRequest.Resources); errResp != nil {
+		return errResp
+	}
+
 	return nil
 }
 
@@ -102,6 +112,46 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	newTokenScopes, scopeErr := h.validateAndApplyScopes(tokenRequest.Scope, refreshTokenClaims.Scopes, logger)
 	if scopeErr != nil {
 		return nil, scopeErr
+	}
+
+	// Compute narrowed audiences per RFC 8707 §2.1. When the client supplies resource parameters,
+	// narrow the audience to the intersection with the original refresh-token audiences.
+	// An empty intersection is a client error (invalid_target).
+	audiences := refreshTokenClaims.Audiences
+	if len(tokenRequest.Resources) > 0 {
+		original := make(map[string]struct{}, len(refreshTokenClaims.Audiences))
+		for _, a := range refreshTokenClaims.Audiences {
+			original[a] = struct{}{}
+		}
+		narrowed := make([]string, 0, len(tokenRequest.Resources))
+		for _, r := range tokenRequest.Resources {
+			if _, ok := original[r]; ok {
+				narrowed = append(narrowed, r)
+			}
+		}
+		if len(narrowed) == 0 {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorInvalidTarget,
+				ErrorDescription: "Requested resources do not match any audience in the original grant",
+			}
+		}
+		audiences = narrowed
+
+		// Downscope: resolve the narrowed RSes and filter scopes to only those valid on them.
+		resolvedRSes, rsErr := resourceindicators.ResolveResourceServers(ctx, h.resourceService, narrowed)
+		if rsErr != nil {
+			return nil, rsErr
+		}
+		narrowedRSes := resourceindicators.FilterByIdentifiers(resolvedRSes, narrowed)
+		oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(
+			strings.Join(newTokenScopes, " "), oauthApp.ScopeClaims)
+		rsValidScopes, scopeErr := resourceindicators.ComputeRSValidScopes(
+			ctx, h.resourceService, narrowedRSes, nonOidcScopes)
+		if scopeErr != nil {
+			return nil, scopeErr
+		}
+		oidcScopes = append(oidcScopes, resourceindicators.UnionScopes(rsValidScopes)...)
+		newTokenScopes = oidcScopes
 	}
 
 	// Get user attributes from attribute cache.
@@ -132,7 +182,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
 		Subject:          refreshTokenClaims.Sub,
-		Audience:         refreshTokenClaims.Aud,
+		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,
 		Scopes:           newTokenScopes,
 		UserAttributes:   attrs,
@@ -180,11 +230,14 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	renewRefreshToken := conf.OAuth.RefreshToken.RenewOnGrant
 
 	// Issue a new refresh token if renew_on_grant is enabled; otherwise reuse the existing one.
+	// RFC 8707 §5: the refresh token preserves the full original audience, not the narrowed one.
 	if renewRefreshToken {
 		logger.Debug("Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
-		errResp := h.IssueRefreshToken(ctx, tokenResponse, oauthApp, refreshTokenClaims.Sub, refreshTokenClaims.Aud,
-			refreshTokenClaims.GrantType, newTokenScopes, refreshTokenClaims.ClaimsRequest,
-			refreshTokenClaims.ClaimsLocales, refreshTokenClaims.AttributeCacheID)
+		errResp := h.IssueRefreshToken(ctx, tokenResponse, oauthApp,
+			refreshTokenClaims.Sub, refreshTokenClaims.Audiences,
+			refreshTokenClaims.GrantType, newTokenScopes,
+			refreshTokenClaims.ClaimsRequest, refreshTokenClaims.ClaimsLocales,
+			refreshTokenClaims.AttributeCacheID)
 		if errResp != nil && errResp.Error != "" {
 			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
 			return nil, errResp
@@ -211,22 +264,22 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	ctx context.Context,
 	tokenResponse *model.TokenResponseDTO,
 	oauthApp *appmodel.OAuthAppConfigProcessedDTO,
-	subject, audience, grantType string,
+	subject string, audiences []string, grantType string,
 	scopes []string,
 	claimsRequest *model.ClaimsRequest,
 	claimsLocales string,
 	attributeCacheID string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
-		ClientID:            oauthApp.ClientID,
-		Scopes:              scopes,
-		GrantType:           grantType,
-		AccessTokenSubject:  subject,
-		AccessTokenAudience: audience,
-		AttributeCacheID:    attributeCacheID,
-		OAuthApp:            oauthApp,
-		ClaimsRequest:       claimsRequest,
-		ClaimsLocales:       claimsLocales,
+		ClientID:             oauthApp.ClientID,
+		Scopes:               scopes,
+		GrantType:            grantType,
+		AccessTokenSubject:   subject,
+		AccessTokenAudiences: audiences,
+		AttributeCacheID:     attributeCacheID,
+		OAuthApp:             oauthApp,
+		ClaimsRequest:        claimsRequest,
+		ClaimsLocales:        claimsLocales,
 	}
 
 	// Build refresh token using token builder

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
@@ -40,12 +41,15 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 // testUserID and testAudience are declared in tokenexchange_test.go
 const testRefreshTokenUserID = "test-user-id"
 const testRefreshTokenAudience = "test-audience"
 const testRefreshTokenClientID = "test-client-id"
+const testRS01URI = "https://rs01.example.com"
+const testRS02URI = "https://rs02.example.com"
 
 type RefreshTokenGrantHandlerTestSuite struct {
 	suite.Suite
@@ -54,6 +58,7 @@ type RefreshTokenGrantHandlerTestSuite struct {
 	mockTokenBuilder     *tokenservicemock.TokenBuilderInterfaceMock
 	mockTokenValidator   *tokenservicemock.TokenValidatorInterfaceMock
 	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	mockResourceService  *resourcemock.ResourceServiceInterfaceMock
 	oauthApp             *appmodel.OAuthAppConfigProcessedDTO
 	validRefreshToken    string
 	validClaims          map[string]interface{}
@@ -86,12 +91,23 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
 	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, mock.Anything).
+		Return(func(_ context.Context, identifier string) *resource.ResourceServer {
+			return &resource.ResourceServer{ID: identifier, Identifier: identifier}
+		}, func(_ context.Context, _ string) *serviceerror.ServiceError {
+			return nil
+		}).Maybe()
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{}, nil).Maybe()
 
 	suite.handler = &refreshTokenGrantHandler{
 		jwtService:       suite.mockJWTService,
 		tokenBuilder:     suite.mockTokenBuilder,
 		tokenValidator:   suite.mockTokenValidator,
 		attrCacheService: suite.mockAttrCacheService,
+		resourceService:  suite.mockResourceService,
 	}
 
 	suite.oauthApp = &appmodel.OAuthAppConfigProcessedDTO{
@@ -135,6 +151,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestNewRefreshTokenGrantHandler(
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
 		suite.mockAttrCacheService,
+		suite.mockResourceService,
 	)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*RefreshTokenGrantHandlerInterface)(nil), handler)
@@ -202,7 +219,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 			return ctx.ClientID == testRefreshTokenClientID &&
 				ctx.GrantType == "authorization_code" &&
 				ctx.AccessTokenSubject == testRefreshTokenUserID &&
-				ctx.AccessTokenAudience == testRefreshTokenAudience
+				len(ctx.AccessTokenAudiences) == 1 && ctx.AccessTokenAudiences[0] == testRefreshTokenAudience
 		})).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		TokenType: "",
@@ -215,7 +232,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp,
-		testRefreshTokenUserID, testRefreshTokenAudience,
+		testRefreshTokenUserID, []string{testRefreshTokenAudience},
 		"authorization_code", []string{"read", "write"}, nil, "", "")
 
 	assert.Nil(suite.T(), err)
@@ -235,7 +252,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 
 	tokenResponse := &model.TokenResponseDTO{}
 
-	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", "",
+	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", nil,
 		"authorization_code", []string{"read"}, nil, "", "")
 
 	assert.NotNil(suite.T(), err)
@@ -247,7 +264,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 	// Mock token builder with matcher that checks for empty sub and aud
 	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
-			return ctx.AccessTokenSubject == "" && ctx.AccessTokenAudience == ""
+			return ctx.AccessTokenSubject == "" && len(ctx.AccessTokenAudiences) == 0
 		})).Return(&model.TokenDTO{
 		Token:    "new.refresh.token",
 		IssuedAt: int64(1234567890),
@@ -255,7 +272,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 
 	tokenResponse := &model.TokenResponseDTO{}
 
-	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", "",
+	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", nil,
 		"authorization_code", []string{"read"}, nil, "", "")
 
 	assert.Nil(suite.T(), err)
@@ -268,7 +285,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithClaims
 			return ctx.ClientID == testRefreshTokenClientID &&
 				ctx.GrantType == "authorization_code" &&
 				ctx.AccessTokenSubject == testRefreshTokenUserID &&
-				ctx.AccessTokenAudience == testRefreshTokenAudience &&
+				len(ctx.AccessTokenAudiences) == 1 && ctx.AccessTokenAudiences[0] == testRefreshTokenAudience &&
 				ctx.ClaimsLocales == "en-US fr-CA ja"
 		})).Return(&model.TokenDTO{
 		Token:         "new.refresh.token",
@@ -280,7 +297,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithClaims
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp,
-		testRefreshTokenUserID, testRefreshTokenAudience,
+		testRefreshTokenUserID, []string{testRefreshTokenAudience},
 		"authorization_code", []string{"read"}, nil, "en-US fr-CA ja", "")
 
 	assert.Nil(suite.T(), err)
@@ -293,7 +310,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -305,7 +322,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.ClientID == testRefreshTokenClientID &&
-				len(ctx.Scopes) == 1 && ctx.Scopes[0] == "read"
+				len(ctx.Scopes) == 1 && ctx.Scopes[0] == testScopeRead
 		})).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
@@ -330,7 +347,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -350,7 +367,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.AccessTokenSubject == testRefreshTokenUserID &&
-				ctx.AccessTokenAudience == testRefreshTokenAudience
+				len(ctx.AccessTokenAudiences) == 1 && ctx.AccessTokenAudiences[0] == testRefreshTokenAudience
 		})).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		IssuedAt:  time.Now().Unix(),
@@ -370,7 +387,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_GetAttributeCach
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -401,7 +418,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_BuildAccessToken
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -428,7 +445,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -522,7 +539,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"openid", "read"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -575,7 +592,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOp
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -587,7 +604,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOp
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.ClientID == testRefreshTokenClientID &&
-				len(ctx.Scopes) == 1 && ctx.Scopes[0] == "read"
+				len(ctx.Scopes) == 1 && ctx.Scopes[0] == testScopeRead
 		})).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
@@ -609,7 +626,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"openid", "read"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -652,7 +669,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_R
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -689,7 +706,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtendsCache_Whe
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -727,7 +744,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_E
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -770,7 +787,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -815,7 +832,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -868,7 +885,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsCacheExtend
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"read", "write"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: testCacheID,
@@ -1005,7 +1022,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
-			Aud:              testRefreshTokenAudience,
+			Audiences:        []string{testRefreshTokenAudience},
 			Scopes:           []string{"openid", "read"},
 			GrantType:        "authorization_code",
 			AttributeCacheID: "",
@@ -1057,4 +1074,286 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	assert.Equal(suite.T(), "new.access.token", response.AccessToken.Token)
 	assert.Equal(suite.T(), "new.id.token", response.IDToken.Token)
 	assert.Equal(suite.T(), "new.refresh.token", response.RefreshToken.Token)
+}
+
+// ============================================================================
+// §5 — resource parameter in refresh_token grant (RFC 8707 §2.1)
+// ============================================================================
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateGrant_MalformedResourceURI_ReturnsInvalidTarget() {
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Resources:    []string{"not-an-absolute-uri"},
+	}
+
+	err := suite.handler.ValidateGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_KnownResource_NarrowsAud() {
+	// Original aud=[rs01, rs02]; request resource=[rs01] → issued aud=[rs01].
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+		Resources:    []string{testRS01URI},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), "new.access.token", response.AccessToken.Token)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_UnknownResource_InvalidTarget() {
+	// Original aud=[rs01, rs02]; request resource=[rs99] (unknown) → empty intersection → invalid_target.
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+		Resources:    []string{"https://rs99.example.com"},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+	assert.Equal(suite.T(), "Requested resources do not match any audience in the original grant", err.ErrorDescription)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_MixedResources_DropsUnknown() {
+	// Original aud=[rs01, rs02]; request resource=[rs99, rs01] → issued aud=[rs01] (rs99 dropped).
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+		Resources:    []string{"https://rs99.example.com", testRS01URI},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoResourceParam_AudUnchanged() {
+	// No resource param → issued aud equals original aud (regression guard).
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 2 &&
+				ctx.Audiences[0] == testRS01URI &&
+				ctx.Audiences[1] == testRS02URI
+		})).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_OriginalAudPreservedInNewRefreshToken() {
+	// RFC 8707 §5: when renewRefreshToken=true and narrowing occurs, the new refresh token must
+	// carry the ORIGINAL (un-narrowed) audiences so future refreshes can recover dropped resources.
+	config.GetThunderRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	// New refresh token must carry the original full aud [rs01, rs02], not only the narrowed rs01.
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
+			return len(ctx.AccessTokenAudiences) == 2 &&
+				ctx.AccessTokenAudiences[0] == testRS01URI &&
+				ctx.AccessTokenAudiences[1] == testRS02URI
+		})).Return(&model.TokenDTO{
+		Token:     "new.refresh.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 86400,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+		Resources:    []string{testRS01URI},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), "new.refresh.token", response.RefreshToken.Token)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_EmptyIntersection_InvalidTarget() {
+	// All requested resources are outside the original grant → invalid_target (Issue 2).
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI},
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read",
+		Resources:    []string{testRS02URI},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+	assert.Equal(suite.T(), "Requested resources do not match any audience in the original grant", err.ErrorDescription)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_ScopeDownscoped() {
+	// Original aud=[rs01, rs02] with scopes [read write]; narrow to rs01 only.
+	// ValidatePermissions returns "write" as invalid for rs01, so access token must carry only "read".
+	suite.mockResourceService.ExpectedCalls = nil
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&resource.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, testRS01URI, mock.Anything).
+		Return([]string{"write"}, nil)
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Audiences:        []string{testRS01URI, testRS02URI},
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI &&
+				len(ctx.Scopes) == 1 && ctx.Scopes[0] == testScopeRead
+		})).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	tokenReq := &model.TokenRequest{
+		GrantType:    string(constants.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+		Scope:        "read write",
+		Resources:    []string{testRS01URI},
+	}
+
+	response, err := suite.handler.HandleGrant(context.Background(), tokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), "new.access.token", response.AccessToken.Token)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -20,30 +20,33 @@ package granthandlers
 
 import (
 	"context"
-	"net/url"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/resourceindicators"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/log"
-	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // tokenExchangeGrantHandler handles the token exchange grant type.
 type tokenExchangeGrantHandler struct {
-	tokenBuilder   tokenservice.TokenBuilderInterface
-	tokenValidator tokenservice.TokenValidatorInterface
+	tokenBuilder    tokenservice.TokenBuilderInterface
+	tokenValidator  tokenservice.TokenValidatorInterface
+	resourceService resource.ResourceServiceInterface
 }
 
 // newTokenExchangeGrantHandler creates a new instance of tokenExchangeGrantHandler.
 func newTokenExchangeGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
+	resourceService resource.ResourceServiceInterface,
 ) GrantHandlerInterface {
 	return &tokenExchangeGrantHandler{
-		tokenBuilder:   tokenBuilder,
-		tokenValidator: tokenValidator,
+		tokenBuilder:    tokenBuilder,
+		tokenValidator:  tokenValidator,
+		resourceService: resourceService,
 	}
 }
 
@@ -78,20 +81,8 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(ctx context.Context, tokenRequ
 		}
 	}
 
-	if tokenRequest.Resource != "" {
-		if !utils.IsValidURI(tokenRequest.Resource) {
-			return &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: "Invalid resource parameter: must be an absolute URI",
-			}
-		}
-		parsedURI, err := url.Parse(tokenRequest.Resource)
-		if err != nil || parsedURI.Fragment != "" {
-			return &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: "Invalid resource parameter: must not contain a fragment component",
-			}
-		}
+	if errResp := resourceindicators.ValidateResourceURIs(tokenRequest.Resources); errResp != nil {
+		return errResp
 	}
 
 	if tokenRequest.ActorToken != "" && tokenRequest.ActorTokenType == "" {
@@ -173,18 +164,34 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 		return nil, errResp
 	}
 
-	// Determine final audience
-	finalAudience := tokenservice.DetermineAudience(
-		tokenRequest.Audience,
-		tokenRequest.Resource,
-		subjectClaims.Aud,
-		tokenRequest.ClientID,
-	)
+	// Determine final audiences per RFC 8693 §2.1: audience and resource parameters may be
+	// combined. audience values are opaque logical names passed verbatim; resource values are
+	// RFC 8707 URIs that resolve to registered Resource Servers and participate in scope
+	// downscoping.
+	resolvedRSes, resErr := resourceindicators.ResolveResourceServers(ctx, h.resourceService, tokenRequest.Resources)
+	if resErr != nil {
+		return nil, resErr
+	}
+	// Narrow to RS-defined permissions when resource params present (RFC 8707 §2.2), matching client_credentials.
+	if len(resolvedRSes) > 0 {
+		rsValidScopes, rsErr := resourceindicators.ComputeRSValidScopes(
+			ctx, h.resourceService, resolvedRSes, finalScopes)
+		if rsErr != nil {
+			return nil, rsErr
+		}
+		finalScopes = resourceindicators.UnionScopes(rsValidScopes)
+	}
+	rsAudiences, audErr := resourceindicators.ComposeAudiences(ctx, h.resourceService, tokenRequest.ClientID,
+		resolvedRSes, finalScopes)
+	if audErr != nil {
+		return nil, audErr
+	}
+	finalAudiences := mergeAudiences(tokenRequest.Audiences, rsAudiences, tokenRequest.ClientID)
 
 	// Build access token using token builder
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
 		Subject:        subjectClaims.Sub,
-		Audience:       finalAudience,
+		Audiences:      finalAudiences,
 		ClientID:       tokenRequest.ClientID,
 		Scopes:         finalScopes,
 		UserAttributes: subjectClaims.UserAttributes,
@@ -244,4 +251,47 @@ func (h *tokenExchangeGrantHandler) getScopes(
 	}
 
 	return validRequestedScopes, nil
+}
+
+// mergeAudiences combines opaque audience values with RS-resolved audiences per RFC 8693 §2.1.
+// Rules:
+//   - Start with explicitAudiences verbatim (preserving order, deduped within itself).
+//   - Append rsAudiences items not already present.
+//   - If rsAudiences is the clientID-only fallback (len==1 and value==clientID) and
+//     explicitAudiences is non-empty, the clientID fallback is dropped — the explicit audience
+//     request is sufficient.
+//   - If the merged set is empty, fall back to []string{clientID} (or empty if clientID is empty).
+func mergeAudiences(explicitAudiences []string, rsAudiences []string, clientID string) []string {
+	seen := make(map[string]struct{}, len(explicitAudiences)+len(rsAudiences))
+	merged := make([]string, 0, len(explicitAudiences)+len(rsAudiences))
+
+	for _, a := range explicitAudiences {
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		merged = append(merged, a)
+	}
+
+	// Drop the clientID-only fallback from rsAudiences when explicit audiences were provided.
+	isFallback := len(rsAudiences) == 1 && rsAudiences[0] == clientID
+	if isFallback && len(explicitAudiences) > 0 {
+		rsAudiences = nil
+	}
+
+	for _, a := range rsAudiences {
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		merged = append(merged, a)
+	}
+
+	if len(merged) == 0 {
+		if clientID != "" {
+			return []string{clientID}
+		}
+		return []string{}
+	}
+	return merged
 }

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -35,9 +35,12 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 )
 
 const (
@@ -52,11 +55,12 @@ const (
 
 type TokenExchangeGrantHandlerTestSuite struct {
 	suite.Suite
-	mockJWTService     *jwtmock.JWTServiceInterfaceMock
-	mockTokenBuilder   *tokenservicemock.TokenBuilderInterfaceMock
-	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
-	handler            *tokenExchangeGrantHandler
-	oauthApp           *appmodel.OAuthAppConfigProcessedDTO
+	mockJWTService      *jwtmock.JWTServiceInterfaceMock
+	mockTokenBuilder    *tokenservicemock.TokenBuilderInterfaceMock
+	mockTokenValidator  *tokenservicemock.TokenValidatorInterfaceMock
+	mockResourceService *resourcemock.ResourceServiceInterfaceMock
+	handler             *tokenExchangeGrantHandler
+	oauthApp            *appmodel.OAuthAppConfigProcessedDTO
 }
 
 func TestTokenExchangeGrantHandlerSuite(t *testing.T) {
@@ -77,9 +81,21 @@ func (suite *TokenExchangeGrantHandlerTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, mock.Anything).
+		Return(func(_ context.Context, identifier string) *resource.ResourceServer {
+			return &resource.ResourceServer{ID: identifier, Identifier: identifier}
+		}, func(_ context.Context, _ string) *serviceerror.ServiceError {
+			return nil
+		}).Maybe()
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{}, nil).Maybe()
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
 	suite.handler = &tokenExchangeGrantHandler{
-		tokenBuilder:   suite.mockTokenBuilder,
-		tokenValidator: suite.mockTokenValidator,
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: suite.mockResourceService,
 	}
 
 	suite.oauthApp = &appmodel.OAuthAppConfigProcessedDTO{
@@ -153,7 +169,15 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMock(
 			NestedAct:      nil,
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID && ctx.Audience == expectedAudience
+		if ctx.Subject != testUserID || len(ctx.Audiences) == 0 {
+			return false
+		}
+		for _, a := range ctx.Audiences {
+			if a == expectedAudience {
+				return true
+			}
+		}
+		return false
 	})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
@@ -180,7 +204,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 			NestedAct:      nil,
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID && ctx.Audience == expectedAudience &&
+		return ctx.Subject == testUserID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == expectedAudience) &&
 			tokenservice.JoinScopes(ctx.Scopes) == expectedScope
 	})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
@@ -194,7 +218,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 
 // TestNewTokenExchangeGrantHandler tests the constructor
 func (suite *TokenExchangeGrantHandlerTestSuite) TestNewTokenExchangeGrantHandler() {
-	handler := newTokenExchangeGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator)
+	handler := newTokenExchangeGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator, suite.mockResourceService)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -322,12 +346,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_InvalidResour
 		ClientID:         testClientID,
 		SubjectToken:     "subject-token",
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Resource:         "not-a-valid-uri",
+		Resources:        []string{"not-a-valid-uri"},
 	}
 
 	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, result.Error)
 	assert.Contains(suite.T(), result.ErrorDescription, "Invalid resource parameter")
 }
 
@@ -337,12 +361,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_ResourceURIWi
 		ClientID:         testClientID,
 		SubjectToken:     "subject-token",
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Resource:         "https://api.example.com/resource#fragment",
+		Resources:        []string{"https://api.example.com/resource#fragment"},
 	}
 
 	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, result.Error)
 	assert.Contains(suite.T(), result.ErrorDescription, "must not contain a fragment component")
 }
 
@@ -352,7 +376,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_ValidResource
 		ClientID:         testClientID,
 		SubjectToken:     "subject-token",
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Resource:         "https://api.example.com/resource",
+		Resources:        []string{"https://api.example.com/resource"},
 	}
 
 	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -407,7 +431,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Basic()
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		return ctx.Subject == testUserID &&
-			ctx.Audience == testClientID && // Default audience is clientID when no resource/audience parameter
+			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+			// Default audience is clientID when no resource/audience parameter
 			ctx.ClientID == testClientID &&
 			ctx.UserAttributes["email"] == testUserEmail &&
 			tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
@@ -496,7 +521,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		return ctx.Subject == testUserID &&
-			ctx.Audience == testClientID &&
+			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 			ctx.ActorClaims != nil &&
 			ctx.ActorClaims.Sub == "service456" &&
 			ctx.ActorClaims.Iss == testCustomIssuer
@@ -592,7 +617,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAud
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Audience = "https://api.example.com"
+	tokenRequest.Audiences = []string{"https://api.example.com"}
 
 	suite.setupSuccessfulJWTMock(subjectToken, "https://api.example.com", now)
 
@@ -612,7 +637,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithRes
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Resource = "https://resource.example.com"
+	tokenRequest.Resources = []string{"https://resource.example.com"}
 
 	suite.setupSuccessfulJWTMock(subjectToken, "https://resource.example.com", now)
 
@@ -677,7 +702,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Preserv
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		return ctx.Subject == testUserID &&
-			ctx.Audience == testClientID &&
+			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 			ctx.UserAttributes["email"] == "user@example.com" &&
 			ctx.UserAttributes["name"] == "Test User"
 	})).Return(&model.TokenDTO{
@@ -895,7 +920,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidScope() 
 	// Expect token generation with only valid scopes ("read write", filtering out "delete")
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		// Verify only valid scopes are included (filtering out "delete")
-		return tokenservice.JoinScopes(ctx.Scopes) == "read write"
+		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
 	})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
@@ -1126,7 +1151,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 		SubjectToken:       subjectToken,
 		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 		RequestedTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Audience:           "https://target-service.com",
+		Audiences:          []string{"https://target-service.com"},
 		Scope:              "read",
 	}
 
@@ -1142,9 +1167,11 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 			NestedAct: nil,
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify claims structure per RFC 8693
+		// Verify claims structure per RFC 8693 - explicit audience is used verbatim; clientID
+		// fallback is dropped when explicit audience is non-empty.
 		return ctx.Subject == testUserID &&
-			ctx.Audience == "https://target-service.com" &&
+			len(ctx.Audiences) == 1 &&
+			ctx.Audiences[0] == "https://target-service.com" &&
 			ctx.ClientID == testClientID &&
 			tokenservice.JoinScopes(ctx.Scopes) == testScopeRead &&
 			ctx.UserAttributes["email"] == "user@example.com" &&
@@ -1175,8 +1202,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 	// IssuedTokenType is determined at the token handler level, not the grant handler level
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudiencePriority() {
-	// RFC 8693: Test audience parameter priority (audience > resource > token.aud > client_id)
+func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWithResource() {
+	// RFC 8693 §2.1: audience and resource parameters may be combined; audience is opaque,
+	// resource is RS-resolved. Both contribute to the final aud simultaneously.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": "user123",
@@ -1186,14 +1214,13 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudiencePriority() 
 		"aud": "token-audience",
 	})
 
-	// Test 1: Audience parameter takes priority
 	tokenRequest := &model.TokenRequest{
 		GrantType:        string(constants.GrantTypeTokenExchange),
 		ClientID:         testClientID,
 		SubjectToken:     subjectToken,
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Audience:         "request-audience",
-		Resource:         "https://resource.example.com",
+		Audiences:        []string{"request-audience"},
+		Resources:        []string{"https://resource.example.com"},
 	}
 
 	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
@@ -1205,8 +1232,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudiencePriority() 
 			NestedAct:      nil,
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Should use request audience, not resource or token aud
-		return ctx.Subject == testUserID && ctx.Audience == "request-audience"
+		// explicit audience first, then RS-resolved audience; clientID fallback absent since
+		// explicit audiences were supplied.
+		return ctx.Subject == testUserID &&
+			len(ctx.Audiences) == 2 &&
+			ctx.Audiences[0] == "request-audience" &&
+			ctx.Audiences[1] == "https://resource.example.com"
 	})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
@@ -1448,7 +1479,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ResourceParameterVa
 		ClientID:         testClientID,
 		SubjectToken:     "subject-token",
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Resource:         "https://api.example.com/v1/resource",
+		Resources:        []string{"https://api.example.com/v1/resource"},
 	}
 
 	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -1582,12 +1613,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestIsSupportedTokenType() {
 	assert.False(suite.T(), constants.TokenTypeIdentifier("invalid").IsValid())
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestGetAudience_WithClientIDFallback() {
-	// Test that DetermineAudience falls back to clientID when no audience, resource, or token.aud provided
-	result := tokenservice.DetermineAudience("", "", "", testClientID)
-	assert.Equal(suite.T(), testClientID, result)
-}
-
 func (suite *TokenExchangeGrantHandlerTestSuite) TestExtractUserAttributes() {
 	claims := map[string]interface{}{
 		"sub":       testUserID,
@@ -1617,24 +1642,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestExtractUserAttributes() {
 	assert.NotContains(suite.T(), userAttrs, "scope")
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestDetermineAudience_Priority() {
-	// Audience parameter has highest priority (RFC 8693)
-	aud := tokenservice.DetermineAudience("request-audience", "request-resource", "token-aud", testClientID)
-	assert.Equal(suite.T(), "request-audience", aud)
-
-	// Resource parameter is second priority
-	aud = tokenservice.DetermineAudience("", "request-resource", "token-aud", testClientID)
-	assert.Equal(suite.T(), "request-resource", aud)
-
-	// Token.aud is third priority
-	aud = tokenservice.DetermineAudience("", "", "token-aud", testClientID)
-	assert.Equal(suite.T(), "token-aud", aud)
-
-	// Client ID is fallback when neither audience, resource, nor token.aud provided
-	aud = tokenservice.DetermineAudience("", "", "", testClientID)
-	assert.Equal(suite.T(), testClientID, aud)
-}
-
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAssertion_Success() {
 	defaultAudience := suite.getDefaultAudience()
 	now := time.Now().Unix()
@@ -1661,7 +1668,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
-			Aud:            defaultAudience,
+			Aud:            []string{defaultAudience},
 			Scopes:         []string{"read:documents", "write:documents"}, // Mapped from authorized_permissions
 			UserAttributes: map[string]interface{}{"userType": "person"},
 			NestedAct:      nil,
@@ -1778,7 +1785,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
-			Aud:            defaultAudience,
+			Aud:            []string{defaultAudience},
 			Scopes:         []string{"read", "write"},
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
@@ -1826,7 +1833,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
-			Aud:            suite.oauthApp.AppID,
+			Aud:            []string{suite.oauthApp.AppID},
 			Scopes:         []string{"read:documents", "write:documents"},
 			UserAttributes: map[string]interface{}{"userType": "person"},
 			NestedAct:      nil,
@@ -1854,4 +1861,435 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 	assert.Equal(suite.T(), []string{"read:documents", "write:documents"}, result.AccessToken.Scopes)
 	suite.mockTokenValidator.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
+}
+
+// ============================================================================
+// §6 — audience + resource together in token_exchange (RFC 8693 §2.1)
+// ============================================================================
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudience_AudIsExplicitValue() { //nolint:dupl
+	// Only audience=logical://x → aud = ["logical://x"]; clientID fallback dropped.
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"logical://x"}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "logical://x"
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyResource_AudIsResolvedRS() { //nolint:dupl
+	// Only resource=https://rs01 (rs01 registered) → aud = [testRS01URI].
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Resources = []string{testRS01URI}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceAndResource_BothContribute() {
+	// audience=logical://x, resource=https://rs01 → aud = ["logical://x", testRS01URI].
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"logical://x"}
+	tokenRequest.Resources = []string{testRS01URI}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 2 &&
+			ctx.Audiences[0] == "logical://x" &&
+			ctx.Audiences[1] == testRS01URI
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwoResources_OrderPreserved() {
+	// audience=[a1,a2], resource=[rs01,rs02] → aud=[a1,a2,rs01,rs02] (audience order first).
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"https://a1.example.com", "https://a2.example.com"}
+	tokenRequest.Resources = []string{testRS01URI, "https://rs02.example.com"}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 4 &&
+			ctx.Audiences[0] == "https://a1.example.com" &&
+			ctx.Audiences[1] == "https://a2.example.com" &&
+			ctx.Audiences[2] == testRS01URI &&
+			ctx.Audiences[3] == "https://rs02.example.com"
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClientID_WithResource_BothKept() {
+	// audience=<clientID>, resource=rs01 → aud=[<clientID>, rs01] (no dedup; client asked for clientID).
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{testClientID}
+	tokenRequest.Resources = []string{testRS01URI}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 2 &&
+			ctx.Audiences[0] == testClientID &&
+			ctx.Audiences[1] == testRS01URI
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_ClientIDFallbackDropped() { //nolint:dupl
+	// audience=<something>, no resource, no granted scopes → aud=[<something>] (clientID fallback dropped).
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"https://other-service.example.com"}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "https://other-service.example.com"
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_NeitherAudienceNorResource_FallbackToClientID() {
+	// Neither audience nor resource → §4 fallback: no RS contributes → aud=[clientID].
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID
+	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+// ============================================================================
+// RFC 8707 §2.2 — per-RS scope downscoping in token_exchange
+// ============================================================================
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resource_ScopesNarrowedToRSPermissions() {
+	// Subject token has [read, write, admin]; RS defines [read, write].
+	// Expect token scopes = [read, write] (admin dropped by RS intersection).
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub":   testUserID,
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read write admin",
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Resources = []string{testRS01URI}
+
+	// Use a fresh resource service mock so the catch-all from SetupTest does not shadow
+	// the specific ValidatePermissions expectation.
+	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	rsvc.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&resource.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	// RS only defines [read, write]; ValidatePermissions returns the invalid one (admin).
+	rsvc.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write", "admin"}).
+		Return([]string{"admin"}, nil)
+	rsvc.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+	h := &tokenExchangeGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: rsvc,
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{"read", "write", "admin"},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+	})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopeNotOnRS_Dropped() {
+	// Subject token [read, write, admin], explicit scope=read write, RS defines [read].
+	// getScopes gives [read, write] (admin not in scope param); RS intersection drops write → [read].
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub":   testUserID,
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read write admin",
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Resources = []string{testRS01URI}
+	tokenRequest.Scope = "read write"
+
+	// Use a fresh resource service mock so the catch-all from SetupTest does not shadow
+	// the specific ValidatePermissions expectation.
+	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	rsvc.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&resource.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	// RS defines [read] only; ValidatePermissions returns [write] as invalid.
+	rsvc.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write"}).
+		Return([]string{"write"}, nil)
+	rsvc.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+	h := &tokenExchangeGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: rsvc,
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{"read", "write", "admin"},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+	})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read"},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read"}, result.AccessToken.Scopes)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ResourceOmitted_ScopesUnchanged() {
+	// No resource param → ComputeRSValidScopes is never called; scopes come straight from getScopes.
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub":   testUserID,
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read write",
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{"read", "write"},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+	})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_MultipleResources_UnionScopes() {
+	// RS1 defines [read], RS2 defines [write]; subject token has [read, write, admin].
+	// Union of per-RS valid scopes = [read, write]; admin dropped.
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub":   testUserID,
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read write admin",
+	})
+
+	const testRS02URI = "https://rs02.example.com"
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Resources = []string{testRS01URI, testRS02URI}
+
+	// Use a fresh resource service mock so catch-all ValidatePermissions from SetupTest does
+	// not shadow the per-RS expectations.
+	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	rsvc.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&resource.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	rsvc.On("GetResourceServerByIdentifier", mock.Anything, testRS02URI).
+		Return(&resource.ResourceServer{ID: testRS02URI, Identifier: testRS02URI}, nil)
+	// RS1 defines [read]: returns [write, admin] as invalid.
+	rsvc.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write", "admin"}).
+		Return([]string{"write", "admin"}, nil)
+	// RS2 defines [write]: returns [read, admin] as invalid.
+	rsvc.On("ValidatePermissions", mock.Anything, testRS02URI, []string{"read", "write", "admin"}).
+		Return([]string{"read", "admin"}, nil)
+	rsvc.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+	h := &tokenExchangeGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: rsvc,
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{"read", "write", "admin"},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+	})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
 }

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -30,7 +30,7 @@ type OAuthParameters struct {
 	PermissionScopes    []string
 	CodeChallenge       string
 	CodeChallengeMethod string
-	Resource            string
+	Resources           []string
 	ClaimsRequest       *ClaimsRequest
 	ClaimsLocales       string
 	Nonce               string

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -21,23 +21,23 @@ package model
 
 // TokenRequest represents the OAuth2 token request.
 type TokenRequest struct {
-	GrantType          string `json:"grant_type"`
-	ClientID           string `json:"client_id"`
-	ClientSecret       string `json:"client_secret"`
-	Scope              string `json:"scope,omitempty"`
-	Username           string `json:"username,omitempty"`
-	Password           string `json:"password,omitempty"`
-	RefreshToken       string `json:"refresh_token,omitempty"`
-	CodeVerifier       string `json:"code_verifier,omitempty"`
-	Code               string `json:"code,omitempty"`
-	RedirectURI        string `json:"redirect_uri,omitempty"`
-	Resource           string `json:"resource,omitempty"`
-	SubjectToken       string `json:"subject_token,omitempty"`
-	SubjectTokenType   string `json:"subject_token_type,omitempty"`
-	ActorToken         string `json:"actor_token,omitempty"`
-	ActorTokenType     string `json:"actor_token_type,omitempty"`
-	RequestedTokenType string `json:"requested_token_type,omitempty"`
-	Audience           string `json:"audience,omitempty"`
+	GrantType          string   `json:"grant_type"`
+	ClientID           string   `json:"client_id"`
+	ClientSecret       string   `json:"client_secret"`
+	Scope              string   `json:"scope,omitempty"`
+	Username           string   `json:"username,omitempty"`
+	Password           string   `json:"password,omitempty"`
+	RefreshToken       string   `json:"refresh_token,omitempty"`
+	CodeVerifier       string   `json:"code_verifier,omitempty"`
+	Code               string   `json:"code,omitempty"`
+	RedirectURI        string   `json:"redirect_uri,omitempty"`
+	Resources          []string `json:"resources,omitempty"`
+	SubjectToken       string   `json:"subject_token,omitempty"`
+	SubjectTokenType   string   `json:"subject_token_type,omitempty"`
+	ActorToken         string   `json:"actor_token,omitempty"`
+	ActorTokenType     string   `json:"actor_token_type,omitempty"`
+	RequestedTokenType string   `json:"requested_token_type,omitempty"`
+	Audiences          []string `json:"audiences,omitempty"`
 }
 
 // TokenResponse represents the OAuth2 token response.
@@ -53,18 +53,19 @@ type TokenResponse struct {
 
 // TokenDTO represents the data transfer object for tokens.
 type TokenDTO struct {
-	Token            string
-	TokenType        string
-	IssuedAt         int64
-	ExpiresIn        int64
-	Scopes           []string
-	ClientID         string
-	UserAttributes   map[string]interface{}
-	AttributeCacheID string
-	Subject          string
-	Audience         string
-	ClaimsRequest    *ClaimsRequest
-	ClaimsLocales    string
+	Token             string
+	TokenType         string
+	IssuedAt          int64
+	ExpiresIn         int64
+	Scopes            []string
+	ClientID          string
+	UserAttributes    map[string]interface{}
+	AttributeCacheID  string
+	Subject           string
+	Audiences         []string
+	OriginalAudiences []string
+	ClaimsRequest     *ClaimsRequest
+	ClaimsLocales     string
 }
 
 // TokenResponseDTO represents the data transfer object for token responses.

--- a/backend/internal/oauth/oauth2/resourceindicators/resourceindicators.go
+++ b/backend/internal/oauth/oauth2/resourceindicators/resourceindicators.go
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package resourceindicators provides shared helpers for RFC 8707 resource indicator
+// processing across OAuth 2.0 grant handlers and the authorization endpoint.
+package resourceindicators
+
+import (
+	"context"
+	"net/url"
+	"sort"
+
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
+	"github.com/asgardeo/thunder/internal/resource"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+// ValidateResourceURIs returns an error response when any resource URI is not absolute
+// or contains a fragment component (RFC 8707 §2, RFC 3986 §4.3).
+func ValidateResourceURIs(resources []string) *model.ErrorResponse {
+	for _, res := range resources {
+		parsedURI, err := url.Parse(res)
+		if err != nil || parsedURI.Scheme == "" {
+			return &model.ErrorResponse{
+				Error:            constants.ErrorInvalidTarget,
+				ErrorDescription: "Invalid resource parameter: must be an absolute URI",
+			}
+		}
+		if parsedURI.Fragment != "" {
+			return &model.ErrorResponse{
+				Error:            constants.ErrorInvalidTarget,
+				ErrorDescription: "Invalid resource parameter: must not contain a fragment component",
+			}
+		}
+	}
+	return nil
+}
+
+// ResolveResourceServers resolves each resource identifier to its registered Resource Server.
+// Returns invalid_target on any unknown identifier (RFC 8707 §2.2).
+// The returned slice preserves the order of the input identifiers.
+func ResolveResourceServers(
+	ctx context.Context,
+	resourceService resource.ResourceServiceInterface,
+	resources []string,
+) ([]*resource.ResourceServer, *model.ErrorResponse) {
+	if len(resources) == 0 {
+		return nil, nil
+	}
+	resolved := make([]*resource.ResourceServer, 0, len(resources))
+	for _, identifier := range resources {
+		rs, svcErr := resourceService.GetResourceServerByIdentifier(ctx, identifier)
+		if svcErr != nil {
+			if svcErr.Type == serviceerror.ServerErrorType {
+				return nil, &model.ErrorResponse{
+					Error:            constants.ErrorServerError,
+					ErrorDescription: "Failed to resolve resource server",
+				}
+			}
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorInvalidTarget,
+				ErrorDescription: "The resource parameter does not match any registered resource server",
+			}
+		}
+		resolved = append(resolved, rs)
+	}
+	return resolved, nil
+}
+
+// ComputeRSValidScopes returns, for each resolved Resource Server, the subset of requested
+// scopes that are defined as permissions on that RS. Scopes not defined on any RS are absent
+// from the union of the per-RS slices (downscoping per RFC 6749 §3.3).
+func ComputeRSValidScopes(
+	ctx context.Context,
+	resourceService resource.ResourceServiceInterface,
+	resolvedRSes []*resource.ResourceServer,
+	requestedScopes []string,
+) (map[string][]string, *model.ErrorResponse) {
+	rsValidScopes := make(map[string][]string, len(resolvedRSes))
+	if len(requestedScopes) == 0 || len(resolvedRSes) == 0 {
+		return rsValidScopes, nil
+	}
+	for _, rs := range resolvedRSes {
+		invalid, valErr := resourceService.ValidatePermissions(ctx, rs.ID, requestedScopes)
+		if valErr != nil {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to validate permissions",
+			}
+		}
+		invalidSet := make(map[string]struct{}, len(invalid))
+		for _, p := range invalid {
+			invalidSet[p] = struct{}{}
+		}
+		valid := make([]string, 0, len(requestedScopes))
+		for _, p := range requestedScopes {
+			if _, isInvalid := invalidSet[p]; !isInvalid {
+				valid = append(valid, p)
+			}
+		}
+		rsValidScopes[rs.ID] = valid
+	}
+	return rsValidScopes, nil
+}
+
+// UnionScopes returns the union of all per-RS valid scope slices in deterministic order.
+func UnionScopes(rsValidScopes map[string][]string) []string {
+	keys := make([]string, 0, len(rsValidScopes))
+	for k := range rsValidScopes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	seen := make(map[string]struct{})
+	union := []string{}
+	for _, k := range keys {
+		for _, s := range rsValidScopes[k] {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			union = append(union, s)
+		}
+	}
+	return union
+}
+
+// ComposeAudiences builds the aud claim from the resolved Resource Servers. When resolvedRSes is
+// non-nil (explicit resource parameter), all resolved RS identifiers are included. When
+// resolvedRSes is nil and granted scopes are present, contributors are discovered via the resource
+// service (implicit audience). If no RS contributes, clientID is returned as the sole fallback
+// audience. If clientID is also empty, an empty slice is returned.
+func ComposeAudiences(
+	ctx context.Context,
+	resourceService resource.ResourceServiceInterface,
+	clientID string,
+	resolvedRSes []*resource.ResourceServer,
+	grantedScopes []string,
+) ([]string, *model.ErrorResponse) {
+	var rsIdentifiers []string
+	if resolvedRSes != nil {
+		rsIdentifiers = ContributingAudiences(resolvedRSes)
+	} else if len(grantedScopes) > 0 {
+		implicit, svcErr := resourceService.FindResourceServersByPermissions(ctx, grantedScopes)
+		if svcErr != nil {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to resolve resource servers for granted scopes",
+			}
+		}
+		rsIdentifiers = make([]string, 0, len(implicit))
+		for _, rs := range implicit {
+			if rs.Identifier != "" {
+				rsIdentifiers = append(rsIdentifiers, rs.Identifier)
+			}
+		}
+		sort.Strings(rsIdentifiers)
+	}
+
+	if len(rsIdentifiers) > 0 {
+		seen := make(map[string]struct{}, len(rsIdentifiers))
+		deduped := make([]string, 0, len(rsIdentifiers))
+		for _, id := range rsIdentifiers {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			deduped = append(deduped, id)
+		}
+		return deduped, nil
+	}
+
+	if clientID != "" {
+		return []string{clientID}, nil
+	}
+	return []string{}, nil
+}
+
+// FilterByIdentifiers returns the subset of resolvedRSes whose Identifier is in identifiers.
+// Preserves the order of resolvedRSes.
+func FilterByIdentifiers(resolvedRSes []*resource.ResourceServer, identifiers []string) []*resource.ResourceServer {
+	idSet := make(map[string]struct{}, len(identifiers))
+	for _, id := range identifiers {
+		idSet[id] = struct{}{}
+	}
+	filtered := make([]*resource.ResourceServer, 0, len(identifiers))
+	for _, rs := range resolvedRSes {
+		if _, ok := idSet[rs.Identifier]; ok {
+			filtered = append(filtered, rs)
+		}
+	}
+	return filtered
+}
+
+// ContributingAudiences returns the identifiers of all explicitly resolved Resource Servers.
+// When the client explicitly requests resource targets, those targets form the token audience.
+// Preserves the order of resolvedRSes.
+func ContributingAudiences(
+	resolvedRSes []*resource.ResourceServer,
+) []string {
+	if len(resolvedRSes) == 0 {
+		return nil
+	}
+	auds := make([]string, 0, len(resolvedRSes))
+	for _, rs := range resolvedRSes {
+		if rs.Identifier != "" {
+			auds = append(auds, rs.Identifier)
+		}
+	}
+	return auds
+}

--- a/backend/internal/oauth/oauth2/resourceindicators/resourceindicators_test.go
+++ b/backend/internal/oauth/oauth2/resourceindicators/resourceindicators_test.go
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package resourceindicators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/resource"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
+)
+
+type ResourceIndicatorsTestSuite struct {
+	suite.Suite
+	mockResourceService *resourcemock.ResourceServiceInterfaceMock
+}
+
+func TestResourceIndicatorsTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceIndicatorsTestSuite))
+}
+
+func (suite *ResourceIndicatorsTestSuite) SetupTest() {
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+}
+
+// ValidateResourceURIs tests
+
+func (suite *ResourceIndicatorsTestSuite) TestValidateResourceURIs_Valid() {
+	err := ValidateResourceURIs([]string{"https://api.example.com/resource"})
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestValidateResourceURIs_Empty() {
+	err := ValidateResourceURIs([]string{})
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestValidateResourceURIs_MissingScheme() {
+	err := ValidateResourceURIs([]string{"api.example.com/resource"})
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestValidateResourceURIs_WithFragment() {
+	err := ValidateResourceURIs([]string{"https://api.example.com/resource#frag"})
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+	assert.Contains(suite.T(), err.ErrorDescription, "fragment")
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestValidateResourceURIs_InvalidURI() {
+	err := ValidateResourceURIs([]string{"://bad"})
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+}
+
+// ResolveResourceServers tests
+
+func (suite *ResourceIndicatorsTestSuite) TestResolveResourceServers_Empty() {
+	resolved, err := ResolveResourceServers(context.Background(), suite.mockResourceService, []string{})
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resolved)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestResolveResourceServers_Found() {
+	rs := resource.ResourceServer{ID: "rs01", Identifier: "https://api.example.com"}
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, "https://api.example.com").
+		Return(&rs, nil)
+
+	resolved, err := ResolveResourceServers(context.Background(), suite.mockResourceService,
+		[]string{"https://api.example.com"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []*resource.ResourceServer{&rs}, resolved)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestResolveResourceServers_NotFound_ReturnsInvalidTarget() {
+	svcErr := &serviceerror.ServiceError{Type: serviceerror.ClientErrorType, Code: "RSE-4041"}
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, "https://unknown.example.com").
+		Return(nil, svcErr)
+
+	resolved, err := ResolveResourceServers(context.Background(), suite.mockResourceService,
+		[]string{"https://unknown.example.com"})
+
+	assert.Nil(suite.T(), resolved)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, err.Error)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestResolveResourceServers_StoreFailure_ReturnsServerError() {
+	svcErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "SSE-5000"}
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, "https://api.example.com").
+		Return(nil, svcErr)
+
+	resolved, err := ResolveResourceServers(context.Background(), suite.mockResourceService,
+		[]string{"https://api.example.com"})
+
+	assert.Nil(suite.T(), resolved)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+	assert.Equal(suite.T(), "Failed to resolve resource server", err.ErrorDescription)
+}
+
+// ComposeAudiences §4 fallback-only clientID tests
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_RSContributes_NoClientID() {
+	// When at least one RS contributes, clientID must NOT appear in aud.
+	rs := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", []*resource.ResourceServer{rs}, []string{"read"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NoRS_FallbackToClientID() {
+	// When no RS contributes (explicit empty resolvedRSes), aud falls back to clientID.
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", []*resource.ResourceServer{}, []string{})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NilResolvedRSes_NoScopes_FallbackToClientID() {
+	// resolvedRSes==nil, no scopes → implicit discovery skipped → fallback to clientID.
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]resource.ResourceServer{}, nil).Maybe()
+
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_RSFound() {
+	// resolvedRSes==nil with scopes → implicit discovery returns RS → aud contains RS only, no clientID.
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"read"}).
+		Return([]resource.ResourceServer{
+			{ID: "rs01", Identifier: "https://rs01.example.com"},
+		}, nil)
+
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{"read"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_NoRSFound_FallbackToClientID() {
+	// resolvedRSes==nil with scopes → implicit discovery returns nothing → fallback to clientID.
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"openid"}).
+		Return([]resource.ResourceServer{}, nil)
+
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{"openid"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_EmptyClientID_NoRS_ReturnsEmptySlice() {
+	// No RS and empty clientID → return empty slice (no fallback possible).
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"", []*resource.ResourceServer{}, []string{})
+
+	assert.Nil(suite.T(), err)
+	assert.Empty(suite.T(), auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_MultipleRS_Deduped() {
+	// Multiple RSes with duplicate identifiers are deduped; clientID is absent.
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	rs2 := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", []*resource.ResourceServer{rs1, rs2}, []string{"read"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_ServiceError() {
+	// FindResourceServersByPermissions failure returns server error.
+	svcErr := &serviceerror.ServiceError{Code: "internal_error"}
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"read"}).
+		Return(nil, svcErr)
+
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{"read"})
+
+	assert.Nil(suite.T(), auds)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// ContributingAudiences tests
+
+func (suite *ResourceIndicatorsTestSuite) TestContributingAudiences_Empty() {
+	auds := ContributingAudiences([]*resource.ResourceServer{})
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestContributingAudiences_SkipsEmptyIdentifier() {
+	rs := &resource.ResourceServer{ID: "rs01", Identifier: ""}
+	auds := ContributingAudiences([]*resource.ResourceServer{rs})
+	assert.Empty(suite.T(), auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestContributingAudiences_PreservesOrder() {
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://b.example.com"}
+	rs2 := &resource.ResourceServer{ID: "rs02", Identifier: "https://a.example.com"}
+	auds := ContributingAudiences([]*resource.ResourceServer{rs1, rs2})
+	assert.Equal(suite.T(), []string{"https://b.example.com", "https://a.example.com"}, auds)
+}
+
+// FilterByIdentifiers tests
+
+func (suite *ResourceIndicatorsTestSuite) TestFilterByIdentifiers_Empty() {
+	result := FilterByIdentifiers([]*resource.ResourceServer{}, []string{"https://api.example.com"})
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestFilterByIdentifiers_AllMatch() {
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	rs2 := &resource.ResourceServer{ID: "rs02", Identifier: "https://rs02.example.com"}
+	result := FilterByIdentifiers([]*resource.ResourceServer{rs1, rs2},
+		[]string{"https://rs01.example.com", "https://rs02.example.com"})
+	assert.Equal(suite.T(), []*resource.ResourceServer{rs1, rs2}, result)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestFilterByIdentifiers_Subset() {
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	rs2 := &resource.ResourceServer{ID: "rs02", Identifier: "https://rs02.example.com"}
+	result := FilterByIdentifiers([]*resource.ResourceServer{rs1, rs2},
+		[]string{"https://rs01.example.com"})
+	assert.Equal(suite.T(), []*resource.ResourceServer{rs1}, result)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestFilterByIdentifiers_NoMatch() {
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	result := FilterByIdentifiers([]*resource.ResourceServer{rs1}, []string{"https://other.example.com"})
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestFilterByIdentifiers_PreservesOrder() {
+	rs1 := &resource.ResourceServer{ID: "rs01", Identifier: "https://b.example.com"}
+	rs2 := &resource.ResourceServer{ID: "rs02", Identifier: "https://a.example.com"}
+	result := FilterByIdentifiers([]*resource.ResourceServer{rs1, rs2},
+		[]string{"https://b.example.com", "https://a.example.com"})
+	assert.Equal(suite.T(), []*resource.ResourceServer{rs1, rs2}, result)
+}
+
+// UnionScopes tests
+
+func (suite *ResourceIndicatorsTestSuite) TestUnionScopes_Empty() {
+	result := UnionScopes(map[string][]string{})
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestUnionScopes_Deduped() {
+	input := map[string][]string{
+		"rs01": {"read", "write"},
+		"rs02": {"write", "delete"},
+	}
+	result := UnionScopes(input)
+	assert.Contains(suite.T(), result, "read")
+	assert.Contains(suite.T(), result, "write")
+	assert.Contains(suite.T(), result, "delete")
+	assert.Equal(suite.T(), 3, len(result))
+}

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -90,13 +90,13 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 		CodeVerifier:       r.FormValue("code_verifier"),
 		Code:               r.FormValue("code"),
 		RedirectURI:        r.FormValue("redirect_uri"),
-		Resource:           r.FormValue(constants.RequestParamResource),
+		Resources:          r.Form[constants.RequestParamResource],
 		SubjectToken:       r.FormValue(constants.RequestParamSubjectToken),
 		SubjectTokenType:   r.FormValue(constants.RequestParamSubjectTokenType),
 		ActorToken:         r.FormValue(constants.RequestParamActorToken),
 		ActorTokenType:     r.FormValue(constants.RequestParamActorTokenType),
 		RequestedTokenType: r.FormValue(constants.RequestParamRequestedTokenType),
-		Audience:           r.FormValue(constants.RequestParamAudience),
+		Audiences:          r.Form[constants.RequestParamAudience],
 	}
 
 	// Delegate all business logic to the token service.

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -209,10 +209,14 @@ func (ts *tokenService) ProcessTokenRequest(
 			}
 		}
 
+		refreshAudiences := tokenRespDTO.AccessToken.Audiences
+		if len(tokenRespDTO.AccessToken.OriginalAudiences) > 0 {
+			refreshAudiences = tokenRespDTO.AccessToken.OriginalAudiences
+		}
 		refreshTokenError := refreshGrantHandlerTyped.IssueRefreshToken(
 			ctx,
 			tokenRespDTO, oauthApp,
-			tokenRespDTO.AccessToken.Subject, tokenRespDTO.AccessToken.Audience,
+			tokenRespDTO.AccessToken.Subject, refreshAudiences,
 			grantTypeStr, tokenRespDTO.AccessToken.Scopes, tokenRespDTO.AccessToken.ClaimsRequest,
 			tokenRespDTO.AccessToken.ClaimsLocales, tokenRespDTO.AccessToken.AttributeCacheID,
 		)

--- a/backend/internal/oauth/oauth2/token/service_test.go
+++ b/backend/internal/oauth/oauth2/token/service_test.go
@@ -370,7 +370,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_WithRefreshToken() {
 			ExpiresIn: 3600,
 			Scopes:    []string{"openid"},
 			Subject:   "user123",
-			Audience:  "test-audience",
+			Audiences: []string{"test-audience"},
 		},
 		RefreshToken: model.TokenDTO{Token: ""},
 		IDToken:      model.TokenDTO{Token: ""},
@@ -378,7 +378,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_WithRefreshToken() {
 	suite.mockGrantHandler.On("HandleGrant", mock.Anything, mock.Anything, app).Return(tokenRespDTO, nil)
 
 	mockRefreshHandler.
-		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", "test-audience",
+		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", []string{"test-audience"},
 			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "", "").
 		Return(nil)
 
@@ -425,7 +425,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenIssuance
 			ExpiresIn: 3600,
 			Scopes:    []string{"openid"},
 			Subject:   "user123",
-			Audience:  "test-audience",
+			Audiences: []string{"test-audience"},
 		},
 		RefreshToken: model.TokenDTO{Token: ""},
 		IDToken:      model.TokenDTO{Token: ""},
@@ -433,7 +433,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenIssuance
 	suite.mockGrantHandler.On("HandleGrant", mock.Anything, mock.Anything, app).Return(tokenRespDTO, nil)
 
 	mockRefreshHandler.
-		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", "test-audience",
+		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", []string{"test-audience"},
 			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "", "").
 		Return(&model.ErrorResponse{
 			Error:            "server_error",
@@ -477,7 +477,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenHandlerN
 	tokenRespDTO := &model.TokenResponseDTO{
 		AccessToken: model.TokenDTO{
 			Token: "access-token-123", TokenType: "Bearer", ExpiresIn: 3600,
-			Scopes: []string{"openid"}, Subject: "user123", Audience: "test-audience",
+			Scopes: []string{"openid"}, Subject: "user123", Audiences: []string{"test-audience"},
 		},
 		RefreshToken: model.TokenDTO{Token: ""},
 		IDToken:      model.TokenDTO{Token: ""},
@@ -521,7 +521,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenHandlerC
 	tokenRespDTO := &model.TokenResponseDTO{
 		AccessToken: model.TokenDTO{
 			Token: "access-token-123", TokenType: "Bearer", ExpiresIn: 3600,
-			Scopes: []string{"openid"}, Subject: "user123", Audience: "test-audience",
+			Scopes: []string{"openid"}, Subject: "user123", Audiences: []string{"test-audience"},
 		},
 		RefreshToken: model.TokenDTO{Token: ""},
 		IDToken:      model.TokenDTO{Token: ""},
@@ -606,4 +606,63 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_TokenExchangeWithJWT
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), tokenResp)
 	assert.Equal(suite.T(), string(constants.TokenTypeIdentifierJWT), tokenResp.IssuedTokenType)
+}
+
+func (suite *TokenServiceTestSuite) TestProcessTokenRequest_WithRefreshToken_UsesOriginalAudiences() {
+	// When the access token carries OriginalAudiences (narrowing occurred), the refresh token
+	// issuance must receive the original full set, not the narrowed Audiences (RFC 8707 §5).
+	req := &model.TokenRequest{
+		ClientID:  "test-client-id",
+		GrantType: string(constants.GrantTypeAuthorizationCode),
+		Code:      "test-code",
+		Scope:     "openid",
+	}
+	app := &applicationmodel.OAuthAppConfigProcessedDTO{
+		ClientID: "test-client-id",
+		GrantTypes: []constants.GrantType{
+			constants.GrantTypeAuthorizationCode,
+			constants.GrantTypeRefreshToken,
+		},
+	}
+
+	suite.mockGrantProvider.ExpectedCalls = nil
+	suite.mockGrantProvider.
+		On("GetGrantHandler", constants.GrantTypeAuthorizationCode).
+		Return(suite.mockGrantHandler, nil)
+
+	mockRefreshHandler := granthandlersmock.NewRefreshTokenGrantHandlerInterfaceMock(suite.T())
+	suite.mockGrantProvider.
+		On("GetGrantHandler", constants.GrantTypeRefreshToken).
+		Return(mockRefreshHandler, nil)
+
+	suite.mockGrantHandler.On("ValidateGrant", mock.Anything, mock.Anything, app).Return(nil)
+	suite.mockScopeValidator.On("ValidateScopes", mock.Anything, "openid", "test-client-id").Return("openid", nil)
+
+	tokenRespDTO := &model.TokenResponseDTO{
+		AccessToken: model.TokenDTO{
+			Token:             "access-token-123",
+			TokenType:         "Bearer",
+			ExpiresIn:         3600,
+			Scopes:            []string{"openid"},
+			Subject:           "user123",
+			Audiences:         []string{"narrowed-audience"},
+			OriginalAudiences: []string{"original-audience-1", "original-audience-2"},
+		},
+		RefreshToken: model.TokenDTO{Token: ""},
+		IDToken:      model.TokenDTO{Token: ""},
+	}
+	suite.mockGrantHandler.On("HandleGrant", mock.Anything, mock.Anything, app).Return(tokenRespDTO, nil)
+
+	mockRefreshHandler.
+		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123",
+			[]string{"original-audience-1", "original-audience-2"},
+			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "", "").
+		Return(nil)
+
+	svc := suite.newService()
+	tokenResp, errResp := svc.ProcessTokenRequest(context.Background(), req, app)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), tokenResp)
+	assert.Equal(suite.T(), "access-token-123", tokenResp.AccessToken)
 }

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -69,14 +69,13 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		UserAttributes:   userAttributes,
 		AttributeCacheID: ctx.AttributeCacheID,
 		Subject:          ctx.Subject,
-		Audience:         ctx.Audience,
+		Audiences:        ctx.Audiences,
 		ClaimsRequest:    ctx.ClaimsRequest,
 		ClaimsLocales:    ctx.ClaimsLocales,
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
 		ctx.Subject,
-		ctx.Audience,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
@@ -151,6 +150,12 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 		claims[constants.ClaimClaimsLocales] = ctx.ClaimsLocales
 	}
 
+	if len(ctx.Audiences) > 1 {
+		claims["aud"] = ctx.Audiences
+	} else if len(ctx.Audiences) == 1 {
+		claims["aud"] = ctx.Audiences[0]
+	}
+
 	return claims, nil
 }
 
@@ -223,13 +228,14 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 		Scopes:        ctx.Scopes,
 		ClientID:      ctx.ClientID,
 		Subject:       ctx.AccessTokenSubject,
-		Audience:      tokenConfig.Issuer,
+		Audiences:     []string{tokenConfig.Issuer},
 		ClaimsLocales: ctx.ClaimsLocales,
 	}
 
+	claims["aud"] = tokenConfig.Issuer
+
 	token, iat, err := tb.jwtService.GenerateJWT(
 		ctx.ClientID,
-		tokenConfig.Issuer,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		claims,
@@ -255,7 +261,7 @@ func (tb *tokenBuilder) buildRefreshTokenClaims(ctx *RefreshTokenBuildContext) (
 	}
 
 	claims["access_token_sub"] = ctx.AccessTokenSubject
-	claims["access_token_aud"] = ctx.AccessTokenAudience
+	claims["access_token_aud"] = ctx.AccessTokenAudiences
 	claims["grant_type"] = ctx.GrantType
 
 	if ctx.AttributeCacheID != "" {
@@ -296,12 +302,13 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 		Scopes:    ctx.Scopes,
 		ClientID:  ctx.Audience,
 		Subject:   ctx.Subject,
-		Audience:  ctx.Audience,
+		Audiences: []string{ctx.Audience},
 	}
+
+	jwtClaims["aud"] = ctx.Audience
 
 	token, iat, err := tb.jwtService.GenerateJWT(
 		ctx.Subject,
-		ctx.Audience,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -19,10 +19,11 @@
 package tokenservice
 
 import (
-	"github.com/asgardeo/thunder/internal/system/i18n/core"
-
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/asgardeo/thunder/internal/system/i18n/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -92,7 +93,7 @@ func (suite *TokenBuilderTestSuite) TestNewTokenBuilder() {
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read", "write"},
 		UserAttributes: map[string]interface{}{"name": testUserName},
@@ -105,7 +106,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -134,14 +134,14 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 	actorClaims := &SubjectTokenClaims{
 		Sub:            "actor123",
 		Iss:            "https://actor-issuer.com",
-		Aud:            "",
+		Aud:            nil,
 		UserAttributes: map[string]interface{}{},
 		NestedAct:      nil,
 	}
 
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -155,7 +155,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -175,7 +174,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 	nestedActorClaims := &SubjectTokenClaims{
 		Sub:            "nested-actor",
 		Iss:            "https://nested-issuer.com",
-		Aud:            "",
+		Aud:            nil,
 		UserAttributes: map[string]interface{}{},
 		NestedAct: map[string]interface{}{
 			"sub": "original-actor",
@@ -184,7 +183,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -198,7 +197,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -217,7 +215,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{},
 		UserAttributes: map[string]interface{}{},
@@ -230,7 +228,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -249,7 +246,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -262,7 +259,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -281,7 +277,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -294,7 +290,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType(
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -322,7 +317,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -335,7 +330,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io", // Thunder-level issuer always used
 		int64(7200),
 		mock.Anything, mock.Anything,
@@ -360,7 +354,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_NilContext() {
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFailed() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"read"},
 		UserAttributes: map[string]interface{}{},
@@ -370,7 +364,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.Anything, mock.Anything,
@@ -396,7 +389,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocales() {
 	ctx := &AccessTokenBuildContext{
 		Subject:        "user123",
-		Audience:       "app123",
+		Audiences:      []string{"app123"},
 		ClientID:       "test-client",
 		Scopes:         []string{"openid", "profile"},
 		UserAttributes: map[string]interface{}{"name": testUserName},
@@ -410,7 +403,6 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocal
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -444,13 +436,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read", "write"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    testCacheID,
-		OAuthApp:            oauthAppWithUserAttrs,
+		ClientID:             "test-client",
+		Scopes:               []string{"read", "write"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     testCacheID,
+		OAuthApp:             oauthAppWithUserAttrs,
 	}
 
 	expectedToken := testRefreshToken
@@ -459,12 +451,11 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
 		"https://thunder.io",
-		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["scope"] == "read write" &&
 				claims["access_token_sub"] == "user123" &&
-				claims["access_token_aud"] == testAppID &&
+				reflect.DeepEqual(claims["access_token_aud"], []string{testAppID}) &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["aci"] == testCacheID
 		}), mock.Anything,
@@ -479,19 +470,19 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	assert.Equal(suite.T(), int64(3600), result.ExpiresIn)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
 	assert.Equal(suite.T(), "test-client", result.ClientID)
-	assert.Equal(suite.T(), "https://thunder.io", result.Audience)
+	assert.Equal(suite.T(), []string{"https://thunder.io"}, result.Audiences)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAttributes() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    "",
-		OAuthApp:            suite.oauthApp,
+		ClientID:             "test-client",
+		Scopes:               []string{"read"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     "",
+		OAuthApp:             suite.oauthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -499,7 +490,6 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -517,13 +507,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthApp() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    testCacheID,
-		OAuthApp:            nil,
+		ClientID:             "test-client",
+		Scopes:               []string{"read"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     testCacheID,
+		OAuthApp:             nil,
 	}
 
 	expectedToken := testRefreshToken
@@ -531,7 +521,6 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -548,13 +537,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    "",
-		OAuthApp:            suite.oauthApp,
+		ClientID:             "test-client",
+		Scopes:               []string{},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     "",
+		OAuthApp:             suite.oauthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -562,7 +551,6 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -587,13 +575,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    "",
-		OAuthApp:            customOAuthApp,
+		ClientID:             "test-client",
+		Scopes:               []string{"read"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     "",
+		OAuthApp:             customOAuthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -601,7 +589,6 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.Anything, mock.Anything,
@@ -624,13 +611,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    testCacheID,
-		OAuthApp:            oauthAppWithNilAccessToken,
+		ClientID:             "test-client",
+		Scopes:               []string{"read"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     testCacheID,
+		OAuthApp:             oauthAppWithNilAccessToken,
 	}
 
 	expectedToken := testRefreshToken
@@ -638,7 +625,6 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -663,18 +649,17 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_NilContext() {
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFailed() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"read"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    "",
-		OAuthApp:            suite.oauthApp,
+		ClientID:             "test-client",
+		Scopes:               []string{"read"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     "",
+		OAuthApp:             suite.oauthApp,
 	}
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.Anything, mock.Anything,
@@ -699,14 +684,14 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLocales() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:            "test-client",
-		Scopes:              []string{"openid", "profile"},
-		GrantType:           string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:  "user123",
-		AccessTokenAudience: "app123",
-		AttributeCacheID:    "",
-		OAuthApp:            suite.oauthApp,
-		ClaimsLocales:       "en-US fr-CA ja",
+		ClientID:             "test-client",
+		Scopes:               []string{"openid", "profile"},
+		GrantType:            string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:   "user123",
+		AccessTokenAudiences: []string{"app123"},
+		AttributeCacheID:     "",
+		OAuthApp:             suite.oauthApp,
+		ClaimsLocales:        "en-US fr-CA ja",
 	}
 
 	expectedToken := testRefreshToken
@@ -715,12 +700,11 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLoca
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
 		"https://thunder.io",
-		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["scope"] == "openid profile" &&
 				claims["access_token_sub"] == "user123" &&
-				claims["access_token_aud"] == testAppID &&
+				reflect.DeepEqual(claims["access_token_aud"], []string{testAppID}) &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["access_token_claims_locales"] == "en-US fr-CA ja"
 		}), mock.Anything,
@@ -754,7 +738,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_Basic() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -792,7 +775,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithNonce() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -823,7 +805,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithoutNonce() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -854,7 +835,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoAuthTime() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -898,7 +878,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -938,7 +917,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithStandardOIDCSco
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -969,7 +947,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoUserAttributes() 
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -1008,7 +985,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_EmptyUserAttributes
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -1049,7 +1025,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(7200),
 		mock.Anything, mock.Anything,
@@ -1083,7 +1058,6 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_JWTGenerationFailed()
 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
-		"app123",
 		"https://thunder.io",
 		int64(3600),
 		mock.Anything, mock.Anything,

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -43,9 +43,11 @@ type TokenConfig struct {
 }
 
 // AccessTokenBuildContext contains all the information needed to build an access token.
+// The aud claim is serialized as a JSON array when Audiences has 2+ entries, and as a string
+// when it has a single entry.
 type AccessTokenBuildContext struct {
 	Subject          string
-	Audience         string
+	Audiences        []string
 	ClientID         string
 	Scopes           []string
 	UserAttributes   map[string]interface{}
@@ -60,15 +62,15 @@ type AccessTokenBuildContext struct {
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
 type RefreshTokenBuildContext struct {
-	ClientID            string
-	Scopes              []string
-	GrantType           string
-	AccessTokenSubject  string
-	AccessTokenAudience string
-	AttributeCacheID    string
-	OAuthApp            *appmodel.OAuthAppConfigProcessedDTO
-	ClaimsRequest       *oauth2model.ClaimsRequest
-	ClaimsLocales       string
+	ClientID             string
+	Scopes               []string
+	GrantType            string
+	AccessTokenSubject   string
+	AccessTokenAudiences []string
+	AttributeCacheID     string
+	OAuthApp             *appmodel.OAuthAppConfigProcessedDTO
+	ClaimsRequest        *oauth2model.ClaimsRequest
+	ClaimsLocales        string
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -86,7 +88,7 @@ type IDTokenBuildContext struct {
 // RefreshTokenClaims represents the validated claims from a refresh token.
 type RefreshTokenClaims struct {
 	Sub              string
-	Aud              string
+	Audiences        []string
 	GrantType        string
 	Scopes           []string
 	AttributeCacheID string
@@ -99,7 +101,7 @@ type RefreshTokenClaims struct {
 type SubjectTokenClaims struct {
 	Sub            string
 	Iss            string
-	Aud            string
+	Aud            []string
 	Scopes         []string
 	UserAttributes map[string]interface{}
 	NestedAct      map[string]interface{}
@@ -109,7 +111,7 @@ type SubjectTokenClaims struct {
 type AccessTokenClaims struct {
 	Sub       string
 	Iss       string
-	Aud       string
+	Aud       []string
 	GrantType string
 	Scopes    []string
 	ClientID  string

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -106,6 +106,39 @@ func extractStringClaim(claims map[string]interface{}, key string) (string, erro
 	return strValue, nil
 }
 
+// extractAudiences returns the JWT "aud" claim as a []string, accepting either
+// the RFC 7519 §4.1.3 string form or the array form. Returns an error when the
+// claim is missing, empty, or has an unsupported type.
+func extractAudiences(claims map[string]interface{}) ([]string, error) {
+	value, ok := claims["aud"]
+	if !ok {
+		return nil, fmt.Errorf("missing claim: aud")
+	}
+
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			return nil, fmt.Errorf("claim aud is empty")
+		}
+		return []string{v}, nil
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("claim aud is an empty array")
+		}
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok || s == "" {
+				return nil, fmt.Errorf("claim aud array contains a non-string or empty element")
+			}
+			result = append(result, s)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("claim aud has unsupported type")
+	}
+}
+
 // extractInt64Claim safely extracts an int64 claim from a claims map.
 func extractInt64Claim(claims map[string]interface{}, key string) (int64, error) {
 	value, ok := claims[key]
@@ -123,6 +156,36 @@ func extractInt64Claim(claims map[string]interface{}, key string) (int64, error)
 		return int64(v), nil
 	default:
 		return 0, fmt.Errorf("claim %s is not a number", key)
+	}
+}
+
+// extractStringSliceClaim extracts a claim that may be a string or a JSON array of strings.
+// Returns nil if the claim is missing or not a recognized type.
+func extractStringSliceClaim(claims map[string]interface{}, key string) []string {
+	value, ok := claims[key]
+	if !ok {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				result = append(result, s)
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	default:
+		return nil
 	}
 }
 
@@ -148,20 +211,6 @@ func extractScopesFromClaims(claims map[string]interface{}, isAuthAssertion bool
 	}
 
 	return []string{}
-}
-
-// DetermineAudience determines the audience for a token based on priority.
-func DetermineAudience(audience, resource, tokenAud, defaultAudience string) string {
-	if audience != "" {
-		return audience
-	}
-	if resource != "" {
-		return resource
-	}
-	if tokenAud != "" {
-		return tokenAud
-	}
-	return defaultAudience
 }
 
 // getStandardJWTClaims returns the standard JWT claims that should be excluded from user attributes.

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -41,11 +41,6 @@ type UtilsTestSuite struct {
 	suite.Suite
 }
 
-const (
-	testTokenAud        = "https://token-aud.example.com" //nolint:gosec // Test data, not a real credential
-	testDefaultAudience = "default-app"
-)
-
 func TestUtilsTestSuite(t *testing.T) {
 	suite.Run(t, new(UtilsTestSuite))
 }
@@ -291,65 +286,6 @@ func (suite *UtilsTestSuite) TestJoinScopes_WithEmptySlice() {
 func (suite *UtilsTestSuite) TestJoinScopes_WithNilSlice() {
 	scopes := []string(nil)
 	result := JoinScopes(scopes)
-
-	assert.Equal(suite.T(), "", result)
-}
-
-// ============================================================================
-// DetermineAudience Tests
-// ============================================================================
-
-func (suite *UtilsTestSuite) TestDetermineAudience_WithAudience() {
-	audience := "https://api.example.com"
-	resource := "https://other-api.com"
-	tokenAud := testTokenAud
-	defaultAudience := testDefaultAudience
-
-	result := DetermineAudience(audience, resource, tokenAud, defaultAudience)
-
-	assert.Equal(suite.T(), audience, result)
-}
-
-func (suite *UtilsTestSuite) TestDetermineAudience_WithResource() {
-	audience := ""
-	resource := "https://api.example.com"
-	tokenAud := testTokenAud
-	defaultAudience := testDefaultAudience
-
-	result := DetermineAudience(audience, resource, tokenAud, defaultAudience)
-
-	assert.Equal(suite.T(), resource, result)
-}
-
-func (suite *UtilsTestSuite) TestDetermineAudience_WithTokenAud() {
-	audience := ""
-	resource := ""
-	tokenAud := testTokenAud
-	defaultAudience := testDefaultAudience
-
-	result := DetermineAudience(audience, resource, tokenAud, defaultAudience)
-
-	assert.Equal(suite.T(), tokenAud, result)
-}
-
-func (suite *UtilsTestSuite) TestDetermineAudience_WithoutResource() {
-	audience := ""
-	resource := ""
-	tokenAud := ""
-	defaultAudience := testDefaultAudience
-
-	result := DetermineAudience(audience, resource, tokenAud, defaultAudience)
-
-	assert.Equal(suite.T(), defaultAudience, result)
-}
-
-func (suite *UtilsTestSuite) TestDetermineAudience_EmptyDefault() {
-	audience := ""
-	resource := ""
-	tokenAud := ""
-	defaultAudience := ""
-
-	result := DetermineAudience(audience, resource, tokenAud, defaultAudience)
 
 	assert.Equal(suite.T(), "", result)
 }
@@ -1140,4 +1076,78 @@ func (suite *UtilsTestSuite) TestBuildClientAttributes_NilOUService_ReturnsNil()
 	claims, err := BuildClientAttributes(context.Background(), app, nil)
 	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), claims)
+}
+
+// ============================================================================
+// §1 — extractAudiences direct unit tests
+// ============================================================================
+
+func (suite *UtilsTestSuite) TestExtractAudiences_StringValue() {
+	claims := map[string]interface{}{"aud": "x"}
+	auds, err := extractAudiences(claims)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"x"}, auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_StringSlice() {
+	claims := map[string]interface{}{"aud": []interface{}{"x", "y"}}
+	auds, err := extractAudiences(claims)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"x", "y"}, auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_SingleElementSlice() {
+	claims := map[string]interface{}{"aud": []interface{}{"x"}}
+	auds, err := extractAudiences(claims)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"x"}, auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_EmptyString_ReturnsError() {
+	claims := map[string]interface{}{"aud": ""}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_EmptySlice_ReturnsError() {
+	claims := map[string]interface{}{"aud": []interface{}{}}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_NilValue_ReturnsError() {
+	claims := map[string]interface{}{"aud": nil}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_MissingKey_ReturnsError() {
+	claims := map[string]interface{}{}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_WrongType_ReturnsError() {
+	claims := map[string]interface{}{"aud": 123}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_MixedSliceNonString_ReturnsError() {
+	claims := map[string]interface{}{"aud": []interface{}{"x", 42}}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
+}
+
+func (suite *UtilsTestSuite) TestExtractAudiences_SliceWithEmptyString_ReturnsError() {
+	claims := map[string]interface{}{"aud": []interface{}{"x", ""}}
+	auds, err := extractAudiences(claims)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), auds)
 }

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -20,6 +20,7 @@ package tokenservice
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -83,7 +84,7 @@ func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims,
 	if issErr != nil {
 		return nil, fmt.Errorf("missing required 'iss' claim in access token")
 	}
-	aud, audErr := extractStringClaim(claims, "aud")
+	auds, audErr := extractAudiences(claims)
 	if audErr != nil {
 		return nil, fmt.Errorf("missing required 'aud' claim in access token")
 	}
@@ -98,7 +99,7 @@ func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims,
 	return &AccessTokenClaims{
 		Sub:       sub,
 		Iss:       iss,
-		Aud:       aud,
+		Aud:       auds,
 		GrantType: grantType,
 		Scopes:    scopes,
 		ClientID:  clientID,
@@ -123,7 +124,7 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 
 	// Extract claims
 	sub, _ := extractStringClaim(claims, "access_token_sub")
-	aud, _ := extractStringClaim(claims, "access_token_aud")
+	audiences := extractStringSliceClaim(claims, "access_token_aud")
 	grantType, _ := extractStringClaim(claims, "grant_type")
 	iat, _ := extractInt64Claim(claims, "iat")
 	scopes := extractScopesFromClaims(claims, false)
@@ -146,7 +147,7 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 	// Extract user type and organizational unit details if present
 	return &RefreshTokenClaims{
 		Sub:              sub,
-		Aud:              aud,
+		Audiences:        audiences,
 		GrantType:        grantType,
 		Scopes:           scopes,
 		AttributeCacheID: attributeCacheID,
@@ -193,22 +194,29 @@ func (tv *tokenValidator) ValidateSubjectToken(
 	isAuthAssertion := tv.isAuthAssertion(claims)
 
 	// Extract and validate audience claim
-	var aud string
+	var auds []string
 	if isAuthAssertion {
-		// For auth assertions, audience is required and must match config default or requesting client's app_id
-		aud, err = extractStringClaim(claims, "aud")
+		// For auth assertions, audience is required, must be a single value, and must match
+		// config default or requesting client's app_id. Multi-aud auth assertions are rejected
+		// as a defense-in-depth measure (auth assertions are a narrow control surface).
+		auds, err = extractAudiences(claims)
 		if err != nil {
 			return nil, fmt.Errorf("auth assertion is missing 'aud' claim: %w", err)
+		}
+		if len(auds) > 1 {
+			return nil, fmt.Errorf("auth assertion must have a single audience")
 		}
 
 		defaultAudience := config.GetThunderRuntime().Config.JWT.Audience
 		clientAppID := oauthApp.AppID
 
-		if aud != defaultAudience && aud != clientAppID {
+		if !slices.Contains([]string{defaultAudience, clientAppID}, auds[0]) {
 			return nil, fmt.Errorf("auth assertion audience mismatch")
 		}
 	} else {
-		aud, _ = extractStringClaim(claims, "aud")
+		// Non-assertion subject tokens tolerate missing/malformed aud; downstream code treats
+		// nil/empty Aud as "no declared audience". Auth assertions remain strict (above).
+		auds, _ = extractAudiences(claims)
 	}
 
 	// Extract scopes
@@ -226,7 +234,7 @@ func (tv *tokenValidator) ValidateSubjectToken(
 	return &SubjectTokenClaims{
 		Sub:            sub,
 		Iss:            iss,
-		Aud:            aud,
+		Aud:            auds,
 		Scopes:         scopes,
 		UserAttributes: userAttributes,
 		NestedAct:      nestedAct,
@@ -292,8 +300,8 @@ func (tv *tokenValidator) validateOAuth2RefreshClaims(claims map[string]interfac
 		return fmt.Errorf("missing or invalid 'access_token_sub' claim: %w", err)
 	}
 
-	if _, err := extractStringClaim(claims, "access_token_aud"); err != nil {
-		return fmt.Errorf("missing or invalid 'access_token_aud' claim: %w", err)
+	if auds := extractStringSliceClaim(claims, "access_token_aud"); len(auds) == 0 {
+		return fmt.Errorf("missing or invalid 'access_token_aud' claim")
 	}
 
 	if _, err := extractStringClaim(claims, "grant_type"); err != nil {

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -608,6 +608,87 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_EdgeCase_VeryLong
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+// ============================================================================
+// §1 — Auth-assertion multi-aud rejection test
+// ============================================================================
+
+func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_AuthAssertion_RejectsMultiAud() {
+	// Auth assertions with more than one audience element must be rejected (defense-in-depth;
+	// auth assertions are a narrow control surface).
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub":       "user123",
+		"iss":       "https://thunder.io",
+		"aud":       []interface{}{"a", "b"},
+		"exp":       float64(now + 3600),
+		"assurance": "high", // marks this as an auth assertion
+	}
+	token := suite.createTestJWT(claims)
+
+	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "auth assertion must have a single audience")
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// ============================================================================
+// §1 — Non-assertion multi-aud tests
+// ============================================================================
+
+func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_AcceptsMultiAud() {
+	// Non-assertion subject tokens with a multi-value aud are accepted when at least one element
+	// matches the requesting app's AppID or the configured default audience.
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://thunder.io",
+		"aud": []interface{}{"x", "y"},
+		"exp": float64(now + 3600),
+	}
+	token := suite.createTestJWT(claims)
+
+	oauthAppWithID := &appmodel.OAuthAppConfigProcessedDTO{
+		ClientID: "test-client",
+		AppID:    "x", // Matches one element of the aud array.
+	}
+
+	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(token, oauthAppWithID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"x", "y"}, result.Aud)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_ToleratesMalformedAud() {
+	// Non-assertion subject tokens with a malformed aud (wrong type) do NOT return an error;
+	// Aud is set to nil/empty for legacy tolerance. Downstream code treats nil Aud as
+	// "no declared audience".
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://thunder.io",
+		"aud": 123, // numeric — wrong type, silently ignored
+		"exp": float64(now + 3600),
+	}
+	token := suite.createTestJWT(claims)
+
+	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Empty(suite.T(), result.Aud)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
 func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
 	now := time.Now().Unix()
 	claims := map[string]interface{}{
@@ -631,7 +712,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
-	assert.Equal(suite.T(), testAppID, result.Aud)
+	assert.Equal(suite.T(), []string{testAppID}, result.Audiences)
 	assert.Equal(suite.T(), "authorization_code", result.GrantType)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
 	assert.Equal(suite.T(), "test-cache-id", result.AttributeCacheID)
@@ -1003,7 +1084,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithClaim
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
-	assert.Equal(suite.T(), testAppID, result.Aud)
+	assert.Equal(suite.T(), []string{testAppID}, result.Audiences)
 	assert.Equal(suite.T(), "authorization_code", result.GrantType)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
 	assert.Equal(suite.T(), "test-cache-id", result.AttributeCacheID)
@@ -1040,7 +1121,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithAppI
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
 	assert.Equal(suite.T(), "https://thunder.io", result.Iss)
-	assert.Equal(suite.T(), testAppID, result.Aud)
+	assert.Equal(suite.T(), []string{testAppID}, result.Aud)
 	assert.Equal(suite.T(), []string{"read:documents", "write:documents"}, result.Scopes)
 	assert.Equal(suite.T(), "person", result.UserAttributes["userType"])
 	suite.mockJWTService.AssertExpectations(suite.T())
@@ -1208,7 +1289,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithDefa
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
 	assert.Equal(suite.T(), "https://thunder.io", result.Iss)
-	assert.Equal(suite.T(), defaultAudience, result.Aud)
+	assert.Equal(suite.T(), []string{defaultAudience}, result.Aud)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
@@ -1401,7 +1482,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidAud
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "claim aud is not a string")
+	assert.Contains(suite.T(), err.Error(), "claim aud has unsupported type")
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
@@ -1654,7 +1735,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Success() {
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
 	assert.Equal(suite.T(), "https://thunder.io", result.Iss)
-	assert.Equal(suite.T(), "test-app", result.Aud)
+	assert.Equal(suite.T(), []string{"test-app"}, result.Aud)
 	assert.Equal(suite.T(), "test-client", result.ClientID)
 	assert.Equal(suite.T(), "authorization_code", result.GrantType)
 	assert.Equal(suite.T(), []string{"openid", "profile"}, result.Scopes)
@@ -1680,7 +1761,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Success_MinClaims(
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user123", result.Sub)
 	assert.Equal(suite.T(), "https://thunder.io", result.Iss)
-	assert.Equal(suite.T(), "test-app", result.Aud)
+	assert.Equal(suite.T(), []string{"test-app"}, result.Aud)
 	assert.Equal(suite.T(), "test-client", result.ClientID)
 	assert.Empty(suite.T(), result.GrantType)
 	assert.Empty(suite.T(), result.Scopes)

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -162,9 +162,10 @@ func (s *userInfoService) generateJWSUserInfo(
 	issuer := runtime.Config.JWT.Issuer
 	validity := runtime.Config.JWT.ValidityPeriod
 
+	response["aud"] = clientID
+
 	signedJWT, _, err := s.jwtService.GenerateJWT(
 		sub,
-		clientID,
 		issuer,
 		validity,
 		response,

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -1100,7 +1100,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 	s.mockJWTService.On(
 		"GenerateJWT",
 		"user123",
-		"client123",
 		issuer,
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
 		mock.Anything,
@@ -1159,7 +1158,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 	s.mockJWTService.On(
 		"GenerateJWT",
 		"user123",
-		"client123",
 		issuer,
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
 		mock.Anything,

--- a/backend/internal/resource/ResourceServiceInterface_mock_test.go
+++ b/backend/internal/resource/ResourceServiceInterface_mock_test.go
@@ -461,6 +461,76 @@ func (_c *ResourceServiceInterfaceMock_DeleteResourceServer_Call) RunAndReturn(r
 	return _c
 }
 
+// FindResourceServersByPermissions provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) FindResourceServersByPermissions(ctx context.Context, permissions []string) ([]ResourceServer, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, permissions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindResourceServersByPermissions")
+	}
+
+	var r0 []ResourceServer
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]ResourceServer, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, permissions)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []ResourceServer); ok {
+		r0 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindResourceServersByPermissions'
+type ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call struct {
+	*mock.Call
+}
+
+// FindResourceServersByPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - permissions []string
+func (_e *ResourceServiceInterfaceMock_Expecter) FindResourceServersByPermissions(ctx interface{}, permissions interface{}) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	return &ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call{Call: _e.mock.On("FindResourceServersByPermissions", ctx, permissions)}
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) Run(run func(ctx context.Context, permissions []string)) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) Return(resourceServers []ResourceServer, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(resourceServers, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) RunAndReturn(run func(ctx context.Context, permissions []string) ([]ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAction provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) GetAction(ctx context.Context, resourceServerID string, resourceID *string, id string) (*Action, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, resourceID, id)
@@ -861,6 +931,76 @@ func (_c *ResourceServiceInterfaceMock_GetResourceServer_Call) Return(resourceSe
 }
 
 func (_c *ResourceServiceInterfaceMock_GetResourceServer_Call) RunAndReturn(run func(ctx context.Context, id string) (*ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceServerByIdentifier provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) GetResourceServerByIdentifier(ctx context.Context, identifier string) (*ResourceServer, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, identifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceServerByIdentifier")
+	}
+
+	var r0 *ResourceServer
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*ResourceServer, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, identifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *ResourceServer); ok {
+		r0 = returnFunc(ctx, identifier)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, identifier)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceServerByIdentifier'
+type ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call struct {
+	*mock.Call
+}
+
+// GetResourceServerByIdentifier is a helper method to define mock.On call
+//   - ctx context.Context
+//   - identifier string
+func (_e *ResourceServiceInterfaceMock_Expecter) GetResourceServerByIdentifier(ctx interface{}, identifier interface{}) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	return &ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call{Call: _e.mock.On("GetResourceServerByIdentifier", ctx, identifier)}
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) Run(run func(ctx context.Context, identifier string)) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) Return(resourceServer *ResourceServer, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(resourceServer, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) RunAndReturn(run func(ctx context.Context, identifier string) (*ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/resource/composite_store.go
+++ b/backend/internal/resource/composite_store.go
@@ -164,12 +164,42 @@ func (c *compositeResourceStore) CheckResourceServerNameExists(ctx context.Conte
 	)
 }
 
+func (c *compositeResourceStore) CheckResourceServerHandleExists(
+	ctx context.Context, handle string) (bool, error) {
+	return declarativeresource.CompositeBooleanCheckHelper(
+		func() (bool, error) { return c.fileStore.CheckResourceServerHandleExists(ctx, handle) },
+		func() (bool, error) { return c.dbStore.CheckResourceServerHandleExists(ctx, handle) },
+	)
+}
+
 func (c *compositeResourceStore) CheckResourceServerIdentifierExists(
 	ctx context.Context, identifier string) (bool, error) {
 	return declarativeresource.CompositeBooleanCheckHelper(
 		func() (bool, error) { return c.fileStore.CheckResourceServerIdentifierExists(ctx, identifier) },
 		func() (bool, error) { return c.dbStore.CheckResourceServerIdentifierExists(ctx, identifier) },
 	)
+}
+
+func (c *compositeResourceStore) GetResourceServerByIdentifier(
+	ctx context.Context, identifier string) (ResourceServer, error) {
+	server, err := declarativeresource.CompositeGetHelper(
+		func() (ResourceServer, error) {
+			s, err := c.dbStore.GetResourceServerByIdentifier(ctx, identifier)
+			if err == nil {
+				s.IsReadOnly = false
+			}
+			return s, err
+		},
+		func() (ResourceServer, error) {
+			s, err := c.fileStore.GetResourceServerByIdentifier(ctx, identifier)
+			if err == nil {
+				s.IsReadOnly = true
+			}
+			return s, err
+		},
+		errResourceServerNotFound,
+	)
+	return server, err
 }
 
 func (c *compositeResourceStore) CheckResourceServerHasDependencies(
@@ -275,6 +305,11 @@ func (c *compositeResourceStore) GetResourceListCountByParent(
 func (c *compositeResourceStore) UpdateResource(
 	ctx context.Context, id string, resServerID string, res Resource) error {
 	return c.dbStore.UpdateResource(ctx, id, resServerID, res)
+}
+
+func (c *compositeResourceStore) UpdateResourcePermission(
+	ctx context.Context, id string, resServerID string, permission string) error {
+	return c.dbStore.UpdateResourcePermission(ctx, id, resServerID, permission)
 }
 
 func (c *compositeResourceStore) DeleteResource(
@@ -465,6 +500,11 @@ func (c *compositeResourceStore) UpdateAction(
 	return c.dbStore.UpdateAction(ctx, id, resServerID, resID, action)
 }
 
+func (c *compositeResourceStore) UpdateActionPermission(
+	ctx context.Context, id string, resServerID string, resID *string, permission string) error {
+	return c.dbStore.UpdateActionPermission(ctx, id, resServerID, resID, permission)
+}
+
 func (c *compositeResourceStore) DeleteAction(
 	ctx context.Context, id string, resServerID string, resID *string) error {
 	return c.dbStore.DeleteAction(ctx, id, resServerID, resID)
@@ -521,6 +561,26 @@ func (c *compositeResourceStore) ValidatePermissions(
 	}
 
 	return result, nil
+}
+
+func (c *compositeResourceStore) FindResourceServersByPermissions(
+	ctx context.Context, permissions []string,
+) ([]ResourceServer, error) {
+	if len(permissions) == 0 {
+		return []ResourceServer{}, nil
+	}
+
+	dbServers, err := c.dbStore.FindResourceServersByPermissions(ctx, permissions)
+	if err != nil {
+		return nil, err
+	}
+
+	fileServers, err := c.fileStore.FindResourceServersByPermissions(ctx, permissions)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeAndDeduplicateResourceServers(dbServers, fileServers), nil
 }
 
 func mergeAndDeduplicateResourceServers(dbServers, fileServers []ResourceServer) []ResourceServer {

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -309,7 +309,7 @@ func processResourceServer(rs *ResourceServer) error {
 
 	// Process resources and compute permissions
 	for i := range rs.Resources {
-		if err := processResource(&rs.Resources[i], resourceHandleMap, delimiter); err != nil {
+		if err := processResource(&rs.Resources[i], resourceHandleMap, rs.Handle, delimiter); err != nil {
 			return err
 		}
 	}
@@ -321,16 +321,15 @@ func processResourceServer(rs *ResourceServer) error {
 func processResource(
 	res *Resource,
 	resourceHandleMap map[string]*Resource,
+	rsHandle string,
 	delimiter string,
 ) error {
-	// Build permission string from parent chain
-	permission, err := buildPermissionString(res, resourceHandleMap, delimiter)
+	permission, err := buildPermissionString(res, resourceHandleMap, rsHandle, delimiter)
 	if err != nil {
 		return err
 	}
 	res.Permission = permission
 
-	// Process actions
 	for i := range res.Actions {
 		actionPermission := permission + delimiter + res.Actions[i].Handle
 		res.Actions[i].Permission = actionPermission
@@ -340,19 +339,30 @@ func processResource(
 }
 
 // buildPermissionString constructs the permission string by traversing parent chain.
-// Returns an error if a parent handle is not found in the resourceHandleMap.
 func buildPermissionString(
 	res *Resource,
 	resourceHandleMap map[string]*Resource,
+	rsHandle string,
 	delimiter string,
 ) (string, error) {
 	var parts []string
 
-	// Build parent chain
+	if rsHandle != "" {
+		parts = append(parts, rsHandle)
+	}
+
 	parentChain := []string{}
+	visited := make(map[string]bool)
 	current := res
 	for current != nil {
 		if current.Handle != "" {
+			if visited[current.Handle] {
+				return "", fmt.Errorf(
+					"circular parent reference detected at handle '%s' for resource '%s'",
+					current.Handle, res.Handle,
+				)
+			}
+			visited[current.Handle] = true
 			parentChain = append([]string{current.Handle}, parentChain...)
 		}
 
@@ -362,7 +372,6 @@ func buildPermissionString(
 
 		parent, exists := resourceHandleMap[current.ParentHandle]
 		if !exists {
-			// Surface the missing parent handle error instead of silently breaking
 			return "", fmt.Errorf(
 				"parent resource handle '%s' not found for resource '%s': cannot resolve permission chain",
 				current.ParentHandle,
@@ -372,12 +381,10 @@ func buildPermissionString(
 		current = parent
 	}
 
-	// Add parent chain (excluding current resource)
 	if len(parentChain) > 1 {
 		parts = append(parts, parentChain[:len(parentChain)-1]...)
 	}
 
-	// Add current resource handle
 	parts = append(parts, res.Handle)
 
 	return strings.Join(parts, delimiter), nil

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -312,50 +312,47 @@ func TestBuildPermissionString(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		resource         *Resource
-		serverIdentifier string
-		delimiter        string
-		expected         string
+		name      string
+		resource  *Resource
+		handler   string
+		delimiter string
+		expected  string
 	}{
 		{
-			name: "root resource with identifier",
+			name: "root resource with handler",
 			resource: &Resource{
 				Handle:       "users",
-				Parent:       nil,
 				ParentHandle: "",
 			},
-			serverIdentifier: "api",
-			delimiter:        ":",
-			expected:         "users",
+			handler:   "booking-api",
+			delimiter: ":",
+			expected:  "booking-api:users",
 		},
 		{
-			name: "nested resource with identifier",
+			name: "nested resource with handler",
 			resource: &Resource{
 				Handle:       "profile",
-				Parent:       nil,
 				ParentHandle: "users",
 			},
-			serverIdentifier: "api",
-			delimiter:        ":",
-			expected:         "users:profile",
+			handler:   "booking-api",
+			delimiter: ":",
+			expected:  "booking-api:users:profile",
 		},
 		{
-			name: "root resource without identifier",
+			name: "root resource without handler",
 			resource: &Resource{
 				Handle:       "users",
-				Parent:       nil,
 				ParentHandle: "",
 			},
-			serverIdentifier: "",
-			delimiter:        ":",
-			expected:         "users",
+			handler:   "",
+			delimiter: ":",
+			expected:  "users",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := buildPermissionString(tt.resource, resourceHandleMap, tt.delimiter)
+			result, err := buildPermissionString(tt.resource, resourceHandleMap, tt.handler, tt.delimiter)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -366,6 +363,7 @@ func TestProcessResourceServer_SetsPermissionsAndDelimiter(t *testing.T) {
 	rs := &ResourceServer{
 		ID:         "rs1",
 		Name:       "Test Server",
+		Handle:     "test-api",
 		OUID:       "ou1",
 		Identifier: "api",
 		Resources: []Resource{
@@ -388,16 +386,48 @@ func TestProcessResourceServer_SetsPermissionsAndDelimiter(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, ":", rs.Delimiter)
-	assert.Equal(t, "users", rs.Resources[0].Permission)
-	assert.Equal(t, "users:read", rs.Resources[0].Actions[0].Permission)
-	assert.Equal(t, "users:profile", rs.Resources[1].Permission)
+	assert.Equal(t, "test-api:users", rs.Resources[0].Permission)
+	assert.Equal(t, "test-api:users:read", rs.Resources[0].Actions[0].Permission)
+	assert.Equal(t, "test-api:users:profile", rs.Resources[1].Permission)
+}
+
+func TestProcessResourceServer_WithHandlePrefixesPermissions(t *testing.T) {
+	rs := &ResourceServer{
+		ID:     "rs1",
+		Name:   "Test Server",
+		OUID:   "ou1",
+		Handle: "booking-api",
+		Resources: []Resource{
+			{
+				Name:   "Users",
+				Handle: "users",
+				Actions: []Action{
+					{Name: "Read", Handle: "read"},
+				},
+			},
+			{
+				Name:         "Profile",
+				Handle:       "profile",
+				ParentHandle: "users",
+			},
+		},
+	}
+
+	err := processResourceServer(rs)
+
+	assert.NoError(t, err)
+	assert.Equal(t, ":", rs.Delimiter)
+	assert.Equal(t, "booking-api:users", rs.Resources[0].Permission)
+	assert.Equal(t, "booking-api:users:read", rs.Resources[0].Actions[0].Permission)
+	assert.Equal(t, "booking-api:users:profile", rs.Resources[1].Permission)
 }
 
 func TestProcessResourceServer_DuplicateHandle(t *testing.T) {
 	rs := &ResourceServer{
-		ID:   "rs1",
-		Name: "Test Server",
-		OUID: "ou1",
+		ID:     "rs1",
+		Name:   "Test Server",
+		Handle: "dup-test",
+		OUID:   "ou1",
 		Resources: []Resource{
 			{Name: "Users", Handle: "users"},
 			{Name: "Users Duplicate", Handle: "users"},
@@ -424,7 +454,7 @@ func TestProcessResource_SetsPermissions(t *testing.T) {
 		"child": resource,
 	}
 
-	err := processResource(resource, resourceHandleMap, ":")
+	err := processResource(resource, resourceHandleMap, "", ":")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "root:child", resource.Permission)
@@ -435,7 +465,7 @@ func TestProcessResource_MissingParent(t *testing.T) {
 	resource := &Resource{Handle: "child", ParentHandle: "missing"}
 	resourceHandleMap := map[string]*Resource{}
 
-	err := processResource(resource, resourceHandleMap, ":")
+	err := processResource(resource, resourceHandleMap, "", ":")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parent resource handle")
@@ -445,6 +475,7 @@ func TestParseAndValidateResourceServerWrapper_Success(t *testing.T) {
 	yamlData := []byte(`
 id: "rs1"
 name: "Test Server"
+handle: "test-api"
 identifier: "api"
 ou_id: "ou1"
 resources:
@@ -464,9 +495,9 @@ resources:
 	assert.NoError(t, err)
 	rs, ok := result.(*ResourceServer)
 	assert.True(t, ok)
-	assert.Equal(t, "users", rs.Resources[0].Permission)
-	assert.Equal(t, "users:read", rs.Resources[0].Actions[0].Permission)
-	assert.Equal(t, "users:profile", rs.Resources[1].Permission)
+	assert.Equal(t, "test-api:users", rs.Resources[0].Permission)
+	assert.Equal(t, "test-api:users:read", rs.Resources[0].Actions[0].Permission)
+	assert.Equal(t, "test-api:users:profile", rs.Resources[1].Permission)
 }
 
 func TestParseAndValidateResourceServerWrapper_InvalidYAML(t *testing.T) {

--- a/backend/internal/resource/error_constants.go
+++ b/backend/internal/resource/error_constants.go
@@ -301,6 +301,19 @@ var (
 			DefaultValue: "The total number of records exceeds the maximum limit in composite mode",
 		},
 	}
+	// ErrorDelimiterInResourceServerHandle is returned when the resource server handle contains the delimiter.
+	ErrorDelimiterInResourceServerHandle = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "RES-1022",
+		Error: core.I18nMessage{
+			Key:          "error.resourceservice.delimiter_conflict_in_resource_server_handle",
+			DefaultValue: "Delimiter conflict in handle",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.resourceservice.delimiter_conflict_in_resource_server_handle_description",
+			DefaultValue: "Resource server handle cannot contain the delimiter character",
+		},
+	}
 )
 
 // Internal error constants.

--- a/backend/internal/resource/file_based_store.go
+++ b/backend/internal/resource/file_based_store.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
@@ -132,6 +133,17 @@ func (f *fileBasedResourceStore) CheckResourceServerNameExists(ctx context.Conte
 	return true, nil
 }
 
+func (f *fileBasedResourceStore) CheckResourceServerHandleExists(
+	ctx context.Context, handle string) (bool, error) {
+	_, err := f.GenericFileBasedStore.GetByField(handle, func(d interface{}) string {
+		return d.(*ResourceServer).Handle
+	})
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (f *fileBasedResourceStore) CheckResourceServerIdentifierExists(
 	ctx context.Context, identifier string) (bool, error) {
 	_, err := f.GenericFileBasedStore.GetByField(identifier, func(d interface{}) string {
@@ -141,6 +153,23 @@ func (f *fileBasedResourceStore) CheckResourceServerIdentifierExists(
 		return false, nil
 	}
 	return true, nil
+}
+
+func (f *fileBasedResourceStore) GetResourceServerByIdentifier(
+	ctx context.Context, identifier string) (ResourceServer, error) {
+	data, err := f.GenericFileBasedStore.GetByField(identifier, func(d interface{}) string {
+		return d.(*ResourceServer).Identifier
+	})
+	if err != nil {
+		return ResourceServer{}, errResourceServerNotFound
+	}
+
+	rs, ok := data.(*ResourceServer)
+	if !ok {
+		return ResourceServer{}, errors.New("data corrupted")
+	}
+
+	return *rs, nil
 }
 
 func (f *fileBasedResourceStore) CheckResourceServerHasDependencies(
@@ -359,6 +388,11 @@ func (f *fileBasedResourceStore) UpdateResource(
 	return errImmutableStore
 }
 
+func (f *fileBasedResourceStore) UpdateResourcePermission(
+	ctx context.Context, id string, resServerID string, permission string) error {
+	return errImmutableStore
+}
+
 func (f *fileBasedResourceStore) DeleteResource(ctx context.Context, id string, resServerID string) error {
 	return errImmutableStore
 }
@@ -491,6 +525,11 @@ func (f *fileBasedResourceStore) UpdateAction(
 	return errImmutableStore
 }
 
+func (f *fileBasedResourceStore) UpdateActionPermission(
+	ctx context.Context, id string, resServerID string, resID *string, permission string) error {
+	return errImmutableStore
+}
+
 func (f *fileBasedResourceStore) DeleteAction(
 	ctx context.Context, id string, resServerID string, resID *string) error {
 	return errImmutableStore
@@ -580,4 +619,52 @@ func (f *fileBasedResourceStore) ValidatePermissions(
 		}
 	}
 	return invalidList, nil
+}
+
+func (f *fileBasedResourceStore) FindResourceServersByPermissions(
+	ctx context.Context, permissions []string,
+) ([]ResourceServer, error) {
+	if len(permissions) == 0 {
+		return []ResourceServer{}, nil
+	}
+
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	permSet := make(map[string]struct{}, len(permissions))
+	for _, p := range permissions {
+		permSet[p] = struct{}{}
+	}
+
+	matched := make([]ResourceServer, 0)
+	for _, item := range list {
+		rs, ok := item.Data.(*ResourceServer)
+		if !ok || rs.Identifier == "" {
+			continue
+		}
+		if containsAnyPermission(rs, permSet) {
+			matched = append(matched, *rs)
+		}
+	}
+
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].Identifier < matched[j].Identifier
+	})
+	return matched, nil
+}
+
+func containsAnyPermission(rs *ResourceServer, permSet map[string]struct{}) bool {
+	for _, res := range rs.Resources {
+		if _, ok := permSet[res.Permission]; ok {
+			return true
+		}
+		for _, action := range res.Actions {
+			if _, ok := permSet[action.Permission]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/resource/handler.go
+++ b/backend/internal/resource/handler.go
@@ -75,6 +75,7 @@ func (h *resourceHandler) HandleResourceServerPostRequest(w http.ResponseWriter,
 	serviceReq := ResourceServer{
 		Name:        sanitized.Name,
 		Description: sanitized.Description,
+		Handle:      sanitized.Handle,
 		Identifier:  sanitized.Identifier,
 		OUID:        sanitized.OUID,
 		Delimiter:   sanitized.Delimiter,
@@ -118,6 +119,7 @@ func (h *resourceHandler) HandleResourceServerPutRequest(w http.ResponseWriter, 
 	serviceReq := ResourceServer{
 		Name:        sanitized.Name,
 		Description: sanitized.Description,
+		Handle:      sanitized.Handle,
 		Identifier:  sanitized.Identifier,
 		OUID:        sanitized.OUID,
 	}
@@ -543,6 +545,7 @@ func sanitizeCreateResourceServerRequest(req *CreateResourceServerRequest) Creat
 	return CreateResourceServerRequest{
 		Name:        sysutils.SanitizeString(req.Name),
 		Description: sysutils.SanitizeString(req.Description),
+		Handle:      sysutils.SanitizeString(req.Handle),
 		Identifier:  sysutils.SanitizeString(req.Identifier),
 		OUID:        sysutils.SanitizeString(req.OUID),
 		Delimiter:   sysutils.SanitizeString(req.Delimiter),
@@ -554,6 +557,7 @@ func sanitizeUpdateResourceServerRequest(req *UpdateResourceServerRequest) Updat
 	return UpdateResourceServerRequest{
 		Name:        sysutils.SanitizeString(req.Name),
 		Description: sysutils.SanitizeString(req.Description),
+		Handle:      sysutils.SanitizeString(req.Handle),
 		Identifier:  sysutils.SanitizeString(req.Identifier),
 		OUID:        sysutils.SanitizeString(req.OUID),
 	}
@@ -609,6 +613,7 @@ func toResourceServerResponse(rs *ResourceServer) *ResourceServerResponse {
 		ID:          rs.ID,
 		Name:        rs.Name,
 		Description: rs.Description,
+		Handle:      rs.Handle,
 		Identifier:  rs.Identifier,
 		OUID:        rs.OUID,
 		Delimiter:   rs.Delimiter,

--- a/backend/internal/resource/model.go
+++ b/backend/internal/resource/model.go
@@ -25,6 +25,7 @@ type ResourceServerResponse struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Handle      string `json:"handle"`
 	Identifier  string `json:"identifier,omitempty"`
 	OUID        string `json:"ouId"`
 	Delimiter   string `json:"delimiter"`
@@ -87,6 +88,7 @@ type ActionListResponse struct {
 type CreateResourceServerRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Handle      string `json:"handle,omitempty"`
 	Identifier  string `json:"identifier,omitempty"`
 	OUID        string `json:"ouId"`
 	Delimiter   string `json:"delimiter,omitempty"`
@@ -96,6 +98,7 @@ type CreateResourceServerRequest struct {
 type UpdateResourceServerRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Handle      string `json:"handle,omitempty"`
 	Identifier  string `json:"identifier,omitempty"`
 	OUID        string `json:"ouId"`
 }
@@ -192,6 +195,7 @@ type ResourceServer struct {
 	ID          string     `yaml:"id" json:"-"`
 	Name        string     `yaml:"name" json:"name"`
 	Description string     `yaml:"description,omitempty" json:"description,omitempty"`
+	Handle      string     `yaml:"handle" json:"handle"`
 	Identifier  string     `yaml:"identifier,omitempty" json:"identifier,omitempty"`
 	OUID        string     `yaml:"ou_id" json:"ouId"`
 	Delimiter   string     `yaml:"delimiter,omitempty" json:"delimiter,omitempty"`

--- a/backend/internal/resource/resourceStoreInterface_mock_test.go
+++ b/backend/internal/resource/resourceStoreInterface_mock_test.go
@@ -331,6 +331,72 @@ func (_c *resourceStoreInterfaceMock_CheckResourceHasDependencies_Call) RunAndRe
 	return _c
 }
 
+// CheckResourceServerHandleExists provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) CheckResourceServerHandleExists(ctx context.Context, handle string) (bool, error) {
+	ret := _mock.Called(ctx, handle)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckResourceServerHandleExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, handle)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, handle)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, handle)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckResourceServerHandleExists'
+type resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call struct {
+	*mock.Call
+}
+
+// CheckResourceServerHandleExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+func (_e *resourceStoreInterfaceMock_Expecter) CheckResourceServerHandleExists(ctx interface{}, handle interface{}) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	return &resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call{Call: _e.mock.On("CheckResourceServerHandleExists", ctx, handle)}
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) Run(run func(ctx context.Context, handle string)) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) Return(b bool, err error) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) RunAndReturn(run func(ctx context.Context, handle string) (bool, error)) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckResourceServerHasDependencies provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) CheckResourceServerHasDependencies(ctx context.Context, resServerID string) (bool, error) {
 	ret := _mock.Called(ctx, resServerID)
@@ -927,6 +993,74 @@ func (_c *resourceStoreInterfaceMock_DeleteResourceServer_Call) Return(err error
 }
 
 func (_c *resourceStoreInterfaceMock_DeleteResourceServer_Call) RunAndReturn(run func(ctx context.Context, id string) error) *resourceStoreInterfaceMock_DeleteResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindResourceServersByPermissions provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) FindResourceServersByPermissions(ctx context.Context, permissions []string) ([]ResourceServer, error) {
+	ret := _mock.Called(ctx, permissions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindResourceServersByPermissions")
+	}
+
+	var r0 []ResourceServer
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]ResourceServer, error)); ok {
+		return returnFunc(ctx, permissions)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []ResourceServer); ok {
+		r0 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, permissions)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_FindResourceServersByPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindResourceServersByPermissions'
+type resourceStoreInterfaceMock_FindResourceServersByPermissions_Call struct {
+	*mock.Call
+}
+
+// FindResourceServersByPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - permissions []string
+func (_e *resourceStoreInterfaceMock_Expecter) FindResourceServersByPermissions(ctx interface{}, permissions interface{}) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	return &resourceStoreInterfaceMock_FindResourceServersByPermissions_Call{Call: _e.mock.On("FindResourceServersByPermissions", ctx, permissions)}
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) Run(run func(ctx context.Context, permissions []string)) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) Return(resourceServers []ResourceServer, err error) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(resourceServers, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) RunAndReturn(run func(ctx context.Context, permissions []string) ([]ResourceServer, error)) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1609,6 +1743,72 @@ func (_c *resourceStoreInterfaceMock_GetResourceServer_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetResourceServerByIdentifier provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) GetResourceServerByIdentifier(ctx context.Context, identifier string) (ResourceServer, error) {
+	ret := _mock.Called(ctx, identifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceServerByIdentifier")
+	}
+
+	var r0 ResourceServer
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (ResourceServer, error)); ok {
+		return returnFunc(ctx, identifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ResourceServer); ok {
+		r0 = returnFunc(ctx, identifier)
+	} else {
+		r0 = ret.Get(0).(ResourceServer)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, identifier)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceServerByIdentifier'
+type resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call struct {
+	*mock.Call
+}
+
+// GetResourceServerByIdentifier is a helper method to define mock.On call
+//   - ctx context.Context
+//   - identifier string
+func (_e *resourceStoreInterfaceMock_Expecter) GetResourceServerByIdentifier(ctx interface{}, identifier interface{}) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	return &resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call{Call: _e.mock.On("GetResourceServerByIdentifier", ctx, identifier)}
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) Run(run func(ctx context.Context, identifier string)) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) Return(resourceServer ResourceServer, err error) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(resourceServer, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) RunAndReturn(run func(ctx context.Context, identifier string) (ResourceServer, error)) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetResourceServerList provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) GetResourceServerList(ctx context.Context, limit int, offset int) ([]ResourceServer, error) {
 	ret := _mock.Called(ctx, limit, offset)
@@ -1947,6 +2147,81 @@ func (_c *resourceStoreInterfaceMock_UpdateAction_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// UpdateActionPermission provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) UpdateActionPermission(ctx context.Context, id string, resServerID string, resID *string, permission string) error {
+	ret := _mock.Called(ctx, id, resServerID, resID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateActionPermission")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *string, string) error); ok {
+		r0 = returnFunc(ctx, id, resServerID, resID, permission)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// resourceStoreInterfaceMock_UpdateActionPermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateActionPermission'
+type resourceStoreInterfaceMock_UpdateActionPermission_Call struct {
+	*mock.Call
+}
+
+// UpdateActionPermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - resServerID string
+//   - resID *string
+//   - permission string
+func (_e *resourceStoreInterfaceMock_Expecter) UpdateActionPermission(ctx interface{}, id interface{}, resServerID interface{}, resID interface{}, permission interface{}) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	return &resourceStoreInterfaceMock_UpdateActionPermission_Call{Call: _e.mock.On("UpdateActionPermission", ctx, id, resServerID, resID, permission)}
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) Run(run func(ctx context.Context, id string, resServerID string, resID *string, permission string)) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 *string
+		if args[3] != nil {
+			arg3 = args[3].(*string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) Return(err error) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, resID *string, permission string) error) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateResource provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) UpdateResource(ctx context.Context, id string, resServerID string, res Resource) error {
 	ret := _mock.Called(ctx, id, resServerID, res)
@@ -2012,6 +2287,75 @@ func (_c *resourceStoreInterfaceMock_UpdateResource_Call) Return(err error) *res
 }
 
 func (_c *resourceStoreInterfaceMock_UpdateResource_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, res Resource) error) *resourceStoreInterfaceMock_UpdateResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateResourcePermission provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) UpdateResourcePermission(ctx context.Context, id string, resServerID string, permission string) error {
+	ret := _mock.Called(ctx, id, resServerID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateResourcePermission")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, id, resServerID, permission)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// resourceStoreInterfaceMock_UpdateResourcePermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateResourcePermission'
+type resourceStoreInterfaceMock_UpdateResourcePermission_Call struct {
+	*mock.Call
+}
+
+// UpdateResourcePermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - resServerID string
+//   - permission string
+func (_e *resourceStoreInterfaceMock_Expecter) UpdateResourcePermission(ctx interface{}, id interface{}, resServerID interface{}, permission interface{}) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	return &resourceStoreInterfaceMock_UpdateResourcePermission_Call{Call: _e.mock.On("UpdateResourcePermission", ctx, id, resServerID, permission)}
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) Run(run func(ctx context.Context, id string, resServerID string, permission string)) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) Return(err error) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, permission string) error) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -58,6 +58,9 @@ type ResourceServiceInterface interface {
 		ctx context.Context, id string, rs ResourceServer,
 	) (*ResourceServer, *serviceerror.ServiceError)
 	DeleteResourceServer(ctx context.Context, id string) *serviceerror.ServiceError
+	GetResourceServerByIdentifier(
+		ctx context.Context, identifier string,
+	) (*ResourceServer, *serviceerror.ServiceError)
 	IsResourceServerDeclarative(id string) bool
 
 	// Resource operations
@@ -90,6 +93,13 @@ type ResourceServiceInterface interface {
 	ValidatePermissions(
 		ctx context.Context, resourceServerID string, permissions []string,
 	) ([]string, *serviceerror.ServiceError)
+
+	// FindResourceServersByPermissions returns registered resource servers that define at least
+	// one permission in the supplied set. Used by the OAuth2 token layer to populate aud when no
+	// explicit resource parameter was supplied.
+	FindResourceServersByPermissions(
+		ctx context.Context, permissions []string,
+	) ([]ResourceServer, *serviceerror.ServiceError)
 }
 
 // resourceService is the default implementation of ResourceServiceInterface.
@@ -157,6 +167,20 @@ func (rs *resourceService) CreateResourceServer(
 		return nil, &ErrorNameConflict
 	}
 
+	// Check handle uniqueness (if provided)
+	if resourceServer.Handle != "" {
+		handleExists, err := rs.resourceStore.CheckResourceServerHandleExists(ctx, resourceServer.Handle)
+		if err != nil {
+			rs.logger.Error("Failed to check resource server handle", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+		if handleExists {
+			rs.logger.Debug("Resource server handle already exists",
+				log.String("handle", resourceServer.Handle))
+			return nil, &ErrorHandleConflict
+		}
+	}
+
 	// Check identifier uniqueness (if provided)
 	if resourceServer.Identifier != "" {
 		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
@@ -170,9 +194,20 @@ func (rs *resourceService) CreateResourceServer(
 			return nil, &ErrorIdentifierConflict
 		}
 	}
+
 	// Set default delimiter if not provided
 	if resourceServer.Delimiter == "" {
 		resourceServer.Delimiter = rs.defaultDelimiter
+	}
+
+	// Validate handle format and ensure it does not contain the delimiter character
+	if resourceServer.Handle != "" {
+		if svcErr := validateHandle(resourceServer.Handle, resourceServer.Delimiter); svcErr != nil {
+			if svcErr.Code == ErrorDelimiterInHandle.Code {
+				return nil, &ErrorDelimiterInResourceServerHandle
+			}
+			return nil, svcErr
+		}
 	}
 
 	id, err := utils.GenerateUUIDv7()
@@ -193,6 +228,7 @@ func (rs *resourceService) CreateResourceServer(
 			ID:          id,
 			Name:        resourceServer.Name,
 			Description: resourceServer.Description,
+			Handle:      resourceServer.Handle,
 			Identifier:  resourceServer.Identifier,
 			OUID:        resourceServer.OUID,
 			Delimiter:   resourceServer.Delimiter,
@@ -221,6 +257,28 @@ func (rs *resourceService) GetResourceServer(
 			return nil, &ErrorResourceServerNotFound
 		}
 		rs.logger.Error("Failed to get resource server", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	return &resourceServer, nil
+}
+
+// GetResourceServerByIdentifier retrieves a resource server by its identifier.
+func (rs *resourceService) GetResourceServerByIdentifier(
+	ctx context.Context, identifier string,
+) (*ResourceServer, *serviceerror.ServiceError) {
+	if identifier == "" {
+		return nil, &ErrorResourceServerNotFound
+	}
+
+	resourceServer, err := rs.resourceStore.GetResourceServerByIdentifier(ctx, identifier)
+	if err != nil {
+		if errors.Is(err, errResourceServerNotFound) {
+			rs.logger.Debug("Resource server not found for identifier",
+				log.String("identifier", identifier))
+			return nil, &ErrorResourceServerNotFound
+		}
+		rs.logger.Error("Failed to get resource server by identifier", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -296,8 +354,46 @@ func (rs *resourceService) UpdateResourceServer(
 		})
 	}
 
-	// Preserve the immutable delimiter from existing record
+	// Delimiter is always preserved from the existing record
 	resourceServer.Delimiter = existingResServer.Delimiter
+
+	// Handle: preserve existing if not provided; validate and check uniqueness if changed
+	if resourceServer.Handle == "" {
+		resourceServer.Handle = existingResServer.Handle
+	} else if resourceServer.Handle != existingResServer.Handle {
+		if svcErr := validateHandle(resourceServer.Handle, resourceServer.Delimiter); svcErr != nil {
+			if svcErr.Code == ErrorDelimiterInHandle.Code {
+				return nil, &ErrorDelimiterInResourceServerHandle
+			}
+			return nil, svcErr
+		}
+		handleExists, err := rs.resourceStore.CheckResourceServerHandleExists(ctx, resourceServer.Handle)
+		if err != nil {
+			rs.logger.Error("Failed to check resource server handle", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+		if handleExists {
+			rs.logger.Debug("Resource server handle already exists",
+				log.String("handle", resourceServer.Handle))
+			return nil, &ErrorHandleConflict
+		}
+	}
+
+	// Identifier: preserve existing if not provided; check uniqueness if changed
+	if resourceServer.Identifier == "" {
+		resourceServer.Identifier = existingResServer.Identifier
+	} else if resourceServer.Identifier != existingResServer.Identifier {
+		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
+		if err != nil {
+			rs.logger.Error("Failed to check resource server identifier", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+		if identifierExists {
+			rs.logger.Debug("Resource server identifier already exists",
+				log.String("identifier", resourceServer.Identifier))
+			return nil, &ErrorIdentifierConflict
+		}
+	}
 
 	// Validate organization unit
 	_, svcErr := rs.ouService.GetOrganizationUnit(ctx, resourceServer.OUID)
@@ -320,18 +416,11 @@ func (rs *resourceService) UpdateResourceServer(
 		}
 	}
 
-	// Check identifier uniqueness, if provided and changed
-	if resourceServer.Identifier != "" && existingResServer.Identifier != resourceServer.Identifier {
-		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
-		if err != nil {
-			rs.logger.Error("Failed to check resource server identifier", log.Error(err))
-			return nil, &serviceerror.InternalServerError
-		}
-		if identifierExists {
-			rs.logger.Debug("Resource server identifier already exists",
-				log.String("identifier", resourceServer.Identifier))
-			return nil, &ErrorIdentifierConflict
-		}
+	// When handle changes, collect all resources and actions for permission recomputation
+	handleChanged := existingResServer.Handle != resourceServer.Handle
+	permData, svcErr2 := rs.collectPermissionData(ctx, id, handleChanged)
+	if svcErr2 != nil {
+		return nil, svcErr2
 	}
 
 	var updatedRS *ResourceServer
@@ -341,10 +430,17 @@ func (rs *resourceService) UpdateResourceServer(
 			return err
 		}
 
+		if handleChanged {
+			if err := rs.recomputePermissions(txCtx, id, resourceServer, permData); err != nil {
+				return err
+			}
+		}
+
 		updatedRS = &ResourceServer{
 			ID:          id,
 			Name:        resourceServer.Name,
 			Description: resourceServer.Description,
+			Handle:      resourceServer.Handle,
 			Identifier:  resourceServer.Identifier,
 			OUID:        resourceServer.OUID,
 			Delimiter:   resourceServer.Delimiter,
@@ -355,6 +451,110 @@ func (rs *resourceService) UpdateResourceServer(
 	}
 
 	return updatedRS, nil
+}
+
+// permissionData holds the resources and actions collected for permission recomputation.
+type permissionData struct {
+	resources       []Resource
+	rsLevelActions  []Action
+	resourceActions []struct {
+		resourceID string
+		actions    []Action
+	}
+}
+
+// collectPermissionData fetches all resources and actions under a resource server when the handle changes.
+// Returns a zero-value permissionData (no store calls) when handleChanged is false.
+func (rs *resourceService) collectPermissionData(
+	ctx context.Context, rsID string, handleChanged bool,
+) (*permissionData, *serviceerror.ServiceError) {
+	if !handleChanged {
+		return &permissionData{}, nil
+	}
+
+	pd := &permissionData{}
+	var err error
+
+	pd.resources, err = rs.resourceStore.GetResourceList(ctx, rsID, serverconst.MaxPageSize, 0)
+	if err != nil {
+		rs.logger.Error("Failed to list resources for permission recomputation", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	pd.rsLevelActions, err = rs.resourceStore.GetActionList(ctx, rsID, nil, serverconst.MaxPageSize, 0)
+	if err != nil {
+		rs.logger.Error("Failed to list RS-level actions for permission recomputation", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	for i := range pd.resources {
+		actions, err := rs.resourceStore.GetActionList(
+			ctx, rsID, &pd.resources[i].ID, serverconst.MaxPageSize, 0,
+		)
+		if err != nil {
+			rs.logger.Error("Failed to list resource actions for permission recomputation", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+		if len(actions) > 0 {
+			pd.resourceActions = append(pd.resourceActions, struct {
+				resourceID string
+				actions    []Action
+			}{resourceID: pd.resources[i].ID, actions: actions})
+		}
+	}
+
+	return pd, nil
+}
+
+// recomputePermissions updates the stored permission strings for all resources and actions
+// under a resource server whose handle has changed. Must be called inside a transaction.
+func (rs *resourceService) recomputePermissions(
+	ctx context.Context, rsID string, resourceServer ResourceServer, pd *permissionData,
+) error {
+	permByID := make(map[string]string, len(pd.resources))
+
+	for i := range pd.resources {
+		res := &pd.resources[i]
+		var parentRes *Resource
+		if res.Parent != nil {
+			if parentPerm, ok := permByID[*res.Parent]; ok {
+				parentRes = &Resource{Permission: parentPerm}
+			}
+		}
+		newPerm := derivePermission(resourceServer, parentRes, res.Handle)
+		permByID[res.ID] = newPerm
+		if err := rs.resourceStore.UpdateResourcePermission(ctx, res.ID, rsID, newPerm); err != nil {
+			rs.logger.Error("Failed to update resource permission", log.Error(err))
+			return err
+		}
+	}
+
+	for i := range pd.rsLevelActions {
+		newPerm := derivePermission(resourceServer, nil, pd.rsLevelActions[i].Handle)
+		if err := rs.resourceStore.UpdateActionPermission(
+			ctx, pd.rsLevelActions[i].ID, rsID, nil, newPerm,
+		); err != nil {
+			rs.logger.Error("Failed to update RS-level action permission", log.Error(err))
+			return err
+		}
+	}
+
+	for _, ra := range pd.resourceActions {
+		parentPerm := permByID[ra.resourceID]
+		parentRes := &Resource{Permission: parentPerm}
+		for i := range ra.actions {
+			newPerm := derivePermission(resourceServer, parentRes, ra.actions[i].Handle)
+			resID := ra.resourceID
+			if err := rs.resourceStore.UpdateActionPermission(
+				ctx, ra.actions[i].ID, rsID, &resID, newPerm,
+			); err != nil {
+				rs.logger.Error("Failed to update resource action permission", log.Error(err))
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // DeleteResourceServer deletes a resource server.
@@ -911,11 +1111,6 @@ func (rs *resourceService) UpdateAction(
 	if rs.IsResourceServerDeclarative(resourceServerID) {
 		return nil, &ErrorImmutableAction
 	}
-
-	// Check if resource server is declarative (immutable)
-	if rs.IsResourceServerDeclarative(resourceServerID) {
-		return nil, &ErrorImmutableAction
-	}
 	// Validate resource server exists
 	_, svcErr := rs.validateAndGetResourceServer(ctx, resourceServerID)
 	if svcErr != nil {
@@ -1086,6 +1281,24 @@ func (rs *resourceService) ValidatePermissions(
 	}
 
 	return invalidPermissions, nil
+}
+
+// FindResourceServersByPermissions returns registered resource servers that define at least one
+// permission in the supplied set.
+func (rs *resourceService) FindResourceServersByPermissions(
+	ctx context.Context,
+	permissions []string,
+) ([]ResourceServer, *serviceerror.ServiceError) {
+	if len(permissions) == 0 {
+		return []ResourceServer{}, nil
+	}
+
+	resourceServers, err := rs.resourceStore.FindResourceServersByPermissions(ctx, permissions)
+	if err != nil {
+		rs.logger.Error("Failed to find resource servers by permissions", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	return resourceServers, nil
 }
 
 // Validation helper methods
@@ -1280,8 +1493,10 @@ func derivePermission(
 	handle string,
 ) string {
 	if parentResource != nil {
-		// Build permission: parent_permission + delimiter + handle
 		return parentResource.Permission + resourceServer.Delimiter + handle
 	}
-	return handle // Top-level resource - permission is just the handle
+	if resourceServer.Handle != "" {
+		return resourceServer.Handle + resourceServer.Delimiter + handle
+	}
+	return handle
 }

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -51,6 +51,7 @@ func matchResourceServer(expected ResourceServer) interface{} {
 	return mock.MatchedBy(func(actual ResourceServer) bool {
 		return actual.Name == expected.Name &&
 			actual.Description == expected.Description &&
+			actual.Handle == expected.Handle &&
 			actual.Identifier == expected.Identifier &&
 			actual.OUID == expected.OUID &&
 			actual.Delimiter != "" // Delimiter should be set
@@ -170,6 +171,7 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_Success() {
 	rs := ResourceServer{
 		Name:        "test-rs",
 		Description: "Test resource server",
+		Handle:      "test-handle",
 		Identifier:  "test-identifier",
 		OUID:        "ou-123",
 	}
@@ -178,6 +180,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_Success() {
 		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
 		"test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"test-handle").
 		Return(false, nil)
 	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
 		"test-identifier").
@@ -193,6 +198,7 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_Success() {
 	suite.NotEmpty(result.ID)
 	suite.Equal("test-rs", result.Name)
 	suite.Equal("Test resource server", result.Description)
+	suite.Equal("test-handle", result.Handle)
 	suite.mockStore.AssertExpectations(suite.T())
 	suite.mockOU.AssertExpectations(suite.T())
 }
@@ -205,17 +211,17 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_ValidationErrors
 	}{
 		{
 			name:           "EmptyName",
-			resourceServer: ResourceServer{Name: "", OUID: "ou-123"},
+			resourceServer: ResourceServer{Name: "", Handle: "test-handle", OUID: "ou-123"},
 			expectedError:  ErrorInvalidRequestFormat,
 		},
 		{
 			name:           "EmptyOU",
-			resourceServer: ResourceServer{Name: "test-rs", OUID: ""},
+			resourceServer: ResourceServer{Name: "test-rs", Handle: "test-handle", OUID: ""},
 			expectedError:  ErrorInvalidRequestFormat,
 		},
 		{
 			name:           "InvalidDelimiter",
-			resourceServer: ResourceServer{Name: "test-rs", Delimiter: "::", OUID: "ou-123"},
+			resourceServer: ResourceServer{Name: "test-rs", Handle: "test-handle", Delimiter: "::", OUID: "ou-123"},
 			expectedError:  ErrorInvalidDelimiter,
 		},
 	}
@@ -233,8 +239,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_ValidationErrors
 
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_OUNotFound() {
 	rs := ResourceServer{
-		Name: "test-rs",
-		OUID: "ou-123",
+		Name:   "test-rs",
+		Handle: "test-handle",
+		OUID:   "ou-123",
 	}
 
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
@@ -250,8 +257,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_OUNotFound() {
 
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_OUServiceError() {
 	rs := ResourceServer{
-		Name: "test-rs",
-		OUID: "ou-123",
+		Name:   "test-rs",
+		Handle: "test-handle",
+		OUID:   "ou-123",
 	}
 
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
@@ -266,8 +274,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_OUServiceError()
 
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_NameConflict() {
 	rs := ResourceServer{
-		Name: "test-rs",
-		OUID: "ou-123",
+		Name:   "test-rs",
+		Handle: "test-handle",
+		OUID:   "ou-123",
 	}
 
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
@@ -286,6 +295,7 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_NameConflict() {
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_StoreError() {
 	rs := ResourceServer{
 		Name:       "test-rs",
+		Handle:     "test-handle",
 		OUID:       "ou-123",
 		Identifier: "", // Empty identifier - no need to check
 	}
@@ -295,7 +305,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_StoreError() {
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
 		"test-rs").
 		Return(false, nil)
-	// No identifier check needed since identifier is empty
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"test-handle").
+		Return(false, nil)
 	suite.mockStore.On("CreateResourceServer", mock.Anything,
 		mock.AnythingOfType("string"), matchResourceServer(rs)).
 		Return(errors.New("database error"))
@@ -310,6 +322,7 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_StoreError() {
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_IdentifierConflict() {
 	rs := ResourceServer{
 		Name:       "test-rs",
+		Handle:     "test-handle",
 		Identifier: "test-identifier",
 		OUID:       "ou-123",
 	}
@@ -318,6 +331,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_IdentifierConfli
 		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
 		"test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"test-handle").
 		Return(false, nil)
 	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
 		"test-identifier").
@@ -332,8 +348,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_IdentifierConfli
 
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckNameError() {
 	rs := ResourceServer{
-		Name: "test-rs",
-		OUID: "ou-123",
+		Name:   "test-rs",
+		Handle: "test-handle",
+		OUID:   "ou-123",
 	}
 
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
@@ -352,6 +369,7 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckNameError()
 func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckIdentifierError() {
 	rs := ResourceServer{
 		Name:       "test-rs",
+		Handle:     "test-handle",
 		Identifier: "test-identifier",
 		OUID:       "ou-123",
 	}
@@ -360,6 +378,9 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckIdentifierE
 		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
 		"test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"test-handle").
 		Return(false, nil)
 	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
 		"test-identifier").
@@ -370,6 +391,53 @@ func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckIdentifierE
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateResourceServer_DelimiterInHandle() {
+	rs := ResourceServer{
+		Name:      "test-rs",
+		Handle:    "foo:bar",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
+		"test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"foo:bar").
+		Return(false, nil)
+
+	result, err := suite.service.CreateResourceServer(context.Background(), rs)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorDelimiterInResourceServerHandle.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateResourceServer_DelimiterInRSHandleDefaultDelimiter() {
+	rs := ResourceServer{
+		Name:   "test-rs",
+		Handle: "foo:bar",
+		OUID:   "ou-123",
+	}
+
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
+		"test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"foo:bar").
+		Return(false, nil)
+
+	result, err := suite.service.CreateResourceServer(context.Background(), rs)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorDelimiterInResourceServerHandle.Code, err.Code)
 }
 
 func (suite *ResourceServiceTestSuite) TestGetResourceServer_Success() {
@@ -447,6 +515,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_Success() {
 	rs := ResourceServer{
 		Name:        "updated-rs",
 		Description: "Updated",
+		Handle:      "new-handle",
+		Identifier:  "new-identifier",
 		OUID:        "ou-123",
 	}
 
@@ -454,7 +524,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_Success() {
 		ID:          "rs-123",
 		Name:        "old-name",
 		Description: "Old",
-		Identifier:  "identifier",
+		Handle:      "original-handler",
+		Identifier:  "original-identifier",
 		OUID:        "ou-123",
 		Delimiter:   ":",
 	}
@@ -462,14 +533,25 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_Success() {
 	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
 	suite.mockStore.On("GetResourceServer", mock.Anything,
 		"rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything,
+		"new-handle").Return(false, nil)
+	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
+		"new-identifier").Return(false, nil)
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
 		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything,
 		"updated-rs").
 		Return(false, nil)
+	suite.mockStore.On("GetResourceList", mock.Anything,
+		"rs-123", mock.Anything, mock.Anything).Return([]Resource{}, nil)
+	suite.mockStore.On("GetActionList", mock.Anything,
+		"rs-123", (*string)(nil), mock.Anything, mock.Anything).Return([]Action{}, nil)
 	suite.mockStore.On("UpdateResourceServer", mock.Anything,
 		"rs-123", mock.MatchedBy(func(r ResourceServer) bool {
-			return r.Name == rs.Name && r.Identifier == rs.Identifier && r.Description == rs.Description &&
+			return r.Name == rs.Name &&
+				r.Handle == "new-handle" &&
+				r.Identifier == "new-identifier" &&
+				r.Description == rs.Description &&
 				r.Delimiter == existingRS.Delimiter
 		})).Return(nil)
 
@@ -479,6 +561,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_Success() {
 	suite.NotNil(result)
 	suite.Equal("rs-123", result.ID)
 	suite.Equal("updated-rs", result.Name)
+	suite.Equal("new-handle", result.Handle)
+	suite.Equal("new-identifier", result.Identifier)
 }
 
 func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_NotFound() {
@@ -611,66 +695,6 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_NameConflict() {
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorNameConflict.Code, err.Code)
-}
-
-func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_IdentifierConflict() {
-	rs := ResourceServer{
-		Name:       "test-rs",
-		Identifier: "test-identifier",
-		OUID:       "ou-123",
-	}
-
-	existingRS := ResourceServer{
-		ID:         "rs-123",
-		Name:       "test-rs",
-		Identifier: "old-identifier",
-		OUID:       "ou-123",
-	}
-
-	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
-	suite.mockStore.On("GetResourceServer", mock.Anything,
-		"rs-123").Return(existingRS, nil)
-	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
-		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
-	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
-		"test-identifier").
-		Return(true, nil)
-
-	result, err := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
-
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(ErrorIdentifierConflict.Code, err.Code)
-}
-
-func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_CheckIdentifierError() {
-	rs := ResourceServer{
-		Name:       "test-rs",
-		Identifier: "test-identifier",
-		OUID:       "ou-123",
-	}
-
-	existingRS := ResourceServer{
-		ID:         "rs-123",
-		Name:       "test-rs",
-		Identifier: "old-identifier",
-		OUID:       "ou-123",
-	}
-
-	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
-	suite.mockStore.On("GetResourceServer", mock.Anything,
-		"rs-123").Return(existingRS, nil)
-	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
-		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
-	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
-		"test-identifier").
-		Return(false, errors.New("database error"))
-
-	result, err := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
-
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
 func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_StoreError() {
@@ -3991,46 +4015,53 @@ func (suite *ResourceServiceTestSuite) TestDerivePermission() {
 		expectedPermission string
 	}{
 		{
-			name:               "TopLevelResource",
-			resourceServer:     ResourceServer{Identifier: "myapp"},
+			name:               "TopLevelResourceNoHandle",
+			resourceServer:     ResourceServer{Delimiter: ":"},
 			parent:             nil,
 			handle:             "users",
 			expectedPermission: "users",
 		},
 		{
+			name:               "TopLevelResourceWithHandle",
+			resourceServer:     ResourceServer{Handle: "booking-api", Delimiter: ":"},
+			parent:             nil,
+			handle:             "users",
+			expectedPermission: "booking-api:users",
+		},
+		{
 			name:               "ChildResourceWithColon",
-			resourceServer:     ResourceServer{Identifier: "myapp", Delimiter: ":"},
+			resourceServer:     ResourceServer{Delimiter: ":"},
 			parent:             &Resource{Permission: "users"},
 			handle:             "read",
 			expectedPermission: "users:read",
 		},
 		{
+			name:               "ChildResourceWithHandleInheritsPrefix",
+			resourceServer:     ResourceServer{Handle: "booking-api", Delimiter: ":"},
+			parent:             &Resource{Permission: "booking-api:users"},
+			handle:             "read",
+			expectedPermission: "booking-api:users:read",
+		},
+		{
 			name:               "DeeplyNestedWithSlash",
-			resourceServer:     ResourceServer{Identifier: "myapp", Delimiter: "/"},
+			resourceServer:     ResourceServer{Delimiter: "/"},
 			parent:             &Resource{Permission: "api/v1/users"},
 			handle:             "read",
 			expectedPermission: "api/v1/users/read",
 		},
 		{
 			name:               "DotDelimiter",
-			resourceServer:     ResourceServer{Identifier: "webapp", Delimiter: "."},
+			resourceServer:     ResourceServer{Delimiter: "."},
 			parent:             &Resource{Permission: "admin.panel"},
 			handle:             "delete",
 			expectedPermission: "admin.panel.delete",
 		},
 		{
-			name:               "PipeDelimiter",
-			resourceServer:     ResourceServer{Identifier: "test", Delimiter: "|"},
-			parent:             &Resource{Permission: "resource|list"},
-			handle:             "export",
-			expectedPermission: "resource|list|export",
-		},
-		{
-			name:               "HashDelimiter",
-			resourceServer:     ResourceServer{Identifier: "test", Delimiter: "#"},
-			parent:             &Resource{Permission: "app#module"},
-			handle:             "execute",
-			expectedPermission: "app#module#execute",
+			name:               "HandleWithDotDelimiter",
+			resourceServer:     ResourceServer{Handle: "webapp", Delimiter: "."},
+			parent:             nil,
+			handle:             "admin",
+			expectedPermission: "webapp.admin",
 		},
 	}
 
@@ -4366,44 +4397,42 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_ImmutableDeclara
 }
 
 func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_MutableResource() {
-	// Test that updating a non-declarative resource server succeeds
 	resourceServerID := "mutable-rs"
 	updateReq := ResourceServer{
-		ID:         resourceServerID,
-		Name:       "Updated Name",
-		OUID:       "ou-1",
-		Identifier: "updated-identifier",
+		ID:   resourceServerID,
+		Name: "Updated Name",
+		OUID: "ou-1",
+		// Handle and Identifier omitted — should be preserved from existing
 	}
 
 	existingRS := ResourceServer{
 		ID:         resourceServerID,
 		Name:       "Original Name",
 		OUID:       "ou-1",
+		Handle:     "original-handler",
 		Identifier: "original-identifier",
+		Delimiter:  ":",
 	}
 
-	// Mock IsResourceServerDeclarative to return false
 	suite.mockStore.On("IsResourceServerDeclarative", resourceServerID).Return(false)
-
-	// Mock the necessary store calls
 	suite.mockStore.On("GetResourceServer", mock.Anything, resourceServerID).
 		Return(existingRS, nil)
 	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-1").
 		Return(oupkg.OrganizationUnit{ID: "ou-1"}, nil)
 	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, "Updated Name").
 		Return(false, nil)
-	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything, "updated-identifier").
-		Return(false, nil)
-	suite.mockStore.On("UpdateResourceServer", mock.Anything, resourceServerID, mock.Anything).
-		Return(nil)
+	suite.mockStore.On("UpdateResourceServer", mock.Anything, resourceServerID,
+		mock.MatchedBy(func(r ResourceServer) bool {
+			return r.Handle == existingRS.Handle && r.Identifier == existingRS.Identifier
+		})).Return(nil)
 
-	// Execute the test
 	result, svcErr := suite.service.UpdateResourceServer(context.Background(), resourceServerID, updateReq)
 
-	// Assert success
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("Updated Name", result.Name)
+	suite.Equal("original-handler", result.Handle)
+	suite.Equal("original-identifier", result.Identifier)
 
 	suite.mockStore.AssertExpectations(suite.T())
 	suite.mockOU.AssertExpectations(suite.T())
@@ -4534,5 +4563,284 @@ func (suite *ResourceServiceTestSuite) TestDeleteAction_ImmutableDeclarativeReso
 	suite.Equal("RES-1020", svcErr.Code)
 	suite.Equal(ErrorImmutableAction.Code, svcErr.Code)
 
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+// UpdateResourceServer handle/identifier mutability tests
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleChangedPreservesExistingWhenOmitted() {
+	rs := ResourceServer{
+		Name: "updated-rs",
+		OUID: "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "old-name",
+		Handle:    "existing-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, "updated-rs").Return(false, nil)
+	suite.mockStore.On("UpdateResourceServer", mock.Anything, "rs-123",
+		mock.MatchedBy(func(r ResourceServer) bool {
+			return r.Handle == "existing-handle"
+		})).Return(nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(svcErr)
+	suite.NotNil(result)
+	suite.Equal("existing-handle", result.Handle)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleChanged_PermissionsRecomputed() {
+	rs := ResourceServer{
+		Name:   "my-rs",
+		Handle: "new-handle",
+		OUID:   "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "my-rs",
+		Handle:    "old-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	resID := "res-001"
+	actionID := "act-001"
+	rsActionID := "rsact-001"
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything, "new-handle").Return(false, nil)
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("GetResourceList", mock.Anything, "rs-123", mock.Anything, mock.Anything).
+		Return([]Resource{{ID: resID, Name: "res", Handle: "res", Permission: "old-handle:res"}}, nil)
+	suite.mockStore.On("GetActionList", mock.Anything, "rs-123", (*string)(nil), mock.Anything, mock.Anything).
+		Return([]Action{{ID: rsActionID, Name: "rs-action", Handle: "rs-act", Permission: "old-handle:rs-act"}}, nil)
+	suite.mockStore.On("GetActionList", mock.Anything, "rs-123", &resID, mock.Anything, mock.Anything).
+		Return([]Action{{ID: actionID, Name: "act", Handle: "do", Permission: "old-handle:res:do"}}, nil)
+	suite.mockStore.On("UpdateResourceServer", mock.Anything, "rs-123", mock.Anything).Return(nil)
+	suite.mockStore.On("UpdateResourcePermission", mock.Anything, resID, "rs-123", "new-handle:res").Return(nil)
+	suite.mockStore.On("UpdateActionPermission", mock.Anything, rsActionID, "rs-123", (*string)(nil),
+		"new-handle:rs-act").Return(nil)
+	suite.mockStore.On("UpdateActionPermission", mock.Anything, actionID, "rs-123", &resID,
+		"new-handle:res:do").Return(nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(svcErr)
+	suite.NotNil(result)
+	suite.Equal("new-handle", result.Handle)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleConflict() {
+	rs := ResourceServer{
+		Name:   "updated-rs",
+		Handle: "taken-handle",
+		OUID:   "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "old-name",
+		Handle:    "original-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything, "taken-handle").Return(true, nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorHandleConflict.Code, svcErr.Code)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleInvalidFormat() {
+	rs := ResourceServer{
+		Name:   "updated-rs",
+		Handle: "invalid handle!", // space and ! are not valid
+		OUID:   "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "old-name",
+		Handle:    "original-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidHandle.Code, svcErr.Code)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleContainsDelimiter() {
+	rs := ResourceServer{
+		Name:   "updated-rs",
+		Handle: "foo:bar", // delimiter ':' in handle
+		OUID:   "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "old-name",
+		Handle:    "original-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorDelimiterInResourceServerHandle.Code, svcErr.Code)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_IdentifierChanged() {
+	rs := ResourceServer{
+		Name:       "my-rs",
+		Identifier: "https://api.example.com/new/",
+		OUID:       "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:         "rs-123",
+		Name:       "my-rs",
+		Handle:     "my-handle",
+		Identifier: "https://api.example.com/old/",
+		Delimiter:  ":",
+		OUID:       "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
+		"https://api.example.com/new/").Return(false, nil)
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("UpdateResourceServer", mock.Anything, "rs-123",
+		mock.MatchedBy(func(r ResourceServer) bool {
+			return r.Identifier == "https://api.example.com/new/"
+		})).Return(nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(svcErr)
+	suite.NotNil(result)
+	suite.Equal("https://api.example.com/new/", result.Identifier)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_IdentifierConflict() {
+	rs := ResourceServer{
+		Name:       "updated-rs",
+		Identifier: "https://api.example.com/taken/",
+		OUID:       "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:         "rs-123",
+		Name:       "old-name",
+		Handle:     "my-handle",
+		Identifier: "https://api.example.com/original/",
+		Delimiter:  ":",
+		OUID:       "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
+		"https://api.example.com/taken/").Return(true, nil)
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorIdentifierConflict.Code, svcErr.Code)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_HandleCheckStoreError() {
+	rs := ResourceServer{
+		Name:   "updated-rs",
+		Handle: "new-handle",
+		OUID:   "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:        "rs-123",
+		Name:      "old-name",
+		Handle:    "original-handle",
+		Delimiter: ":",
+		OUID:      "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything, "new-handle").
+		Return(false, errors.New("db error"))
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+	suite.mockStore.AssertExpectations(suite.T())
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_IdentifierCheckStoreError() {
+	rs := ResourceServer{
+		Name:       "updated-rs",
+		Identifier: "https://api.example.com/new/",
+		OUID:       "ou-123",
+	}
+
+	existingRS := ResourceServer{
+		ID:         "rs-123",
+		Name:       "old-name",
+		Handle:     "my-handle",
+		Identifier: "https://api.example.com/old/",
+		Delimiter:  ":",
+		OUID:       "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
+	suite.mockStore.On("CheckResourceServerIdentifierExists", mock.Anything,
+		"https://api.example.com/new/").Return(false, errors.New("db error"))
+
+	result, svcErr := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
 	suite.mockStore.AssertExpectations(suite.T())
 }

--- a/backend/internal/resource/store.go
+++ b/backend/internal/resource/store.go
@@ -38,7 +38,9 @@ type resourceStoreInterface interface {
 	UpdateResourceServer(ctx context.Context, id string, rs ResourceServer) error
 	DeleteResourceServer(ctx context.Context, id string) error
 	CheckResourceServerNameExists(ctx context.Context, name string) (bool, error)
+	CheckResourceServerHandleExists(ctx context.Context, handle string) (bool, error)
 	CheckResourceServerIdentifierExists(ctx context.Context, identifier string) (bool, error)
+	GetResourceServerByIdentifier(ctx context.Context, identifier string) (ResourceServer, error)
 	CheckResourceServerHasDependencies(ctx context.Context, resServerID string) (bool, error)
 	IsResourceServerDeclarative(id string) bool
 
@@ -52,6 +54,7 @@ type resourceStoreInterface interface {
 	GetResourceListCount(ctx context.Context, resServerID string) (int, error)
 	GetResourceListCountByParent(ctx context.Context, resServerID string, parentID *string) (int, error)
 	UpdateResource(ctx context.Context, id string, resServerID string, res Resource) error
+	UpdateResourcePermission(ctx context.Context, id string, resServerID string, permission string) error
 	DeleteResource(ctx context.Context, id string, resServerID string) error
 	CheckResourceHandleExists(
 		ctx context.Context, resServerID string, handle string, parentID *string,
@@ -65,12 +68,14 @@ type resourceStoreInterface interface {
 	GetActionList(ctx context.Context, resServerID string, resID *string, limit, offset int) ([]Action, error)
 	GetActionListCount(ctx context.Context, resServerID string, resID *string) (int, error)
 	UpdateAction(ctx context.Context, id string, resServerID string, resID *string, action Action) error
+	UpdateActionPermission(ctx context.Context, id string, resServerID string, resID *string, permission string) error
 	DeleteAction(ctx context.Context, id string, resServerID string, resID *string) error
 	IsActionExist(ctx context.Context, id string, resServerID string, resID *string) (bool, error)
 	CheckActionHandleExists(
 		ctx context.Context, resServerID string, resID *string, handle string,
 	) (bool, error)
 	ValidatePermissions(ctx context.Context, resServerID string, permissions []string) ([]string, error)
+	FindResourceServersByPermissions(ctx context.Context, permissions []string) ([]ResourceServer, error)
 }
 
 // resourceStore is the default implementation of resourceStoreInterface.
@@ -107,7 +112,8 @@ func (s *resourceStore) CreateResourceServer(ctx context.Context, id string, rs 
 			rs.OUID,
 			rs.Name,
 			rs.Description,
-			resolveIdentifier(rs.Identifier),
+			resolveNullableString(rs.Handle),
+			resolveNullableString(rs.Identifier),
 			buildPropertiesJSON(rs),
 			s.deploymentID,
 		)
@@ -188,7 +194,8 @@ func (s *resourceStore) UpdateResourceServer(ctx context.Context, id string, rs 
 			rs.OUID,
 			rs.Name,
 			rs.Description,
-			resolveIdentifier(rs.Identifier),
+			resolveNullableString(rs.Handle),
+			resolveNullableString(rs.Identifier),
 			buildPropertiesJSON(rs),
 			id,
 			s.deploymentID,
@@ -228,6 +235,21 @@ func (s *resourceStore) CheckResourceServerNameExists(ctx context.Context, name 
 	return exists, err
 }
 
+// CheckResourceServerHandleExists checks if a resource server handle exists.
+func (s *resourceStore) CheckResourceServerHandleExists(ctx context.Context, handle string) (bool, error) {
+	var exists bool
+	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
+		results, err := dbClient.QueryContext(ctx, queryCheckResourceServerHandleExists, handle, s.deploymentID)
+		if err != nil {
+			return fmt.Errorf("failed to check resource server handle: %w", err)
+		}
+
+		exists, err = parseBoolFromCount(results)
+		return err
+	})
+	return exists, err
+}
+
 // CheckResourceServerIdentifierExists checks if a resource server identifier exists.
 func (s *resourceStore) CheckResourceServerIdentifierExists(ctx context.Context, identifier string) (bool, error) {
 	var exists bool
@@ -241,6 +263,25 @@ func (s *resourceStore) CheckResourceServerIdentifierExists(ctx context.Context,
 		return err
 	})
 	return exists, err
+}
+
+// GetResourceServerByIdentifier retrieves a resource server by its identifier.
+func (s *resourceStore) GetResourceServerByIdentifier(ctx context.Context, identifier string) (ResourceServer, error) {
+	var rs ResourceServer
+	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
+		results, err := dbClient.QueryContext(ctx, queryGetResourceServerByIdentifier, identifier, s.deploymentID)
+		if err != nil {
+			return fmt.Errorf("failed to get resource server by identifier: %w", err)
+		}
+
+		if len(results) == 0 {
+			return errResourceServerNotFound
+		}
+
+		rs, err = buildResourceServerFromResultRow(results[0])
+		return err
+	})
+	return rs, err
 }
 
 // CheckResourceServerHasDependencies checks if resource server has dependencies.
@@ -455,6 +496,26 @@ func (s *resourceStore) UpdateResource(ctx context.Context, id string, resServer
 	})
 }
 
+// UpdateResourcePermission updates only the permission field of a resource.
+func (s *resourceStore) UpdateResourcePermission(
+	ctx context.Context, id string, resServerID string, permission string,
+) error {
+	return s.withDBClient(func(dbClient provider.DBClientInterface) error {
+		_, err := dbClient.ExecuteContext(
+			ctx,
+			queryUpdateResourcePermission,
+			permission,
+			id,
+			resServerID,
+			s.deploymentID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update resource permission: %w", err)
+		}
+		return nil
+	})
+}
+
 // DeleteResource deletes a resource.
 func (s *resourceStore) DeleteResource(ctx context.Context, id string, resServerID string) error {
 	return s.withDBClient(func(dbClient provider.DBClientInterface) error {
@@ -665,6 +726,27 @@ func (s *resourceStore) UpdateAction(
 	})
 }
 
+// UpdateActionPermission updates only the permission field of an action.
+func (s *resourceStore) UpdateActionPermission(
+	ctx context.Context, id string, resServerID string, resID *string, permission string,
+) error {
+	return s.withDBClient(func(dbClient provider.DBClientInterface) error {
+		_, err := dbClient.ExecuteContext(
+			ctx,
+			queryUpdateActionPermission,
+			permission,     // $1: PERMISSION
+			id,             // $2: ACTION_ID
+			resServerID,    // $3: RESOURCE_SERVER_ID
+			resID,          // $4: RESOURCE_ID (nullable)
+			s.deploymentID, // $5: DEPLOYMENT_ID
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update action permission: %w", err)
+		}
+		return nil
+	})
+}
+
 // DeleteAction deletes an action.
 func (s *resourceStore) DeleteAction(
 	ctx context.Context, id string, resServerID string, resID *string,
@@ -776,6 +858,48 @@ func (s *resourceStore) ValidatePermissions(
 	return invalidPermissions, nil
 }
 
+// FindResourceServersByPermissions returns distinct resource servers that define at least one of
+// the supplied permissions.
+func (s *resourceStore) FindResourceServersByPermissions(
+	ctx context.Context, permissions []string,
+) ([]ResourceServer, error) {
+	if len(permissions) == 0 {
+		return []ResourceServer{}, nil
+	}
+
+	var resourceServers []ResourceServer
+	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
+		permissionsJSON, jsonErr := json.Marshal(permissions)
+		if jsonErr != nil {
+			return fmt.Errorf("failed to marshal permissions to JSON: %w", jsonErr)
+		}
+
+		results, err := dbClient.QueryContext(
+			ctx,
+			queryFindResourceServersByPermissions,
+			s.deploymentID,
+			string(permissionsJSON),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to find resource servers by permissions: %w", err)
+		}
+
+		resourceServers = make([]ResourceServer, 0, len(results))
+		for _, row := range results {
+			rs, buildErr := buildResourceServerFromResultRow(row)
+			if buildErr != nil {
+				return fmt.Errorf("failed to build resource server: %w", buildErr)
+			}
+			resourceServers = append(resourceServers, rs)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resourceServers, nil
+}
+
 // Helper methods
 
 // getConfigDBClient retrieves the config database client.
@@ -796,12 +920,12 @@ func (s *resourceStore) withDBClient(fn func(provider.DBClientInterface) error) 
 	return fn(dbClient)
 }
 
-// resolveIdentifier converts empty identifier to nil for database storage.
-func resolveIdentifier(identifier string) interface{} {
-	if identifier == "" {
+// resolveNullableString converts empty string to nil for database storage.
+func resolveNullableString(value string) interface{} {
+	if value == "" {
 		return nil
 	}
-	return identifier
+	return value
 }
 
 // parseCountResult parses a count result from database query.
@@ -893,6 +1017,10 @@ func buildResourceServerFromResultRow(row map[string]interface{}) (ResourceServe
 
 	if desc, ok := row["description"].(string); ok {
 		rs.Description = desc
+	}
+
+	if handle, ok := row["handle"].(string); ok {
+		rs.Handle = handle
 	}
 
 	if identifier, ok := row["identifier"].(string); ok {

--- a/backend/internal/resource/store_constants.go
+++ b/backend/internal/resource/store_constants.go
@@ -28,14 +28,14 @@ var (
 	queryCreateResourceServer = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-01",
 		Query: `INSERT INTO RESOURCE_SERVER
-			(ID, OU_ID, NAME, DESCRIPTION, IDENTIFIER, PROPERTIES, DEPLOYMENT_ID)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			(ID, OU_ID, NAME, DESCRIPTION, HANDLE, IDENTIFIER, PROPERTIES, DEPLOYMENT_ID)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 	}
 
 	// queryGetResourceServerByID retrieves a resource server by ID.
 	queryGetResourceServerByID = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-02",
-		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION, IDENTIFIER, PROPERTIES
+		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION, HANDLE, IDENTIFIER, PROPERTIES
 			FROM RESOURCE_SERVER
 			WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
@@ -43,7 +43,7 @@ var (
 	// queryGetResourceServerList retrieves a list of resource servers with pagination.
 	queryGetResourceServerList = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-03",
-		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION, IDENTIFIER, PROPERTIES
+		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION, HANDLE, IDENTIFIER, PROPERTIES
 			FROM RESOURCE_SERVER
 			WHERE DEPLOYMENT_ID = $3
 			ORDER BY CREATED_AT DESC
@@ -60,8 +60,8 @@ var (
 	queryUpdateResourceServer = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-05",
 		Query: `UPDATE RESOURCE_SERVER
-			SET OU_ID = $1, NAME = $2, DESCRIPTION = $3, IDENTIFIER = $4, PROPERTIES = $5
-			WHERE ID = $6 AND DEPLOYMENT_ID = $7`,
+			SET OU_ID = $1, NAME = $2, DESCRIPTION = $3, HANDLE = $4, IDENTIFIER = $5, PROPERTIES = $6
+			WHERE ID = $7 AND DEPLOYMENT_ID = $8`,
 	}
 
 	// queryDeleteResourceServer deletes a resource server.
@@ -76,10 +76,24 @@ var (
 		Query: `SELECT COUNT(*) as count FROM RESOURCE_SERVER WHERE NAME = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
+	// queryCheckResourceServerHandleExists checks if a resource server handler already exists.
+	queryCheckResourceServerHandleExists = dbmodel.DBQuery{
+		ID:    "RSQ-RES_MGT-08",
+		Query: `SELECT COUNT(*) as count FROM RESOURCE_SERVER WHERE HANDLE = $1 AND DEPLOYMENT_ID = $2`,
+	}
+
 	// queryCheckResourceServerIdentifierExists checks if a resource server identifier already exists.
 	queryCheckResourceServerIdentifierExists = dbmodel.DBQuery{
-		ID:    "RSQ-RES_MGT-08",
+		ID:    "RSQ-RES_MGT-33",
 		Query: `SELECT COUNT(*) as count FROM RESOURCE_SERVER WHERE IDENTIFIER = $1 AND DEPLOYMENT_ID = $2`,
+	}
+
+	// queryGetResourceServerByIdentifier retrieves a resource server by identifier.
+	queryGetResourceServerByIdentifier = dbmodel.DBQuery{
+		ID: "RSQ-RES_MGT-34",
+		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION, HANDLE, IDENTIFIER, PROPERTIES
+			FROM RESOURCE_SERVER
+			WHERE IDENTIFIER = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// queryCheckResourceServerHasDependencies checks if resource server has resources or actions.
@@ -184,6 +198,16 @@ var (
 		        WHERE ID = $4
 		          AND RESOURCE_SERVER_ID = $5
 		          AND DEPLOYMENT_ID = $6`,
+	}
+
+	// queryUpdateResourcePermission updates only the permission field of a resource.
+	queryUpdateResourcePermission = dbmodel.DBQuery{
+		ID: "RSQ-RES_MGT-36",
+		Query: `UPDATE RESOURCE
+		        SET PERMISSION = $1
+		        WHERE ID = $2
+		          AND RESOURCE_SERVER_ID = $3
+		          AND DEPLOYMENT_ID = $4`,
 	}
 
 	// queryDeleteResource deletes a resource.
@@ -295,6 +319,17 @@ var (
 		          AND DEPLOYMENT_ID = $7`,
 	}
 
+	// queryUpdateActionPermission updates only the permission field of an action.
+	queryUpdateActionPermission = dbmodel.DBQuery{
+		ID: "RSQ-RES_MGT-37",
+		Query: `UPDATE ACTION
+		        SET PERMISSION = $1
+		        WHERE ID = $2
+		          AND RESOURCE_SERVER_ID = $3
+		          AND (RESOURCE_ID = $4 OR (RESOURCE_ID IS NULL AND $4 IS NULL))
+		          AND DEPLOYMENT_ID = $5`,
+	}
+
 	// queryDeleteAction deletes an action.
 	queryDeleteAction = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-29",
@@ -325,6 +360,49 @@ var (
 		          AND (a.RESOURCE_ID = $2 OR (a.RESOURCE_ID IS NULL AND $2 IS NULL))
 		          AND a.HANDLE = $3
 		          AND a.DEPLOYMENT_ID = $4`,
+	}
+
+	// queryFindResourceServersByPermissions returns distinct resource servers that define at least
+	// one of the supplied permissions (as a RESOURCE.PERMISSION or ACTION.PERMISSION). Results are
+	// ordered by IDENTIFIER for deterministic output. Parameter $2 must be a JSON array string.
+	queryFindResourceServersByPermissions = dbmodel.DBQuery{
+		ID: "RSQ-RES_MGT-35",
+		PostgresQuery: `SELECT DISTINCT rs.ID, rs.OU_ID, rs.NAME, rs.DESCRIPTION, rs.HANDLE,
+		               rs.IDENTIFIER, rs.PROPERTIES
+		        FROM RESOURCE_SERVER rs
+		        WHERE rs.DEPLOYMENT_ID = $1
+		          AND rs.IDENTIFIER IS NOT NULL
+		          AND (
+		              EXISTS (
+		                  SELECT 1 FROM RESOURCE r
+		                  JOIN json_array_elements_text($2::json) AS p ON r.PERMISSION = p.value::text
+		                  WHERE r.RESOURCE_SERVER_ID = rs.ID AND r.DEPLOYMENT_ID = $1
+		              )
+		              OR EXISTS (
+		                  SELECT 1 FROM ACTION a
+		                  JOIN json_array_elements_text($2::json) AS p ON a.PERMISSION = p.value::text
+		                  WHERE a.RESOURCE_SERVER_ID = rs.ID AND a.DEPLOYMENT_ID = $1
+		              )
+		          )
+		        ORDER BY rs.IDENTIFIER`,
+		SQLiteQuery: `SELECT DISTINCT rs.ID, rs.OU_ID, rs.NAME, rs.DESCRIPTION, rs.HANDLE,
+		              rs.IDENTIFIER, rs.PROPERTIES
+		        FROM RESOURCE_SERVER rs
+		        WHERE rs.DEPLOYMENT_ID = $1
+		          AND rs.IDENTIFIER IS NOT NULL
+		          AND (
+		              EXISTS (
+		                  SELECT 1 FROM RESOURCE r
+		                  JOIN json_each($2) AS p ON r.PERMISSION = p.value
+		                  WHERE r.RESOURCE_SERVER_ID = rs.ID AND r.DEPLOYMENT_ID = $1
+		              )
+		              OR EXISTS (
+		                  SELECT 1 FROM ACTION a
+		                  JOIN json_each($2) AS p ON a.PERMISSION = p.value
+		                  WHERE a.RESOURCE_SERVER_ID = rs.ID AND a.DEPLOYMENT_ID = $1
+		              )
+		          )
+		        ORDER BY rs.IDENTIFIER`,
 	}
 
 	// queryValidatePermissions validates if permissions exist for a resource server.

--- a/backend/internal/resource/store_test.go
+++ b/backend/internal/resource/store_test.go
@@ -89,7 +89,7 @@ func (suite *ResourceStoreTestSuite) TestCreateResourceServer() {
 				suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 				suite.mockDBClient.On("ExecuteContext", context.Background(),
 					queryCreateResourceServer, "rs1", "ou1", "Test Server",
-					"Test Description", "test-identifier", []byte(`{"delimiter":":"}`), "test-deployment").
+					"Test Description", nil, "test-identifier", []byte(`{"delimiter":":"}`), "test-deployment").
 					Return(int64(1), nil)
 			},
 			shouldErr: false,
@@ -108,7 +108,7 @@ func (suite *ResourceStoreTestSuite) TestCreateResourceServer() {
 				suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 				suite.mockDBClient.On("ExecuteContext", context.Background(),
 					queryCreateResourceServer, "rs1", "ou1", "Test Server",
-					"Test Description", "test-identifier", []byte(`{"delimiter":":"}`), "test-deployment").
+					"Test Description", nil, "test-identifier", []byte(`{"delimiter":":"}`), "test-deployment").
 					Return(int64(0), errors.New("insert failed"))
 			},
 			shouldErr: true,
@@ -466,7 +466,8 @@ func (suite *ResourceStoreTestSuite) TestUpdateResourceServer() {
 				suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 				suite.mockDBClient.On("ExecuteContext", context.Background(),
 					queryUpdateResourceServer, "ou1", "Updated Server",
-					"Updated Description", "updated-identifier", []byte(`{"delimiter":"-"}`), "rs1", "test-deployment").
+					"Updated Description", nil, "updated-identifier",
+					[]byte(`{"delimiter":"-"}`), "rs1", "test-deployment").
 					Return(int64(1), nil)
 			},
 			shouldErr: false,
@@ -485,7 +486,8 @@ func (suite *ResourceStoreTestSuite) TestUpdateResourceServer() {
 				suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 				suite.mockDBClient.On("ExecuteContext", context.Background(),
 					queryUpdateResourceServer, "ou1", "Updated Server",
-					"Updated Description", "updated-identifier", []byte(`{"delimiter":"-"}`), "rs1", "test-deployment").
+					"Updated Description", nil, "updated-identifier",
+					[]byte(`{"delimiter":"-"}`), "rs1", "test-deployment").
 					Return(int64(0), errors.New("update failed"))
 			},
 			shouldErr: true,
@@ -3380,34 +3382,34 @@ func (suite *ResourceStoreTestSuite) TestBuildActionFromResultRow() {
 	}
 }
 
-// resolveIdentifier Tests
+// resolveNullableString Tests
 
-func (suite *ResourceStoreTestSuite) TestResolveIdentifier() {
+func (suite *ResourceStoreTestSuite) TestResolveNullableString() {
 	testCases := []struct {
-		name       string
-		identifier string
-		expected   interface{}
+		name     string
+		value    string
+		expected interface{}
 	}{
 		{
-			name:       "Success_NonEmptyIdentifier",
-			identifier: "https://api.example.com",
-			expected:   "https://api.example.com",
+			name:     "Success_NonEmptyValue",
+			value:    "https://api.example.com",
+			expected: "https://api.example.com",
 		},
 		{
-			name:       "Success_AnotherNonEmptyIdentifier",
-			identifier: "urn:example:resource:server",
-			expected:   "urn:example:resource:server",
+			name:     "Success_AnotherNonEmptyValue",
+			value:    "urn:example:resource:server",
+			expected: "urn:example:resource:server",
 		},
 		{
-			name:       "Success_EmptyIdentifier_ReturnsNil",
-			identifier: "",
-			expected:   nil,
+			name:     "Success_EmptyValue_ReturnsNil",
+			value:    "",
+			expected: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			result := resolveIdentifier(tc.identifier)
+			result := resolveNullableString(tc.value)
 			suite.Equal(tc.expected, result)
 		})
 	}

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -576,6 +576,8 @@ var defaultMessages = map[string]string{
 	"error.resourceservice.circular_dependency_detected_description": "Setting this parent would create a circular dependency",
 	"error.resourceservice.delimiter_conflict_in_handle": "Delimiter conflict in handle",
 	"error.resourceservice.delimiter_conflict_in_handle_description": "Handle cannot contain the delimiter character",
+	"error.resourceservice.delimiter_conflict_in_resource_server_handle": "Delimiter conflict in handle",
+	"error.resourceservice.delimiter_conflict_in_resource_server_handle_description": "Resource server handle cannot contain the delimiter character",
 	"error.resourceservice.handle_conflict": "Handle conflict",
 	"error.resourceservice.handle_conflict_description": "The same handle already exists within the specified resource",
 	"error.resourceservice.identifier_conflict": "Identifier conflict",

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -45,7 +45,7 @@ import (
 
 // JWTServiceInterface defines the interface for JWT operations.
 type JWTServiceInterface interface {
-	GenerateJWT(sub, aud, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (
+	GenerateJWT(sub, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (
 		string, int64, *serviceerror.ServiceError)
 	VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError
 	VerifyJWTWithPublicKey(jwtToken string, jwtPublicKey crypto.PublicKey, expectedAud,
@@ -140,13 +140,30 @@ func newJWTService(pkiService pki.PKIServiceInterface) (JWTServiceInterface, err
 
 // GenerateJWT generates a standard JWT signed with the server's private key.
 // The typ parameter sets the JWT header "typ" field. If empty, defaults to "JWT".
+// claims["aud"] must be set by the caller as either a string or []string; omitting it
+// or providing another type is a programmer error and returns InternalServerError.
 func (js *jwtService) GenerateJWT(
-	sub, aud, iss string, validityPeriod int64, claims map[string]interface{}, typ string,
+	sub, iss string, validityPeriod int64, claims map[string]interface{}, typ string,
 ) (string, int64, *serviceerror.ServiceError) {
 	if js.privateKey == nil {
 		js.logger.Error("Private key not found for JWT generation")
 		return "", 0, &serviceerror.InternalServerError
 	}
+
+	// Validate that claims["aud"] is present and of an accepted type.
+	audValue, hasAud := claims["aud"]
+	if !hasAud {
+		js.logger.Error("GenerateJWT called without aud in claims")
+		return "", 0, &serviceerror.InternalServerError
+	}
+	switch audValue.(type) {
+	case string, []string:
+		// valid
+	default:
+		js.logger.Error("GenerateJWT called with unsupported aud type in claims")
+		return "", 0, &serviceerror.InternalServerError
+	}
+
 	thunderRuntime := config.GetThunderRuntime()
 
 	// Create the JWT header.
@@ -187,7 +204,6 @@ func (js *jwtService) GenerateJWT(
 	payload := map[string]interface{}{
 		"sub": sub,
 		"iss": tokenIssuer,
-		"aud": aud,
 		"exp": expirationTime,
 		"iat": iat.Unix(),
 		"nbf": iat.Unix(),
@@ -439,24 +455,6 @@ func (js *jwtService) getJWKSKeys(jwksURL string) ([]map[string]interface{}, *se
 	return jwks.Keys, nil
 }
 
-// audienceMatches checks whether the aud claim matches the expected audience.
-// Supports both string and array forms of the aud claim.
-func audienceMatches(audClaim interface{}, expectedAud string) bool {
-	switch v := audClaim.(type) {
-	case string:
-		return v == expectedAud
-	case []interface{}:
-		for _, item := range v {
-			if s, ok := item.(string); ok && s == expectedAud {
-				return true
-			}
-		}
-		return false
-	default:
-		return false
-	}
-}
-
 // verifyJWTClaims verifies the standard claims of a JWT token.
 func (js *jwtService) verifyJWTClaims(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError {
 	// Decode the JWT payload
@@ -495,10 +493,27 @@ func (js *jwtService) verifyJWTClaims(jwtToken string, expectedAud, expectedIss 
 		}
 	}
 
-	// Validate aud claim. Supports both string and array forms.
 	if expectedAud != "" {
-		if !audienceMatches(payload["aud"], expectedAud) {
-			js.logger.Debug("Invalid audience: expected " + expectedAud)
+		switch aud := payload["aud"].(type) {
+		case string:
+			if aud != expectedAud {
+				js.logger.Debug("Invalid audience: expected " + expectedAud + ", got " + aud)
+				return &ErrorInvalidJWTFormat
+			}
+		case []interface{}:
+			found := false
+			for _, v := range aud {
+				if s, ok := v.(string); ok && s == expectedAud {
+					found = true
+					break
+				}
+			}
+			if !found {
+				js.logger.Debug("Invalid audience: expected " + expectedAud + " not found in aud array")
+				return &ErrorInvalidJWTFormat
+			}
+		default:
+			js.logger.Debug("Missing or invalid 'aud' claim")
 			return &ErrorInvalidJWTFormat
 		}
 	}

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -256,7 +256,6 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 	testCases := []struct {
 		name               string
 		sub                string
-		aud                string
 		iss                string
 		validity           int64
 		claims             map[string]interface{}
@@ -268,12 +267,12 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		useDefaultValidity bool
 	}{
 		{
-			name:     "Success",
+			name:     "AudAsString",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 3600,
 			claims: map[string]interface{}{
+				"aud":   testAudience,
 				"name":  "John Doe",
 				"email": "john@example.com",
 			},
@@ -320,12 +319,68 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 			},
 		},
 		{
+			name:     "AudAsSlice",
+			sub:      "test-subject",
+			iss:      testIssuer,
+			validity: 3600,
+			claims: map[string]interface{}{
+				"aud": []string{testAudience, "second-audience"},
+			},
+			setupMock:    func() func() { return func() {} },
+			setupService: func() *jwtService { return suite.jwtService },
+			expectError:  false,
+			validateSuccess: func(t *testing.T, token string, iat int64) {
+				parts := strings.Split(token, ".")
+				payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+				assert.NoError(t, err)
+
+				var payload map[string]interface{}
+				err = json.Unmarshal(payloadBytes, &payload)
+				assert.NoError(t, err)
+
+				auds, ok := payload["aud"].([]interface{})
+				assert.True(t, ok)
+				assert.Len(t, auds, 2)
+				assert.Equal(t, testAudience, auds[0])
+				assert.Equal(t, "second-audience", auds[1])
+			},
+		},
+		{
+			name:     "MissingAud",
+			sub:      "test-subject",
+			iss:      testIssuer,
+			validity: 3600,
+			claims:   map[string]interface{}{"name": "no-aud"},
+			setupMock: func() func() {
+				return func() {}
+			},
+			setupService: func() *jwtService {
+				return suite.jwtService
+			},
+			expectError: true,
+			errorCode:   "SSE-5000",
+		},
+		{
+			name:     "WrongTypeAud",
+			sub:      "test-subject",
+			iss:      testIssuer,
+			validity: 3600,
+			claims:   map[string]interface{}{"aud": 12345},
+			setupMock: func() func() {
+				return func() {}
+			},
+			setupService: func() *jwtService {
+				return suite.jwtService
+			},
+			expectError: true,
+			errorCode:   "SSE-5000",
+		},
+		{
 			name:     "DefaultValidity",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 0, // Should use default
-			claims:   map[string]interface{}{},
+			claims:   map[string]interface{}{"aud": testAudience},
 			setupMock: func() func() {
 				return func() {}
 			},
@@ -338,10 +393,9 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:     "DefaultIssuer",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      "", // Should use default
 			validity: 3600,
-			claims:   map[string]interface{}{},
+			claims:   map[string]interface{}{"aud": testAudience},
 			setupMock: func() func() {
 				return func() {}
 			},
@@ -353,10 +407,9 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:      "NilPrivateKey",
 			sub:       "sub",
-			aud:       "aud",
 			iss:       "iss",
 			validity:  3600,
-			claims:    nil,
+			claims:    map[string]interface{}{"aud": "aud"},
 			setupMock: func() func() { return func() {} },
 			setupService: func() *jwtService {
 				return &jwtService{
@@ -368,27 +421,11 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 			errorCode:   "SSE-5000",
 		},
 		{
-			name:     "WithEmptyClaims",
-			sub:      "test-subject",
-			aud:      testAudience,
-			iss:      testIssuer,
-			validity: 1800,
-			claims:   nil,
-			setupMock: func() func() {
-				return func() {}
-			},
-			setupService: func() *jwtService {
-				return suite.jwtService
-			},
-			expectError: false,
-		},
-		{
 			name:     "SigningError",
 			sub:      "sub",
-			aud:      "aud",
 			iss:      "iss",
 			validity: 3600,
-			claims:   nil,
+			claims:   map[string]interface{}{"aud": "aud"},
 			setupMock: func() func() {
 				return func() {}
 			},
@@ -403,10 +440,9 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:     "LongValidityPeriod",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 86400, // 24 hours
-			claims:   map[string]interface{}{},
+			claims:   map[string]interface{}{"aud": testAudience},
 			setupMock: func() func() {
 				return func() {}
 			},
@@ -430,10 +466,10 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:     "ComplexClaims",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 3600,
 			claims: map[string]interface{}{
+				"aud":    testAudience,
 				"roles":  []string{"admin", "user"},
 				"nested": map[string]interface{}{"key": "value"},
 				"number": 42,
@@ -470,10 +506,9 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:     "EmptySubject",
 			sub:      "",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 3600,
-			claims:   nil,
+			claims:   map[string]interface{}{"aud": testAudience},
 			setupMock: func() func() {
 				return func() {}
 			},
@@ -496,10 +531,10 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 		{
 			name:     "SpecialCharactersInClaims",
 			sub:      "test-subject",
-			aud:      testAudience,
 			iss:      testIssuer,
 			validity: 3600,
 			claims: map[string]interface{}{
+				"aud":   testAudience,
 				"email": "test+special@example.com",
 				"name":  "Test User / Admin",
 			},
@@ -532,7 +567,7 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 
 			jwtService := tc.setupService()
 
-			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.aud, tc.iss, tc.validity, tc.claims, TokenTypeJWT)
+			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.iss, tc.validity, tc.claims, TokenTypeJWT)
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -1350,7 +1385,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			name: "ValidToken",
 			setupFunc: func() string {
 				token, _, err := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1379,7 +1414,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			name: "PublicKeyNotAvailable",
 			setupFunc: func() string {
 				token, _, err := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1410,7 +1445,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 	validToken, _, err := suite.jwtService.GenerateJWT(
-		"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	wrongKey, _ := rsa.GenerateKey(rand.Reader, 2048)
@@ -1447,7 +1482,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKS() {
-	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+	token, _, err := suite.jwtService.GenerateJWT(
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	testServer := suite.mockJWKSServer()
@@ -1507,7 +1543,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSUsesCache() {
 	defer serverB.Close()
 
 	token, _, genErr := suite.jwtService.GenerateJWT(
-		"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 	assert.Nil(suite.T(), genErr)
 
 	// 1. First call against serverA — cache miss, one fetch.
@@ -1606,7 +1642,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToGetJWKS,
@@ -1624,7 +1660,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1654,7 +1690,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorNoMatchingJWKFound,
@@ -1683,7 +1719,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1725,7 +1761,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSNetworkError() {
 	// Test with invalid URL to trigger network error
-	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
+	token, _, err := suite.jwtService.GenerateJWT(
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	err = suite.jwtService.VerifyJWTSignatureWithJWKS(token, "http://localhost:99999/invalid")
@@ -1960,7 +1997,8 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 			assert.Equal(t, tc.expectedAlg, jwtSvc.jwsAlg)
 
 			// Test JWT generation with ECDSA key
-			token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
+			token, _, svcErr := service.GenerateJWT(
+				"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
 			assert.Nil(t, svcErr)
 			assert.NotEmpty(t, token)
 
@@ -2022,7 +2060,8 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 	assert.Equal(suite.T(), jws.EdDSA, jwtSvc.jwsAlg)
 
 	// Test JWT generation with Ed25519 key
-	token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
+	token, _, svcErr := service.GenerateJWT(
+		"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
 	assert.Nil(suite.T(), svcErr)
 	assert.NotEmpty(suite.T(), token)
 
@@ -2292,7 +2331,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyAlgorithmDe
 			}
 
 			// Generate token
-			token, _, err := jwtService.GenerateJWT("test-sub", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
+			token, _, err := jwtService.GenerateJWT(
+				"test-sub", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
 			assert.Nil(t, err)
 
 			// Verify with public key (should detect algorithm from header)

--- a/backend/internal/system/mcp/auth/token_verifier_test.go
+++ b/backend/internal/system/mcp/auth/token_verifier_test.go
@@ -56,12 +56,12 @@ func (m *MockJWTService) GetPublicKey() crypto.PublicKey {
 }
 
 func (m *MockJWTService) GenerateJWT(
-	sub, aud, iss string,
+	sub, iss string,
 	validityPeriod int64,
 	claims map[string]interface{},
 	typ string,
 ) (string, int64, *serviceerror.ServiceError) {
-	args := m.Called(sub, aud, iss, validityPeriod, claims, typ)
+	args := m.Called(sub, iss, validityPeriod, claims, typ)
 	return args.String(0), args.Get(1).(int64), args.Get(2).(*serviceerror.ServiceError)
 }
 

--- a/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *JWTServiceInterfaceMock) EXPECT() *JWTServiceInterfaceMock_Expecter {
 }
 
 // GenerateJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError) {
-	ret := _mock.Called(sub, aud, iss, validityPeriod, claims, typ)
+func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError) {
+	ret := _mock.Called(sub, iss, validityPeriod, claims, typ)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateJWT")
@@ -49,21 +49,21 @@ func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, aud string, iss st
 	var r0 string
 	var r1 int64
 	var r2 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}, string) (string, int64, *serviceerror.ServiceError)); ok {
-		return returnFunc(sub, aud, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string) (string, int64, *serviceerror.ServiceError)); ok {
+		return returnFunc(sub, iss, validityPeriod, claims, typ)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}, string) string); ok {
-		r0 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string) string); ok {
+		r0 = returnFunc(sub, iss, validityPeriod, claims, typ)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string, int64, map[string]interface{}, string) int64); ok {
-		r1 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(1).(func(string, string, int64, map[string]interface{}, string) int64); ok {
+		r1 = returnFunc(sub, iss, validityPeriod, claims, typ)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(string, string, string, int64, map[string]interface{}, string) *serviceerror.ServiceError); ok {
-		r2 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(2).(func(string, string, int64, map[string]interface{}, string) *serviceerror.ServiceError); ok {
+		r2 = returnFunc(sub, iss, validityPeriod, claims, typ)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).(*serviceerror.ServiceError)
@@ -79,16 +79,15 @@ type JWTServiceInterfaceMock_GenerateJWT_Call struct {
 
 // GenerateJWT is a helper method to define mock.On call
 //   - sub string
-//   - aud string
 //   - iss string
 //   - validityPeriod int64
 //   - claims map[string]interface{}
 //   - typ string
-func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, aud interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
-	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, aud, iss, validityPeriod, claims, typ)}
+func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
+	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, iss, validityPeriod, claims, typ)}
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -98,21 +97,17 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 int64
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(int64)
 		}
-		var arg3 int64
+		var arg3 map[string]interface{}
 		if args[3] != nil {
-			arg3 = args[3].(int64)
+			arg3 = args[3].(map[string]interface{})
 		}
-		var arg4 map[string]interface{}
+		var arg4 string
 		if args[4] != nil {
-			arg4 = args[4].(map[string]interface{})
-		}
-		var arg5 string
-		if args[5] != nil {
-			arg5 = args[5].(string)
+			arg4 = args[4].(string)
 		}
 		run(
 			arg0,
@@ -120,7 +115,6 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud
 			arg2,
 			arg3,
 			arg4,
-			arg5,
 		)
 	})
 	return _c
@@ -131,7 +125,7 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Return(s string, n int64, se
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
@@ -116,16 +116,16 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_HandleGrant_Call) RunAndReturn(r
 }
 
 // IssueRefreshToken provides a mock function for the type RefreshTokenGrantHandlerInterfaceMock
-func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse {
-	ret := _mock.Called(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
+func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audiences []string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse {
+	ret := _mock.Called(ctx, tokenResponse, oauthApp, subject, audiences, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IssueRefreshToken")
 	}
 
 	var r0 *model.ErrorResponse
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, *model.ClaimsRequest, string, string) *model.ErrorResponse); ok {
-		r0 = returnFunc(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, []string, string, []string, *model.ClaimsRequest, string, string) *model.ErrorResponse); ok {
+		r0 = returnFunc(ctx, tokenResponse, oauthApp, subject, audiences, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ErrorResponse)
@@ -144,17 +144,17 @@ type RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call struct {
 //   - tokenResponse *model.TokenResponseDTO
 //   - oauthApp *model0.OAuthAppConfigProcessedDTO
 //   - subject string
-//   - audience string
+//   - audiences []string
 //   - grantType string
 //   - scopes []string
 //   - claimsRequest *model.ClaimsRequest
 //   - claimsLocales string
 //   - attributeCacheID string
-func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(ctx interface{}, tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}, claimsLocales interface{}, attributeCacheID interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
-	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)}
+func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(ctx interface{}, tokenResponse interface{}, oauthApp interface{}, subject interface{}, audiences interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}, claimsLocales interface{}, attributeCacheID interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", ctx, tokenResponse, oauthApp, subject, audiences, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)}
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audiences []string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -172,9 +172,9 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
-		var arg4 string
+		var arg4 []string
 		if args[4] != nil {
-			arg4 = args[4].(string)
+			arg4 = args[4].([]string)
 		}
 		var arg5 string
 		if args[5] != nil {
@@ -217,7 +217,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Return(e
 	return _c
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audiences []string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
+++ b/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
@@ -462,6 +462,76 @@ func (_c *ResourceServiceInterfaceMock_DeleteResourceServer_Call) RunAndReturn(r
 	return _c
 }
 
+// FindResourceServersByPermissions provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) FindResourceServersByPermissions(ctx context.Context, permissions []string) ([]resource.ResourceServer, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, permissions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindResourceServersByPermissions")
+	}
+
+	var r0 []resource.ResourceServer
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]resource.ResourceServer, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, permissions)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []resource.ResourceServer); ok {
+		r0 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resource.ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindResourceServersByPermissions'
+type ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call struct {
+	*mock.Call
+}
+
+// FindResourceServersByPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - permissions []string
+func (_e *ResourceServiceInterfaceMock_Expecter) FindResourceServersByPermissions(ctx interface{}, permissions interface{}) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	return &ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call{Call: _e.mock.On("FindResourceServersByPermissions", ctx, permissions)}
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) Run(run func(ctx context.Context, permissions []string)) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) Return(resourceServers []resource.ResourceServer, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(resourceServers, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call) RunAndReturn(run func(ctx context.Context, permissions []string) ([]resource.ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAction provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) GetAction(ctx context.Context, resourceServerID string, resourceID *string, id string) (*resource.Action, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, resourceID, id)
@@ -862,6 +932,76 @@ func (_c *ResourceServiceInterfaceMock_GetResourceServer_Call) Return(resourceSe
 }
 
 func (_c *ResourceServiceInterfaceMock_GetResourceServer_Call) RunAndReturn(run func(ctx context.Context, id string) (*resource.ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceServerByIdentifier provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) GetResourceServerByIdentifier(ctx context.Context, identifier string) (*resource.ResourceServer, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, identifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceServerByIdentifier")
+	}
+
+	var r0 *resource.ResourceServer
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resource.ResourceServer, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, identifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resource.ResourceServer); ok {
+		r0 = returnFunc(ctx, identifier)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resource.ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, identifier)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceServerByIdentifier'
+type ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call struct {
+	*mock.Call
+}
+
+// GetResourceServerByIdentifier is a helper method to define mock.On call
+//   - ctx context.Context
+//   - identifier string
+func (_e *ResourceServiceInterfaceMock_Expecter) GetResourceServerByIdentifier(ctx interface{}, identifier interface{}) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	return &ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call{Call: _e.mock.On("GetResourceServerByIdentifier", ctx, identifier)}
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) Run(run func(ctx context.Context, identifier string)) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) Return(resourceServer *resource.ResourceServer, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(resourceServer, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call) RunAndReturn(run func(ctx context.Context, identifier string) (*resource.ResourceServer, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetResourceServerByIdentifier_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/resourcemock/resourceStoreInterface_mock.go
+++ b/backend/tests/mocks/resourcemock/resourceStoreInterface_mock.go
@@ -332,6 +332,72 @@ func (_c *resourceStoreInterfaceMock_CheckResourceHasDependencies_Call) RunAndRe
 	return _c
 }
 
+// CheckResourceServerHandleExists provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) CheckResourceServerHandleExists(ctx context.Context, handle string) (bool, error) {
+	ret := _mock.Called(ctx, handle)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckResourceServerHandleExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, handle)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, handle)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, handle)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckResourceServerHandleExists'
+type resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call struct {
+	*mock.Call
+}
+
+// CheckResourceServerHandleExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+func (_e *resourceStoreInterfaceMock_Expecter) CheckResourceServerHandleExists(ctx interface{}, handle interface{}) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	return &resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call{Call: _e.mock.On("CheckResourceServerHandleExists", ctx, handle)}
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) Run(run func(ctx context.Context, handle string)) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) Return(b bool, err error) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call) RunAndReturn(run func(ctx context.Context, handle string) (bool, error)) *resourceStoreInterfaceMock_CheckResourceServerHandleExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckResourceServerHasDependencies provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) CheckResourceServerHasDependencies(ctx context.Context, resServerID string) (bool, error) {
 	ret := _mock.Called(ctx, resServerID)
@@ -928,6 +994,74 @@ func (_c *resourceStoreInterfaceMock_DeleteResourceServer_Call) Return(err error
 }
 
 func (_c *resourceStoreInterfaceMock_DeleteResourceServer_Call) RunAndReturn(run func(ctx context.Context, id string) error) *resourceStoreInterfaceMock_DeleteResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindResourceServersByPermissions provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) FindResourceServersByPermissions(ctx context.Context, permissions []string) ([]resource.ResourceServer, error) {
+	ret := _mock.Called(ctx, permissions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindResourceServersByPermissions")
+	}
+
+	var r0 []resource.ResourceServer
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]resource.ResourceServer, error)); ok {
+		return returnFunc(ctx, permissions)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []resource.ResourceServer); ok {
+		r0 = returnFunc(ctx, permissions)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resource.ResourceServer)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, permissions)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_FindResourceServersByPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindResourceServersByPermissions'
+type resourceStoreInterfaceMock_FindResourceServersByPermissions_Call struct {
+	*mock.Call
+}
+
+// FindResourceServersByPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - permissions []string
+func (_e *resourceStoreInterfaceMock_Expecter) FindResourceServersByPermissions(ctx interface{}, permissions interface{}) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	return &resourceStoreInterfaceMock_FindResourceServersByPermissions_Call{Call: _e.mock.On("FindResourceServersByPermissions", ctx, permissions)}
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) Run(run func(ctx context.Context, permissions []string)) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) Return(resourceServers []resource.ResourceServer, err error) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
+	_c.Call.Return(resourceServers, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call) RunAndReturn(run func(ctx context.Context, permissions []string) ([]resource.ResourceServer, error)) *resourceStoreInterfaceMock_FindResourceServersByPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1610,6 +1744,72 @@ func (_c *resourceStoreInterfaceMock_GetResourceServer_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetResourceServerByIdentifier provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) GetResourceServerByIdentifier(ctx context.Context, identifier string) (resource.ResourceServer, error) {
+	ret := _mock.Called(ctx, identifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceServerByIdentifier")
+	}
+
+	var r0 resource.ResourceServer
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (resource.ResourceServer, error)); ok {
+		return returnFunc(ctx, identifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) resource.ResourceServer); ok {
+		r0 = returnFunc(ctx, identifier)
+	} else {
+		r0 = ret.Get(0).(resource.ResourceServer)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, identifier)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceServerByIdentifier'
+type resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call struct {
+	*mock.Call
+}
+
+// GetResourceServerByIdentifier is a helper method to define mock.On call
+//   - ctx context.Context
+//   - identifier string
+func (_e *resourceStoreInterfaceMock_Expecter) GetResourceServerByIdentifier(ctx interface{}, identifier interface{}) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	return &resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call{Call: _e.mock.On("GetResourceServerByIdentifier", ctx, identifier)}
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) Run(run func(ctx context.Context, identifier string)) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) Return(resourceServer resource.ResourceServer, err error) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(resourceServer, err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call) RunAndReturn(run func(ctx context.Context, identifier string) (resource.ResourceServer, error)) *resourceStoreInterfaceMock_GetResourceServerByIdentifier_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetResourceServerList provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) GetResourceServerList(ctx context.Context, limit int, offset int) ([]resource.ResourceServer, error) {
 	ret := _mock.Called(ctx, limit, offset)
@@ -1948,6 +2148,81 @@ func (_c *resourceStoreInterfaceMock_UpdateAction_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// UpdateActionPermission provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) UpdateActionPermission(ctx context.Context, id string, resServerID string, resID *string, permission string) error {
+	ret := _mock.Called(ctx, id, resServerID, resID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateActionPermission")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *string, string) error); ok {
+		r0 = returnFunc(ctx, id, resServerID, resID, permission)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// resourceStoreInterfaceMock_UpdateActionPermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateActionPermission'
+type resourceStoreInterfaceMock_UpdateActionPermission_Call struct {
+	*mock.Call
+}
+
+// UpdateActionPermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - resServerID string
+//   - resID *string
+//   - permission string
+func (_e *resourceStoreInterfaceMock_Expecter) UpdateActionPermission(ctx interface{}, id interface{}, resServerID interface{}, resID interface{}, permission interface{}) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	return &resourceStoreInterfaceMock_UpdateActionPermission_Call{Call: _e.mock.On("UpdateActionPermission", ctx, id, resServerID, resID, permission)}
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) Run(run func(ctx context.Context, id string, resServerID string, resID *string, permission string)) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 *string
+		if args[3] != nil {
+			arg3 = args[3].(*string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) Return(err error) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateActionPermission_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, resID *string, permission string) error) *resourceStoreInterfaceMock_UpdateActionPermission_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateResource provides a mock function for the type resourceStoreInterfaceMock
 func (_mock *resourceStoreInterfaceMock) UpdateResource(ctx context.Context, id string, resServerID string, res resource.Resource) error {
 	ret := _mock.Called(ctx, id, resServerID, res)
@@ -2013,6 +2288,75 @@ func (_c *resourceStoreInterfaceMock_UpdateResource_Call) Return(err error) *res
 }
 
 func (_c *resourceStoreInterfaceMock_UpdateResource_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, res resource.Resource) error) *resourceStoreInterfaceMock_UpdateResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateResourcePermission provides a mock function for the type resourceStoreInterfaceMock
+func (_mock *resourceStoreInterfaceMock) UpdateResourcePermission(ctx context.Context, id string, resServerID string, permission string) error {
+	ret := _mock.Called(ctx, id, resServerID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateResourcePermission")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, id, resServerID, permission)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// resourceStoreInterfaceMock_UpdateResourcePermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateResourcePermission'
+type resourceStoreInterfaceMock_UpdateResourcePermission_Call struct {
+	*mock.Call
+}
+
+// UpdateResourcePermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - resServerID string
+//   - permission string
+func (_e *resourceStoreInterfaceMock_Expecter) UpdateResourcePermission(ctx interface{}, id interface{}, resServerID interface{}, permission interface{}) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	return &resourceStoreInterfaceMock_UpdateResourcePermission_Call{Call: _e.mock.On("UpdateResourcePermission", ctx, id, resServerID, permission)}
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) Run(run func(ctx context.Context, id string, resServerID string, permission string)) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) Return(err error) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *resourceStoreInterfaceMock_UpdateResourcePermission_Call) RunAndReturn(run func(ctx context.Context, id string, resServerID string, permission string) error) *resourceStoreInterfaceMock_UpdateResourcePermission_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -12374,6 +12374,7 @@ components:
       required:
         - id
         - name
+        - handle
         - ouId
         - delimiter
       properties:
@@ -12388,11 +12389,17 @@ components:
           type: string
           nullable: true
           description: Optional description of the resource server
+        handle:
+          type: string
+          description: Handle used as a permission-string prefix (unique in the system,
+            immutable after creation)
         identifier:
           type: string
           nullable: true
-          description: Optional identifier for authorization requests (Unique in the
-            system if provided)
+          description: Optional external identifier for the resource server. If an
+            absolute URI, the server participates in RFC 8707 as the `resource`
+            parameter value and JWT `aud` (Unique in the system if provided,
+            immutable after creation)
         ouId:
           type: string
           format: uuid
@@ -12405,6 +12412,7 @@ components:
       type: object
       required:
         - name
+        - handle
         - ouId
       properties:
         name:
@@ -12413,10 +12421,16 @@ components:
         description:
           type: string
           description: Optional description of the resource server
+        handle:
+          type: string
+          description: Handle used as a permission-string prefix (unique in the system,
+            immutable after creation)
         identifier:
           type: string
-          description: Optional identifier for authorization requests (Unique in the
-            system if provided)
+          description: Optional external identifier for the resource server. If an
+            absolute URI, the server participates in RFC 8707 as the `resource`
+            parameter value and JWT `aud` (Unique in the system if provided,
+            immutable after creation)
         ouId:
           type: string
           format: uuid
@@ -12437,10 +12451,16 @@ components:
         description:
           type: string
           description: Optional description of the resource server
+        handle:
+          type: string
+          description: >
+            Short handle for the resource server used in permission strings.
+            If omitted the existing value is preserved.
         identifier:
           type: string
-          description: Optional identifier for authorization requests (Unique in the
-            system if provided)
+          description: >
+            URI identifier for the resource server (e.g. an OAuth2 audience value).
+            If omitted the existing value is preserved.
         ouId:
           type: string
           format: uuid

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -218,7 +218,7 @@ func (ts *OAuthAuthzScopeTestSuite) SetupSuite() {
 			Description: "Permission to write documents",
 		},
 	}
-	scopeTestResourceServer, err := testutils.CreateResourceServerWithActions(resourceServer, actions)
+	scopeTestResourceServer, err = testutils.CreateResourceServerWithActions(resourceServer, actions)
 	if err != nil {
 		ts.T().Fatalf("Failed to create resource server with actions: %v", err)
 	}

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -989,6 +989,21 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithResourceParameter() {
 	// Test that resource parameter is properly stored and used as audience in access token
 	resourceURL := "https://mcp.example.com/mcp"
 
+	// Create a Resource Server with the matching identifier so the resource parameter is valid
+	rs := testutils.ResourceServer{
+		Name:       "MCP Resource Server",
+		Handle:     "mcp-server",
+		Identifier: resourceURL,
+		OUID:       testOUID,
+	}
+	rsID, err := testutils.CreateResourceServerWithActions(rs, nil)
+	ts.NoError(err, "Failed to create resource server")
+	defer func() {
+		if err := testutils.DeleteResourceServer(rsID); err != nil {
+			ts.T().Logf("Warning: Failed to delete resource server: %v", err)
+		}
+	}()
+
 	// Create test user
 	user := testutils.User{
 		OUID: testOUID,
@@ -1091,7 +1106,21 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithResourceParameter() {
 	// Verify the audience claim matches the resource parameter
 	aud, ok := claims["aud"]
 	ts.True(ok, "Audience claim should be present in access token")
-	ts.Equal(resourceURL, aud, "Audience should match the resource parameter")
+	switch audVal := aud.(type) {
+	case string:
+		ts.Equal(resourceURL, audVal, "Audience should match the resource parameter")
+	case []interface{}:
+		found := false
+		for _, a := range audVal {
+			if a == resourceURL {
+				found = true
+				break
+			}
+		}
+		ts.True(found, "Audience array should contain the resource URL")
+	default:
+		ts.Fail("Unexpected audience type")
+	}
 }
 
 // TestAuthorizationCodeFlowWithClaimsLocales tests that claims_locales parameter is accepted and stored

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -45,12 +45,13 @@ const (
 
 type TokenExchangeTestSuite struct {
 	suite.Suite
-	applicationID  string
-	userID         string
-	oUID           string
-	userSchemaID   string
-	client         *http.Client
-	assertionToken string
+	applicationID    string
+	userID           string
+	oUID             string
+	userSchemaID     string
+	resourceServerID string
+	client           *http.Client
+	assertionToken   string
 }
 
 var (
@@ -96,9 +97,28 @@ func (ts *TokenExchangeTestSuite) SetupSuite() {
 
 	// Authenticate user to get assertion token for tests
 	ts.assertionToken = ts.getUserAssertion()
+
+	// Create resource server for resource parameter tests
+	rs := testutils.ResourceServer{
+		Name:       "Token Exchange Test RS",
+		Handle:     "te-resource-server",
+		Identifier: "https://resource.example.com",
+		OUID:       ts.oUID,
+	}
+	rsID, err := testutils.CreateResourceServerWithActions(rs, []testutils.Action{})
+	ts.Require().NoError(err, "Failed to create test resource server")
+	ts.resourceServerID = rsID
+	ts.T().Logf("Created test resource server with ID: %s", rsID)
 }
 
 func (ts *TokenExchangeTestSuite) TearDownSuite() {
+	// Clean up resource server
+	if ts.resourceServerID != "" {
+		if err := testutils.DeleteResourceServer(ts.resourceServerID); err != nil {
+			ts.T().Logf("Failed to delete resource server during teardown: %v", err)
+		}
+	}
+
 	// Clean up application
 	if ts.applicationID != "" {
 		ts.deleteApplication(ts.applicationID)
@@ -299,6 +319,30 @@ func (ts *TokenExchangeTestSuite) getUserAssertion() string {
 	return authResponse.Assertion
 }
 
+// assertAudienceContains verifies that the JWT audience claim (string or array) contains the expected value.
+func (ts *TokenExchangeTestSuite) assertAudienceContains(claims *testutils.JWTClaims, expected string) {
+	ts.T().Helper()
+
+	rawAud, ok := claims.Additional["aud"]
+	ts.Require().True(ok, "JWT should contain an aud claim")
+
+	switch aud := rawAud.(type) {
+	case string:
+		ts.Equal(expected, aud, "Audience should match expected value")
+	case []interface{}:
+		found := false
+		for _, v := range aud {
+			if s, ok := v.(string); ok && s == expected {
+				found = true
+				break
+			}
+		}
+		ts.True(found, "Audience array should contain %q, got %v", expected, aud)
+	default:
+		ts.Failf("unexpected aud type", "expected string or []interface{}, got %T", rawAud)
+	}
+}
+
 func (ts *TokenExchangeTestSuite) exchangeToken(requestBody string, authHeader string) (*TokenExchangeResponse, int, error) {
 	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/token", strings.NewReader(requestBody))
 	if err != nil {
@@ -383,10 +427,10 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_WithAudience() {
 	ts.Equal(http.StatusOK, statusCode)
 	ts.NotEmpty(resp.AccessToken)
 
-	// Verify audience in JWT
+	// Verify audience in JWT contains the requested audience
 	claims, err := testutils.DecodeJWT(resp.AccessToken)
 	ts.Require().NoError(err)
-	ts.Equal("https://api.example.com", claims.Aud, "Audience should match requested audience")
+	ts.assertAudienceContains(claims, "https://api.example.com")
 }
 
 // TestTokenExchange_WithResource tests token exchange with resource parameter
@@ -407,7 +451,7 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_WithResource() {
 	// Verify resource is used as audience
 	claims, err := testutils.DecodeJWT(resp.AccessToken)
 	ts.Require().NoError(err)
-	ts.Equal("https://resource.example.com", claims.Aud, "Audience should match resource parameter")
+	ts.assertAudienceContains(claims, "https://resource.example.com")
 }
 
 // TestTokenExchange_WithRequestedTokenType tests token exchange with requested_token_type

--- a/tests/integration/resource/action_test.go
+++ b/tests/integration/resource/action_test.go
@@ -57,7 +57,7 @@ func (suite *ActionAPITestSuite) SetupSuite() {
 	rsReq := CreateResourceServerRequest{
 		Name:               "Action Test Server",
 		Description:        "Resource server for action testing",
-		Identifier:         "action-test-server",
+		Handle:             "action-test-server",
 		OUID: ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -109,7 +109,7 @@ func (suite *ActionAPITestSuite) TestCreateActionAtResourceServer() {
 	suite.Equal(req.Name, action.Name)
 	suite.Equal(req.Handle, action.Handle)
 	suite.Equal(req.Description, action.Description)
-	suite.Equal("read", action.Permission, "Server-level action permission should be just the handle")
+	suite.Equal("action-test-server:read", action.Permission, "Server-level action permission should be just the handle")
 }
 
 func (suite *ActionAPITestSuite) TestCreateActionAtResourceServerDuplicateHandle() {
@@ -191,12 +191,12 @@ func (suite *ActionAPITestSuite) TestListActionsAtResourceServer() {
 		if action.ID == action1ID {
 			foundAction1 = true
 			suite.Equal(action1.Name, action.Name)
-			suite.Equal("list-action-1", action.Permission, "Permission should be returned in list response")
+			suite.Equal("action-test-server:list-action-1", action.Permission, "Permission should be returned in list response")
 		}
 		if action.ID == action2ID {
 			foundAction2 = true
 			suite.Equal(action2.Name, action.Name)
-			suite.Equal("list-action-2", action.Permission, "Permission should be returned in list response")
+			suite.Equal("action-test-server:list-action-2", action.Permission, "Permission should be returned in list response")
 		}
 	}
 	suite.True(foundAction1, "Should find first action")
@@ -228,7 +228,7 @@ func (suite *ActionAPITestSuite) TestUpdateActionAtResourceServer() {
 	suite.Equal(updateReq.Name, action.Name, "Name should be mutable")
 	suite.Equal(req.Handle, action.Handle, "Handle should be immutable")
 	suite.Equal(updateReq.Description, action.Description)
-	suite.Equal("update-action", action.Permission, "Permission should be immutable")
+	suite.Equal("action-test-server:update-action", action.Permission, "Permission should be immutable")
 }
 
 func (suite *ActionAPITestSuite) TestDeleteActionAtResourceServer() {
@@ -270,7 +270,7 @@ func (suite *ActionAPITestSuite) TestCreateActionAtResource() {
 	suite.Require().NoError(err)
 	suite.Equal(req.Name, action.Name)
 	suite.Equal(req.Description, action.Description)
-	suite.Equal("test-resource:view", action.Permission, "Action permission should be resource:action")
+	suite.Equal("action-test-server:test-resource:view", action.Permission, "Action permission should be resource:action")
 }
 
 func (suite *ActionAPITestSuite) TestCreateActionAtResourceDuplicateHandle() {
@@ -552,6 +552,7 @@ func (suite *ActionAPITestSuite) TestActionPermissionDerivationWithCustomDelimit
 	delimiter := "-"
 	rsReq := CreateResourceServerRequest{
 		Name:               "Action Permission Test Server",
+		Handle:            "actionpermtest",
 		OUID: suite.ouID,
 		Delimiter:          &delimiter,
 	}
@@ -600,7 +601,7 @@ func (suite *ActionAPITestSuite) TestActionPermissionDerivationWithCustomDelimit
 
 	action, err := getActionAtResource(customRsID, level3ID, actionID)
 	suite.Require().NoError(err)
-	suite.Equal("hotels-rooms-suites-book", action.Permission, "Deeply nested action permission should use custom delimiter")
+	suite.Equal("actionpermtest-hotels-rooms-suites-book", action.Permission, "Deeply nested action permission should use custom delimiter")
 }
 
 // Helper functions

--- a/tests/integration/resource/models.go
+++ b/tests/integration/resource/models.go
@@ -23,6 +23,7 @@ type ResourceServerResponse struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
 	Description        string `json:"description,omitempty"`
+	Handle             string `json:"handle"`
 	Identifier         string `json:"identifier,omitempty"`
 	OUID               string `json:"ouId"`
 	Delimiter          string `json:"delimiter"`
@@ -99,6 +100,7 @@ type ResourcePermissionListResponse struct {
 type CreateResourceServerRequest struct {
 	Name               string  `json:"name"`
 	Description        string  `json:"description,omitempty"`
+	Handle             string  `json:"handle"`
 	Identifier         string  `json:"identifier,omitempty"`
 	OUID               string  `json:"ouId"`
 	Delimiter          *string `json:"delimiter,omitempty"`
@@ -106,10 +108,11 @@ type CreateResourceServerRequest struct {
 
 // UpdateResourceServerRequest represents the request to update a resource server.
 type UpdateResourceServerRequest struct {
-	Name               string `json:"name"`
-	Description        string `json:"description,omitempty"`
-	Identifier         string `json:"identifier,omitempty"`
-	OUID               string `json:"ouId"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Handle      string `json:"handle,omitempty"`
+	Identifier  string `json:"identifier,omitempty"`
+	OUID        string `json:"ouId"`
 }
 
 // CreateResourceRequest represents the request to create a resource.

--- a/tests/integration/resource/resource_server_test.go
+++ b/tests/integration/resource/resource_server_test.go
@@ -72,7 +72,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServer() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Booking System",
 		Description:        "Handles all booking operations",
-		Identifier:         "booking-system",
+		Handle:            "booking-system",
 		OUID: testOUID,
 	}
 
@@ -86,7 +86,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServer() {
 	suite.Require().NoError(err)
 	suite.Equal(reqBody.Name, rs.Name)
 	suite.Equal(reqBody.Description, rs.Description)
-	suite.Equal(reqBody.Identifier, rs.Identifier)
+	suite.Equal(reqBody.Handle, rs.Handle)
 	suite.Equal(reqBody.OUID, rs.OUID)
 	suite.NotEmpty(rs.Delimiter, "Delimiter should be set to default value")
 	suite.Equal(":", rs.Delimiter, "Default delimiter should be ':' based on default configuration")
@@ -95,6 +95,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServer() {
 func (suite *ResourceServerAPITestSuite) TestCreateResourceServerWithoutOptionalFields() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Minimal Resource Server",
+		Handle:            "minimal-rs",
 		OUID: testOUID,
 	}
 
@@ -108,12 +109,14 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerWithoutOptional
 	suite.Require().NoError(err)
 	suite.Equal(reqBody.Name, rs.Name)
 	suite.Empty(rs.Description)
+	suite.Equal(reqBody.Handle, rs.Handle)
 	suite.Empty(rs.Identifier)
 }
 
 func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateName() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Duplicate Resource Server",
+		Handle:            "dup-name-1",
 		OUID: testOUID,
 	}
 
@@ -124,6 +127,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateName()
 	// Try with same name - should fail
 	reqBody2 := CreateResourceServerRequest{
 		Name:               "Duplicate Resource Server",
+		Handle:            "dup-name-2",
 		OUID: testOUID,
 	}
 	_, err = createResourceServer(reqBody2)
@@ -131,10 +135,10 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateName()
 	suite.Contains(err.Error(), "409")
 }
 
-func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateIdentifier() {
+func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateHandle() {
 	reqBody1 := CreateResourceServerRequest{
 		Name:               "Resource Server 1",
-		Identifier:         "same-identifier",
+		Handle:            "same-handler",
 		OUID: testOUID,
 	}
 
@@ -144,7 +148,31 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateIdenti
 
 	reqBody2 := CreateResourceServerRequest{
 		Name:               "Resource Server 2",
-		Identifier:         "same-identifier",
+		Handle:            "same-handler",
+		OUID: testOUID,
+	}
+
+	_, err = createResourceServer(reqBody2)
+	suite.Error(err, "Should fail with duplicate handle")
+	suite.Contains(err.Error(), "409")
+}
+
+func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateIdentifier() {
+	reqBody1 := CreateResourceServerRequest{
+		Name:               "Resource Server With Identifier 1",
+		Handle:            "dup-id-1",
+		Identifier:         "https://api.example.com/booking/",
+		OUID: testOUID,
+	}
+
+	rsID1, err := createResourceServer(reqBody1)
+	suite.Require().NoError(err)
+	defer deleteResourceServer(rsID1)
+
+	reqBody2 := CreateResourceServerRequest{
+		Name:               "Resource Server With Identifier 2",
+		Handle:            "dup-id-2",
+		Identifier:         "https://api.example.com/booking/",
 		OUID: testOUID,
 	}
 
@@ -156,6 +184,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDuplicateIdenti
 func (suite *ResourceServerAPITestSuite) TestCreateResourceServerInvalidOU() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Invalid OU Resource Server",
+		Handle:            "invalid-ou-rs",
 		OUID: "00000000-0000-0000-0000-000000000000",
 	}
 
@@ -168,6 +197,7 @@ func (suite *ResourceServerAPITestSuite) TestGetResourceServer() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Get Test Resource Server",
 		Description:        "Resource server for get test",
+		Handle:            "get-test-rs",
 		OUID: testOUID,
 	}
 
@@ -193,12 +223,14 @@ func (suite *ResourceServerAPITestSuite) TestListResourceServers() {
 	rs1 := CreateResourceServerRequest{
 		Name:               "List Resource Server 1",
 		Description:        "First resource server",
+		Handle:            "listrs1",
 		OUID: testOUID,
 		Delimiter:          &delimiter,
 	}
 	rs2 := CreateResourceServerRequest{
 		Name:               "List Resource Server 2",
 		Description:        "Second resource server",
+		Handle:            "list-rs-2",
 		OUID: testOUID,
 	}
 
@@ -246,11 +278,12 @@ func (suite *ResourceServerAPITestSuite) TestListResourceServersWithPagination()
 func (suite *ResourceServerAPITestSuite) TestUpdateResourceServer() {
 	delimiter := "/"
 	reqBody := CreateResourceServerRequest{
-		Name:               "Update Test Resource Server",
-		Description:        "Original description",
-		Identifier:         "original-identifier",
-		OUID: testOUID,
-		Delimiter:          &delimiter,
+		Name:        "Update Test Resource Server",
+		Description: "Original description",
+		Handle:      "original-handler",
+		Identifier:  "https://api.example.com/original/",
+		OUID:        testOUID,
+		Delimiter:   &delimiter,
 	}
 
 	rsID, err := createResourceServer(reqBody)
@@ -258,10 +291,11 @@ func (suite *ResourceServerAPITestSuite) TestUpdateResourceServer() {
 	defer deleteResourceServer(rsID)
 
 	updateReq := UpdateResourceServerRequest{
-		Name:               "Updated Resource Server",
-		Description:        "Updated description",
-		Identifier:         "updated-identifier",
-		OUID: testOUID,
+		Name:        "Updated Resource Server",
+		Description: "Updated description",
+		Handle:      "updated-handler",
+		Identifier:  "https://api.example.com/updated/",
+		OUID:        testOUID,
 	}
 
 	err = updateResourceServer(rsID, updateReq)
@@ -271,8 +305,64 @@ func (suite *ResourceServerAPITestSuite) TestUpdateResourceServer() {
 	suite.Require().NoError(err)
 	suite.Equal(updateReq.Name, rs.Name)
 	suite.Equal(updateReq.Description, rs.Description)
-	suite.Equal(updateReq.Identifier, rs.Identifier)
+	suite.Equal(updateReq.Handle, rs.Handle, "Handle should be updated")
+	suite.Equal(updateReq.Identifier, rs.Identifier, "Identifier should be updated")
 	suite.Equal("/", rs.Delimiter, "Delimiter should remain unchanged after update")
+}
+
+func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerPreservesHandleWhenOmitted() {
+	reqBody := CreateResourceServerRequest{
+		Name:   "Preserve Handle RS",
+		Handle: "preserve-me",
+		OUID:   testOUID,
+	}
+
+	rsID, err := createResourceServer(reqBody)
+	suite.Require().NoError(err)
+	defer deleteResourceServer(rsID)
+
+	updateReq := UpdateResourceServerRequest{
+		Name: "Preserve Handle RS Updated",
+		OUID: testOUID,
+	}
+
+	err = updateResourceServer(rsID, updateReq)
+	suite.Require().NoError(err)
+
+	rs, err := getResourceServer(rsID)
+	suite.Require().NoError(err)
+	suite.Equal("preserve-me", rs.Handle, "Handle should be preserved when not provided in update")
+}
+
+func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerHandleConflict() {
+	rs1 := CreateResourceServerRequest{
+		Name:   "Handle Conflict RS 1",
+		Handle: "handle-conflict-1",
+		OUID:   testOUID,
+	}
+	rs2 := CreateResourceServerRequest{
+		Name:   "Handle Conflict RS 2",
+		Handle: "handle-conflict-2",
+		OUID:   testOUID,
+	}
+
+	rsID1, err := createResourceServer(rs1)
+	suite.Require().NoError(err)
+	defer deleteResourceServer(rsID1)
+
+	rsID2, err := createResourceServer(rs2)
+	suite.Require().NoError(err)
+	defer deleteResourceServer(rsID2)
+
+	updateReq := UpdateResourceServerRequest{
+		Name:   "Handle Conflict RS 2",
+		Handle: "handle-conflict-1",
+		OUID:   testOUID,
+	}
+
+	err = updateResourceServer(rsID2, updateReq)
+	suite.Error(err, "Should fail with handle conflict")
+	suite.Contains(err.Error(), "409")
 }
 
 func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerNotFound() {
@@ -289,10 +379,12 @@ func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerNotFound() {
 func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerNameConflict() {
 	rs1 := CreateResourceServerRequest{
 		Name:               "Conflict Resource Server 1",
+		Handle:            "conflict-rs-1",
 		OUID: testOUID,
 	}
 	rs2 := CreateResourceServerRequest{
 		Name:               "Conflict Resource Server 2",
+		Handle:            "conflict-rs-2",
 		OUID: testOUID,
 	}
 
@@ -315,42 +407,22 @@ func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerNameConflict() 
 	suite.Contains(err.Error(), "409")
 }
 
-func (suite *ResourceServerAPITestSuite) TestUpdateResourceServerIdentifierConflict() {
-	// Create two resource servers with different identifiers
-	rs1 := CreateResourceServerRequest{
-		Name:               "Resource Server 1",
-		Identifier:         "identifier-1",
-		OUID: testOUID,
-	}
-	rs2 := CreateResourceServerRequest{
-		Name:               "Resource Server 2",
-		Identifier:         "identifier-2",
-		OUID: testOUID,
+func (suite *ResourceServerAPITestSuite) TestCreateResourceServerDelimiterInHandle() {
+	reqBody := CreateResourceServerRequest{
+		Name:    "Delimiter In Handle RS",
+		Handle: "foo:bar",
+		OUID:    testOUID,
 	}
 
-	rsID1, err := createResourceServer(rs1)
-	suite.Require().NoError(err)
-	defer deleteResourceServer(rsID1)
-
-	rsID2, err := createResourceServer(rs2)
-	suite.Require().NoError(err)
-	defer deleteResourceServer(rsID2)
-
-	// Try to update second server to have the same identifier as first
-	updateReq := UpdateResourceServerRequest{
-		Name:               "Resource Server 2",
-		Identifier:         "identifier-1",
-		OUID: testOUID,
-	}
-
-	err = updateResourceServer(rsID2, updateReq)
-	suite.Error(err, "Should fail with identifier conflict")
-	suite.Contains(err.Error(), "409")
+	_, err := createResourceServer(reqBody)
+	suite.Error(err, "Should fail when handle contains the default delimiter")
+	suite.Contains(err.Error(), "400")
 }
 
 func (suite *ResourceServerAPITestSuite) TestDeleteResourceServer() {
 	reqBody := CreateResourceServerRequest{
 		Name:               "Delete Test Resource Server",
+		Handle:            "delete-test-rs",
 		OUID: testOUID,
 	}
 
@@ -375,10 +447,11 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerWithVariousDeli
 	// Valid delimiters: a-zA-Z0-9._:-/
 	validDelimiters := []string{":", ".", "-", "_", "/"}
 
-	for _, delim := range validDelimiters {
+	for i, delim := range validDelimiters {
 		delimiter := delim
 		reqBody := CreateResourceServerRequest{
 			Name:               "Server With " + delim + " Delimiter",
+			Handle:            fmt.Sprintf("delimtest%d", i),
 			OUID: testOUID,
 			Delimiter:          &delimiter,
 		}
@@ -412,6 +485,7 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerWithVariousDeli
 		delimiter := tc.value
 		reqBody := CreateResourceServerRequest{
 			Name:               "Server With " + tc.description + " Delimiter",
+			Handle:            "invalid" + tc.description,
 			OUID: testOUID,
 			Delimiter:          &delimiter,
 		}

--- a/tests/integration/resource/resource_test.go
+++ b/tests/integration/resource/resource_test.go
@@ -56,7 +56,7 @@ func (suite *ResourceAPITestSuite) SetupSuite() {
 	rsReq := CreateResourceServerRequest{
 		Name:               "Resource Test Server",
 		Description:        "Resource server for resource testing",
-		Identifier:         "resource-test-server",
+		Handle:             "resource-test-server",
 		OUID: ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -94,7 +94,7 @@ func (suite *ResourceAPITestSuite) TestCreateResource() {
 	suite.Equal(req.Handle, res.Handle)
 	suite.Equal(req.Description, res.Description)
 	suite.Nil(res.Parent)
-	suite.Equal("hotels", res.Permission, "Top-level resource permission should be just the handle")
+	suite.Equal("resource-test-server:hotels", res.Permission, "Top-level resource permission should be just the handle")
 }
 
 func (suite *ResourceAPITestSuite) TestCreateResourceWithParent() {
@@ -127,7 +127,7 @@ func (suite *ResourceAPITestSuite) TestCreateResourceWithParent() {
 	suite.Equal(childReq.Handle, child.Handle)
 	suite.NotNil(child.Parent)
 	suite.Equal(parentID, *child.Parent)
-	suite.Equal("bookings:confirmed", child.Permission, "Nested resource permission should be parent:child")
+	suite.Equal("resource-test-server:bookings:confirmed", child.Permission, "Nested resource permission should be parent:child")
 }
 
 func (suite *ResourceAPITestSuite) TestCreateResourceDuplicateHandle() {
@@ -266,12 +266,12 @@ func (suite *ResourceAPITestSuite) TestListResources() {
 		if res.ID == res1ID {
 			foundRes1 = true
 			suite.Equal(res1.Name, res.Name)
-			suite.Equal("list-resource-1", res.Permission, "Permission should be returned in list response")
+			suite.Equal("resource-test-server:list-resource-1", res.Permission, "Permission should be returned in list response")
 		}
 		if res.ID == res2ID {
 			foundRes2 = true
 			suite.Equal(res2.Name, res.Name)
-			suite.Equal("list-resource-2", res.Permission, "Permission should be returned in list response")
+			suite.Equal("resource-test-server:list-resource-2", res.Permission, "Permission should be returned in list response")
 		}
 	}
 	suite.True(foundRes1, "Should find first resource")
@@ -389,7 +389,7 @@ func (suite *ResourceAPITestSuite) TestUpdateResource() {
 	suite.Equal(req.Handle, res.Handle, "Handle should be immutable")
 	suite.Equal(updateReq.Description, res.Description)
 	suite.Nil(res.Parent, "Parent should remain immutable")
-	suite.Equal("update-test-resource", res.Permission, "Permission should be immutable")
+	suite.Equal("resource-test-server:update-test-resource", res.Permission, "Permission should be immutable")
 }
 
 func (suite *ResourceAPITestSuite) TestUpdateResourceHandleIsImmutable() {
@@ -488,6 +488,7 @@ func (suite *ResourceAPITestSuite) TestResourcePermissionDerivationWithCustomDel
 	delimiter := "."
 	rsReq := CreateResourceServerRequest{
 		Name:               "Custom Delimiter Server",
+		Handle:            "custom-delim-server",
 		OUID: suite.ouID,
 		Delimiter:          &delimiter,
 	}
@@ -507,7 +508,7 @@ func (suite *ResourceAPITestSuite) TestResourcePermissionDerivationWithCustomDel
 
 	level1, err := getResource(customRsID, level1ID)
 	suite.Require().NoError(err)
-	suite.Equal("org", level1.Permission, "Top-level resource permission should be just the handle")
+	suite.Equal("custom-delim-server.org", level1.Permission, "Top-level resource permission should be just the handle")
 
 	// Create level 2: org.dept
 	level2Req := CreateResourceRequest{
@@ -521,7 +522,7 @@ func (suite *ResourceAPITestSuite) TestResourcePermissionDerivationWithCustomDel
 
 	level2, err := getResource(customRsID, level2ID)
 	suite.Require().NoError(err)
-	suite.Equal("org.dept", level2.Permission, "Permission should use custom delimiter")
+	suite.Equal("custom-delim-server.org.dept", level2.Permission, "Permission should use custom delimiter")
 
 	// Create level 3: org.dept.team
 	level3Req := CreateResourceRequest{
@@ -535,7 +536,7 @@ func (suite *ResourceAPITestSuite) TestResourcePermissionDerivationWithCustomDel
 
 	level3, err := getResource(customRsID, level3ID)
 	suite.Require().NoError(err)
-	suite.Equal("org.dept.team", level3.Permission, "Deeply nested permission should use custom delimiter")
+	suite.Equal("custom-delim-server.org.dept.team", level3.Permission, "Deeply nested permission should use custom delimiter")
 }
 
 func (suite *ResourceAPITestSuite) TestDeleteResourceWithChildren() {

--- a/tests/integration/resource/validation_test.go
+++ b/tests/integration/resource/validation_test.go
@@ -56,6 +56,7 @@ func (suite *ValidationTestSuite) SetupSuite() {
 	rsReq := CreateResourceServerRequest{
 		Name:               "validation-test-server",
 		Description:        "Resource server for validation testing",
+		Handle:            "validation-test",
 		OUID: ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -100,6 +101,7 @@ func (suite *ValidationTestSuite) TestUpdateResourceServerMissingName() {
 	// Create a resource server first
 	createReq := CreateResourceServerRequest{
 		Name:               "update-validation-server",
+		Handle:            "update-validation",
 		OUID: suite.ouID,
 	}
 	rsID, err := createResourceServer(createReq)
@@ -121,6 +123,7 @@ func (suite *ValidationTestSuite) TestDeleteResourceServerWithDependencies() {
 	// Create resource server
 	rsReq := CreateResourceServerRequest{
 		Name:               "server-with-dependencies",
+		Handle:            "server-with-deps",
 		OUID: suite.ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -147,6 +150,7 @@ func (suite *ValidationTestSuite) TestDeleteResourceServerWithActions() {
 	// Create resource server
 	rsReq := CreateResourceServerRequest{
 		Name:               "server-with-actions",
+		Handle:            "server-with-actions",
 		OUID: suite.ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -310,6 +314,7 @@ func (suite *ValidationTestSuite) TestCreateResourceInDifferentResourceServer() 
 	// Create second resource server
 	rsReq := CreateResourceServerRequest{
 		Name:               "second-server",
+		Handle:            "second-server",
 		OUID: suite.ouID,
 	}
 	rs2ID, err := createResourceServer(rsReq)
@@ -341,6 +346,7 @@ func (suite *ValidationTestSuite) TestGetResourceFromWrongResourceServer() {
 	// Create second resource server
 	rsReq := CreateResourceServerRequest{
 		Name:               "wrong-server",
+		Handle:            "wrong-server",
 		OUID: suite.ouID,
 	}
 	rs2ID, err := createResourceServer(rsReq)
@@ -386,6 +392,7 @@ func (suite *ValidationTestSuite) TestInvalidContentType() {
 
 	req := CreateResourceServerRequest{
 		Name:               "test-server",
+		Handle:            "test-server",
 		OUID: suite.ouID,
 	}
 	body, _ := json.Marshal(req)
@@ -412,6 +419,7 @@ func (suite *ValidationTestSuite) TestCreateResourceHandleContainsDelimiter() {
 	// First create a resource server to get its delimiter
 	rsReq := CreateResourceServerRequest{
 		Name:               "delimiter-test-server",
+		Handle:            "delimiter-test",
 		OUID: suite.ouID,
 	}
 	rsID, err := createResourceServer(rsReq)
@@ -438,6 +446,7 @@ func (suite *ValidationTestSuite) TestCreateActionHandleContainsDelimiter() {
 	// First create a resource server to get its delimiter
 	rsReq := CreateResourceServerRequest{
 		Name:               "action-delimiter-test-server",
+		Handle:            "action-delim-test",
 		OUID: suite.ouID,
 	}
 	rsID, err := createResourceServer(rsReq)

--- a/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
@@ -1,7 +1,7 @@
 id: decl-rs-1
 name: Declarative Resource Server
 description: A declarative test resource server
-identifier: decl-rs-1
+handle: decl-rs-1
 ou_id: decl-ou-1
 delimiter: ":"
 resources:

--- a/tests/integration/testutils/jwt_utils.go
+++ b/tests/integration/testutils/jwt_utils.go
@@ -28,7 +28,7 @@ import (
 // JWTClaims represents the decoded JWT claims.
 type JWTClaims struct {
 	Sub       string                 `json:"sub"`
-	Aud       string                 `json:"aud"`
+	Aud       string                 `json:"-"` // Handled manually — supports both string and array per RFC 7519
 	Iss       string                 `json:"iss"`
 	Exp       float64                `json:"exp"`
 	Iat       float64                `json:"iat"`
@@ -70,6 +70,18 @@ func DecodeJWT(token string) (*JWTClaims, error) {
 
 	// Store all claims in Additional for flexible access
 	claims.Additional = allClaims
+
+	// Handle aud claim (can be string or array per RFC 7519)
+	switch v := allClaims["aud"].(type) {
+	case string:
+		claims.Aud = v
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				claims.Aud = s
+			}
+		}
+	}
 
 	return &claims, nil
 }

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -189,6 +189,7 @@ type ResourceServer struct {
 	ID          string  `json:"id,omitempty"`
 	Name        string  `json:"name"`
 	Description string  `json:"description,omitempty"`
+	Handle      string  `json:"handle,omitempty"`
 	Identifier  string  `json:"identifier,omitempty"`
 	OUID        string  `json:"ouId"`
 	Delimiter   *string `json:"delimiter,omitempty"`


### PR DESCRIPTION
### Purpose
Add support for audience-restricted access tokens using the `resource` parameter per RFC 8707. Resource Servers now have `handler` (permission prefix) and `identifier` (external URI identity) fields, both immutable after creation. Permission strings are prefixed with the handler (e.g., `booking-api:users:read`). The JWT `aud` claim becomes a JSON array when a `resource` parameter targets an RS, preserving string format for backwards compatibility. Requested scopes are validated against the target Resource Server's permissions in both the token and authorize endpoints.


### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
01. The permission string now has the resource server handler as well. Previously, if we have a resource server as below
```
Resource Server configuration:
  identifier: "https://api.example.com/booking/"
  delimiter: ":"
  Resource:
      handle: reservations
      Action: create
```
Then the permission string will be `reservations:create`

With this change the resource server will have a handler and it will add to the permission string
```
Resource Server configuration:
  identifier: "https://api.example.com/booking/"
  handle: "booking-api"
  delimiter: ":"
  Resource:
      handle: reservations
      Action: create
```
Permission string: `booking-api:reservations:create`

02. JWT `aud` claim is not multi value supported. If it has one value, it return as a string. If it has more than one, then it will be a json array.


### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/2197

### Related PRs
- N/A




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multi-resource (RFC 8707) parameters across auth and token flows.
  * Tokens now support multiple audiences.

* **Improvements**
  * Resource server "handle" exposed in APIs (create/update/response) and used to prefix permission strings.
  * Stronger validation: handle uniqueness, delimiter checks, and resource-server resolution for permissions/audiences.
  * External identifier length increased for longer URIs.

* **Tests**
  * Extensive test updates covering multi-resource flows, audiences, handles, and permission derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->