### PR TITLE
Unify UUID copy UIs + Add Delete capability to Applications edit page's Danger Zone

### DIFF
--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
@@ -17,7 +17,7 @@
  */
 
 import {SettingsCard} from '@thunder/components';
-import {Typography, Button} from '@wso2/oxygen-ui';
+import {Typography, Button, Divider} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 
@@ -28,34 +28,69 @@ interface DangerZoneSectionProps {
   /**
    * Callback function to open the regenerate client secret confirmation dialog
    */
-  onRegenerateClick: () => void;
+  onRegenerateClick?: () => void;
+  /**
+   * Whether to show the regenerate client secret section (only for confidential clients)
+   */
+  showRegenerateSecret?: boolean;
+  /**
+   * Callback function to open the delete application confirmation dialog
+   */
+  onDeleteClick: () => void;
 }
 
 /**
  * Section component displaying the danger zone with destructive actions.
  *
- * Displays a regenerate client secret button for rotating the application's client secret.
- * This action will invalidate the current client secret and all existing tokens.
+ * Displays a regenerate client secret button (for confidential clients) and a
+ * delete application button. These actions are irreversible.
  *
  * @param props - Component props
  * @returns Danger zone UI within a SettingsCard
  */
-export default function DangerZoneSection({onRegenerateClick}: DangerZoneSectionProps): JSX.Element {
+export default function DangerZoneSection({
+  onRegenerateClick = undefined,
+  showRegenerateSecret = false,
+  onDeleteClick,
+}: DangerZoneSectionProps): JSX.Element {
   const {t} = useTranslation();
 
   return (
     <SettingsCard
-      title={t('applications:edit.general.sections.dangerZone.title')}
-      description={t('applications:edit.general.sections.dangerZone.description')}
+      title={t('applications:edit.general.sections.dangerZone.title', 'Danger Zone')}
+      description={t(
+        'applications:edit.general.sections.dangerZone.description',
+        'Actions in this section are irreversible. Proceed with caution.',
+      )}
     >
+      {showRegenerateSecret && (
+        <>
+          <Typography variant="h6" gutterBottom color="error">
+            {t('applications:edit.general.sections.dangerZone.regenerateSecret.title', 'Regenerate Client Secret')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+            {t(
+              'applications:edit.general.sections.dangerZone.regenerateSecret.description',
+              'Regenerating the client secret will immediately invalidate the current client secret and cannot be undone.',
+            )}
+          </Typography>
+          <Button variant="contained" color="error" onClick={onRegenerateClick}>
+            {t('applications:edit.general.sections.dangerZone.regenerateSecret.button', 'Regenerate Client Secret')}
+          </Button>
+          <Divider sx={{my: 3}} />
+        </>
+      )}
       <Typography variant="h6" gutterBottom color="error">
-        {t('applications:edit.general.sections.dangerZone.regenerateSecret.title')}
+        {t('applications:edit.general.sections.dangerZone.deleteApplication.title', 'Delete Application')}
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-        {t('applications:edit.general.sections.dangerZone.regenerateSecret.description')}
+        {t(
+          'applications:edit.general.sections.dangerZone.deleteApplication.description',
+          'Permanently delete this application and all associated data. This action cannot be undone.',
+        )}
       </Typography>
-      <Button variant="contained" color="error" onClick={onRegenerateClick}>
-        {t('applications:edit.general.sections.dangerZone.regenerateSecret.button')}
+      <Button variant="contained" color="error" onClick={onDeleteClick}>
+        {t('applications:edit.general.sections.dangerZone.deleteApplication.button', 'Delete Application')}
       </Button>
     </SettingsCard>
   );

--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -25,6 +25,7 @@ import QuickCopySection from './QuickCopySection';
 import type {Application} from '../../../models/application';
 import {TokenEndpointAuthMethods} from '../../../models/oauth';
 import type {OAuth2Config} from '../../../models/oauth';
+import ApplicationDeleteDialog from '../../ApplicationDeleteDialog';
 import ClientSecretSuccessDialog from '../../ClientSecretSuccessDialog';
 import RegenerateSecretDialog from '../../RegenerateSecretDialog';
 
@@ -60,6 +61,10 @@ interface EditGeneralSettingsProps {
    * @param fieldName - The name of the field being copied
    */
   onCopyToClipboard: (text: string, fieldName: string) => Promise<void>;
+  /**
+   * Callback invoked after the application is successfully deleted
+   */
+  onDeleteSuccess?: () => void;
 }
 
 /**
@@ -80,9 +85,11 @@ export default function EditGeneralSettings({
   oauth2Config = undefined,
   copiedField,
   onCopyToClipboard,
+  onDeleteSuccess = undefined,
 }: EditGeneralSettingsProps): JSX.Element {
   const [regenerateDialogOpen, setRegenerateDialogOpen] = useState(false);
   const [secretDialogOpen, setSecretDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [newClientSecret, setNewClientSecret] = useState<string>('');
 
   const isConfidentialClient =
@@ -118,7 +125,11 @@ export default function EditGeneralSettings({
           oauth2Config={oauth2Config}
           onFieldChange={onFieldChange}
         />
-        {isConfidentialClient && <DangerZoneSection onRegenerateClick={handleRegenerateClick} />}
+        <DangerZoneSection
+          showRegenerateSecret={isConfidentialClient}
+          onRegenerateClick={handleRegenerateClick}
+          onDeleteClick={() => setDeleteDialogOpen(true)}
+        />
       </Stack>
 
       {/* Regenerate Client Secret Confirmation Dialog */}
@@ -134,6 +145,14 @@ export default function EditGeneralSettings({
         open={secretDialogOpen}
         clientSecret={newClientSecret}
         onClose={handleSecretDialogClose}
+      />
+
+      {/* Delete Application Confirmation Dialog */}
+      <ApplicationDeleteDialog
+        open={deleteDialogOpen}
+        applicationId={application.id}
+        onClose={() => setDeleteDialogOpen(false)}
+        onSuccess={onDeleteSuccess}
       />
     </>
   );

--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/__tests__/DangerZoneSection.test.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/__tests__/DangerZoneSection.test.tsx
@@ -27,11 +27,15 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'applications:edit.general.sections.dangerZone.title': 'Danger Zone',
         'applications:edit.general.sections.dangerZone.description':
-          'Irreversible and destructive actions for this application',
+          'Actions in this section are irreversible. Proceed with caution.',
         'applications:edit.general.sections.dangerZone.regenerateSecret.title': 'Regenerate Client Secret',
         'applications:edit.general.sections.dangerZone.regenerateSecret.description':
-          'Regenerating the client secret will immediately invalidate the current client secret and generate a new one. All active access tokens will be revoked and the application will stop working until the new client secret is updated in your application configuration.',
+          'Regenerating the client secret will immediately invalidate the current client secret and cannot be undone.',
         'applications:edit.general.sections.dangerZone.regenerateSecret.button': 'Regenerate Client Secret',
+        'applications:edit.general.sections.dangerZone.deleteApplication.title': 'Delete Application',
+        'applications:edit.general.sections.dangerZone.deleteApplication.description':
+          'Permanently delete this application and all associated data. This action cannot be undone.',
+        'applications:edit.general.sections.dangerZone.deleteApplication.button': 'Delete Application',
       };
       return translations[key] ?? key;
     },
@@ -40,6 +44,7 @@ vi.mock('react-i18next', () => ({
 
 describe('DangerZoneSection', () => {
   const mockOnRegenerateClick = vi.fn();
+  const mockOnDeleteClick = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,38 +55,76 @@ describe('DangerZoneSection', () => {
   });
 
   it('should render the danger zone section', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
 
     expect(screen.getByText('Danger Zone')).toBeInTheDocument();
-    expect(screen.getByText('Irreversible and destructive actions for this application')).toBeInTheDocument();
+    expect(screen.getByText('Actions in this section are irreversible. Proceed with caution.')).toBeInTheDocument();
   });
 
-  it('should render revoke application title', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+  it('should always render delete application section', () => {
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
 
-    const heading = screen.getByRole('heading', {name: 'Regenerate Client Secret', level: 6});
-    expect(heading).toBeInTheDocument();
-  });
-
-  it('should render warning description', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
-
+    expect(screen.getByRole('heading', {name: 'Delete Application', level: 6})).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'Regenerating the client secret will immediately invalidate the current client secret and generate a new one. All active access tokens will be revoked and the application will stop working until the new client secret is updated in your application configuration.',
-      ),
+      screen.getByText('Permanently delete this application and all associated data. This action cannot be undone.'),
     ).toBeInTheDocument();
   });
 
-  it('should render revoke button', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+  it('should render delete button', () => {
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
 
-    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
-    expect(regenerateButton).toBeInTheDocument();
+    const deleteButton = screen.getByRole('button', {name: 'Delete Application'});
+    expect(deleteButton).toBeInTheDocument();
   });
 
-  it('should call onRegenerateClick when revoke button is clicked', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+  it('should call onDeleteClick when delete button is clicked', () => {
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
+
+    const deleteButton = screen.getByRole('button', {name: 'Delete Application'});
+    fireEvent.click(deleteButton);
+
+    expect(mockOnDeleteClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render delete button with error color', () => {
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
+
+    const deleteButton = screen.getByRole('button', {name: 'Delete Application'});
+    expect(deleteButton).toHaveClass('MuiButton-colorError');
+  });
+
+  it('should not render regenerate secret section by default', () => {
+    renderWithProviders(<DangerZoneSection onDeleteClick={mockOnDeleteClick} />);
+
+    expect(screen.queryByRole('button', {name: 'Regenerate Client Secret'})).not.toBeInTheDocument();
+  });
+
+  it('should render regenerate secret section when showRegenerateSecret is true', () => {
+    renderWithProviders(
+      <DangerZoneSection
+        showRegenerateSecret
+        onRegenerateClick={mockOnRegenerateClick}
+        onDeleteClick={mockOnDeleteClick}
+      />,
+    );
+
+    expect(screen.getByRole('heading', {name: 'Regenerate Client Secret', level: 6})).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Regenerating the client secret will immediately invalidate the current client secret and cannot be undone.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Regenerate Client Secret'})).toBeInTheDocument();
+  });
+
+  it('should call onRegenerateClick when regenerate button is clicked', () => {
+    renderWithProviders(
+      <DangerZoneSection
+        showRegenerateSecret
+        onRegenerateClick={mockOnRegenerateClick}
+        onDeleteClick={mockOnDeleteClick}
+      />,
+    );
 
     const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
     fireEvent.click(regenerateButton);
@@ -89,21 +132,16 @@ describe('DangerZoneSection', () => {
     expect(mockOnRegenerateClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should call onRegenerateClick multiple times when clicked multiple times', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+  it('should render both sections with a divider when showRegenerateSecret is true', () => {
+    renderWithProviders(
+      <DangerZoneSection
+        showRegenerateSecret
+        onRegenerateClick={mockOnRegenerateClick}
+        onDeleteClick={mockOnDeleteClick}
+      />,
+    );
 
-    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
-    fireEvent.click(regenerateButton);
-    fireEvent.click(regenerateButton);
-    fireEvent.click(regenerateButton);
-
-    expect(mockOnRegenerateClick).toHaveBeenCalledTimes(3);
-  });
-
-  it('should render revoke button with error color', () => {
-    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
-
-    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
-    expect(regenerateButton).toHaveClass('MuiButton-colorError');
+    expect(screen.getByRole('button', {name: 'Regenerate Client Secret'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Delete Application'})).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
@@ -58,10 +58,23 @@ vi.mock('../AccessSection', () => ({
 }));
 
 vi.mock('../DangerZoneSection', () => ({
-  default: ({onRegenerateClick}: {onRegenerateClick: () => void}) => (
+  default: ({
+    onRegenerateClick,
+    onDeleteClick,
+    showRegenerateSecret,
+  }: {
+    onRegenerateClick?: () => void;
+    onDeleteClick: () => void;
+    showRegenerateSecret?: boolean;
+  }) => (
     <div data-testid="danger-zone-section">
-      <button type="button" onClick={onRegenerateClick} data-testid="regenerate-button">
-        Regenerate Client Secret
+      {showRegenerateSecret && (
+        <button type="button" onClick={onRegenerateClick} data-testid="regenerate-button">
+          Regenerate Client Secret
+        </button>
+      )}
+      <button type="button" onClick={onDeleteClick} data-testid="delete-button">
+        Delete Application
       </button>
     </div>
   ),
@@ -97,6 +110,30 @@ vi.mock('../../../ClientSecretSuccessDialog', () => ({
       <div data-testid="secret-dialog" data-client-secret={clientSecret}>
         <button type="button" onClick={onClose} data-testid="secret-dialog-close">
           Close Secret Dialog
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../../ApplicationDeleteDialog', () => ({
+  default: ({
+    open,
+    applicationId,
+    onClose,
+    onSuccess,
+  }: {
+    open: boolean;
+    applicationId: string;
+    onClose: () => void;
+    onSuccess?: () => void;
+  }) =>
+    open ? (
+      <div data-testid="delete-dialog" data-application-id={applicationId}>
+        <button type="button" onClick={onClose} data-testid="delete-dialog-close">
+          Cancel
+        </button>
+        <button type="button" onClick={() => onSuccess?.()} data-testid="delete-dialog-success">
+          Confirm Delete
         </button>
       </div>
     ) : null,
@@ -308,9 +345,10 @@ describe('EditGeneralSettings', () => {
       );
 
       expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+      expect(screen.getByTestId('regenerate-button')).toBeInTheDocument();
     });
 
-    it('should not render DangerZoneSection for public client (none auth method)', () => {
+    it('should render DangerZoneSection without regenerate for public client (none auth method)', () => {
       const publicClientConfig: OAuth2Config = {
         clientId: 'public-client-123',
         tokenEndpointAuthMethod: 'none',
@@ -327,10 +365,11 @@ describe('EditGeneralSettings', () => {
         />,
       );
 
-      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+      expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+      expect(screen.queryByTestId('regenerate-button')).not.toBeInTheDocument();
     });
 
-    it('should not render DangerZoneSection when no oauth2Config provided', () => {
+    it('should render DangerZoneSection without regenerate when no oauth2Config provided', () => {
       render(
         <EditGeneralSettings
           application={mockApplication}
@@ -341,10 +380,11 @@ describe('EditGeneralSettings', () => {
         />,
       );
 
-      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+      expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+      expect(screen.queryByTestId('regenerate-button')).not.toBeInTheDocument();
     });
 
-    it('should not render DangerZoneSection for private_key_jwt auth method', () => {
+    it('should render DangerZoneSection without regenerate for private_key_jwt auth method', () => {
       const pkjwtClientConfig: OAuth2Config = {
         clientId: 'pkjwt-client-123',
         tokenEndpointAuthMethod: 'private_key_jwt',
@@ -361,7 +401,8 @@ describe('EditGeneralSettings', () => {
         />,
       );
 
-      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+      expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+      expect(screen.queryByTestId('regenerate-button')).not.toBeInTheDocument();
     });
 
     it('should render DangerZoneSection for client_secret_post auth method', () => {
@@ -383,6 +424,7 @@ describe('EditGeneralSettings', () => {
       );
 
       expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+      expect(screen.getByTestId('regenerate-button')).toBeInTheDocument();
     });
   });
 
@@ -494,6 +536,87 @@ describe('EditGeneralSettings', () => {
       fireEvent.click(closeSecretButton);
 
       expect(screen.queryByTestId('secret-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Delete Application Flow', () => {
+    it('should open delete dialog when delete button is clicked', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const deleteButton = screen.getByTestId('delete-button');
+      fireEvent.click(deleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+    });
+
+    it('should pass application id to delete dialog', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const deleteButton = screen.getByTestId('delete-button');
+      fireEvent.click(deleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toHaveAttribute('data-application-id', 'app-123');
+    });
+
+    it('should close delete dialog when cancel is triggered', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const deleteButton = screen.getByTestId('delete-button');
+      fireEvent.click(deleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+
+      const cancelButton = screen.getByTestId('delete-dialog-close');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should call onDeleteSuccess when delete is confirmed', () => {
+      const mockOnDeleteSuccess = vi.fn();
+
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+          onDeleteSuccess={mockOnDeleteSuccess}
+        />,
+      );
+
+      const deleteButton = screen.getByTestId('delete-button');
+      fireEvent.click(deleteButton);
+
+      const confirmButton = screen.getByTestId('delete-dialog-success');
+      fireEvent.click(confirmButton);
+
+      expect(mockOnDeleteSuccess).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/apps/thunder-console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {CopyableId, ResourceAvatar, UnsavedChangesBar} from '@thunder/components';
+import {ResourceAvatar, UnsavedChangesBar} from '@thunder/components';
 import {useLogger} from '@thunder/logger/react';
 import {
   Box,
@@ -331,12 +331,6 @@ export default function ApplicationEditPage() {
                 </Box>
               ) : null;
             })()}
-
-          {/* Application ID */}
-          <CopyableId
-            value={application.id}
-            copyLabel={t('applications:edit.page.copyApplicationId', 'Copy Application ID')}
-          />
         </PageTitle.SubHeader>
       </PageTitle>
 

--- a/frontend/apps/thunder-console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -400,6 +400,9 @@ export default function ApplicationEditPage() {
             oauth2Config={oauth2Config}
             copiedField={copiedField}
             onCopyToClipboard={handleCopyToClipboard}
+            onDeleteSuccess={() => {
+              handleBack().catch(() => null);
+            }}
           />
         </TabPanel>
 

--- a/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
@@ -17,10 +17,21 @@
  */
 
 import {SettingsCard} from '@thunder/components';
-import {Stack, TextField, Button, IconButton, Typography, InputAdornment, Tooltip} from '@wso2/oxygen-ui';
+import {
+  Stack,
+  TextField,
+  Button,
+  IconButton,
+  Typography,
+  InputAdornment,
+  Tooltip,
+  FormControl,
+  FormLabel,
+} from '@wso2/oxygen-ui';
 import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useRef, useEffect, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import QuickCopySection from './QuickCopySection';
 import type {Group} from '../../../models/group';
 
 interface EditGeneralSettingsProps {
@@ -59,84 +70,96 @@ export default function EditGeneralSettings({group, onDeleteClick}: EditGeneralS
 
   return (
     <Stack spacing={3}>
+      <QuickCopySection group={group} copiedField={copiedField} onCopyToClipboard={handleCopyToClipboard} />
+
       {/* Organization Unit */}
       <SettingsCard
         title={t('groups:edit.general.sections.organizationUnit.title')}
         description={t('groups:edit.general.sections.organizationUnit.description')}
       >
         <Stack spacing={2}>
-          <TextField
-            label={t('groups:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
-            value={group.ouHandle ?? '-'}
-            fullWidth
-            size="small"
-            slotProps={{
-              input: {
-                readOnly: true,
-                endAdornment: group.ouHandle ? (
-                  <InputAdornment position="end">
-                    <Tooltip
-                      title={
-                        copiedField === 'ouHandle'
-                          ? t('common:actions.copied')
-                          : t(
-                              'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
-                              'Copy Organization Unit Handle',
-                            )
-                      }
-                    >
-                      <IconButton
-                        aria-label={t(
-                          'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
-                          'Copy Organization Unit Handle',
-                        )}
-                        onClick={() => {
-                          handleCopyToClipboard(group.ouHandle!, 'ouHandle').catch(() => null);
-                        }}
-                        edge="end"
+          <FormControl fullWidth>
+            <FormLabel htmlFor="ou-handle-input">
+              {t('groups:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
+            </FormLabel>
+            <TextField
+              id="ou-handle-input"
+              value={group.ouHandle ?? '-'}
+              fullWidth
+              size="small"
+              slotProps={{
+                input: {
+                  readOnly: true,
+                  endAdornment: group.ouHandle ? (
+                    <InputAdornment position="end">
+                      <Tooltip
+                        title={
+                          copiedField === 'ouHandle'
+                            ? t('common:actions.copied')
+                            : t(
+                                'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
+                                'Copy Organization Unit Handle',
+                              )
+                        }
                       >
-                        {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ) : undefined,
-              },
-            }}
-            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-          />
-          <TextField
-            label={t('groups:edit.general.sections.organizationUnit.idLabel', 'ID')}
-            value={group.ouId}
-            fullWidth
-            size="small"
-            slotProps={{
-              input: {
-                readOnly: true,
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip
-                      title={
-                        copiedField === 'ouId'
-                          ? t('common:actions.copied')
-                          : t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')
-                      }
-                    >
-                      <IconButton
-                        aria-label={t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')}
-                        onClick={() => {
-                          handleCopyToClipboard(group.ouId, 'ouId').catch(() => null);
-                        }}
-                        edge="end"
+                        <IconButton
+                          aria-label={t(
+                            'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
+                            'Copy Organization Unit Handle',
+                          )}
+                          onClick={() => {
+                            handleCopyToClipboard(group.ouHandle!, 'ouHandle').catch(() => null);
+                          }}
+                          edge="end"
+                        >
+                          {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ) : undefined,
+                },
+              }}
+              sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+            />
+          </FormControl>
+          <FormControl fullWidth>
+            <FormLabel htmlFor="ou-id-input">
+              {t('groups:edit.general.sections.organizationUnit.idLabel', 'ID')}
+            </FormLabel>
+            <TextField
+              id="ou-id-input"
+              value={group.ouId}
+              fullWidth
+              size="small"
+              slotProps={{
+                input: {
+                  readOnly: true,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Tooltip
+                        title={
+                          copiedField === 'ouId'
+                            ? t('common:actions.copied')
+                            : t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')
+                        }
                       >
-                        {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              },
-            }}
-            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-          />
+                        <IconButton
+                          aria-label={t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')}
+                          onClick={() => {
+                            handleCopyToClipboard(group.ouId, 'ouId').catch(() => null);
+                          }}
+                          edge="end"
+                        >
+                          {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+            />
+          </FormControl>
         </Stack>
       </SettingsCard>
 

--- a/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/QuickCopySection.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/QuickCopySection.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunder/components';
+import {Stack, TextField, InputAdornment, Tooltip, IconButton, FormControl, FormLabel} from '@wso2/oxygen-ui';
+import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {useTranslation} from 'react-i18next';
+import type {Group} from '../../../models/group';
+
+interface QuickCopySectionProps {
+  group: Group;
+  copiedField: string | null;
+  onCopyToClipboard: (text: string, fieldName: string) => Promise<void>;
+}
+
+export default function QuickCopySection({group, copiedField, onCopyToClipboard}: QuickCopySectionProps) {
+  const {t} = useTranslation();
+
+  return (
+    <SettingsCard
+      title={t('groups:edit.general.sections.quickCopy.title', 'Quick Copy')}
+      description={t(
+        'groups:edit.general.sections.quickCopy.description',
+        'Copy group identifiers for use in your application.',
+      )}
+    >
+      <Stack spacing={3}>
+        <FormControl fullWidth>
+          <FormLabel htmlFor="group-id-input">
+            {t('groups:edit.general.sections.quickCopy.groupId', 'Group ID')}
+          </FormLabel>
+          <TextField
+            fullWidth
+            id="group-id-input"
+            value={group.id}
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip
+                    title={
+                      copiedField === 'group_id'
+                        ? t('common:actions.copied')
+                        : t('groups:edit.general.sections.quickCopy.copyGroupId')
+                    }
+                  >
+                    <IconButton
+                      aria-label={
+                        copiedField === 'group_id'
+                          ? t('common:actions.copied')
+                          : t('groups:edit.general.sections.quickCopy.copyGroupId')
+                      }
+                      onClick={() => {
+                        onCopyToClipboard(group.id, 'group_id').catch(() => null);
+                      }}
+                      edge="end"
+                    >
+                      {copiedField === 'group_id' ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& input': {
+                fontFamily: 'monospace',
+                fontSize: '0.875rem',
+              },
+            }}
+          />
+        </FormControl>
+      </Stack>
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/thunder-console/src/features/groups/pages/GroupEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/pages/GroupEditPage.tsx
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import {CopyableId} from '@thunder/components';
 import {useToast} from '@thunder/contexts';
 import {useLogger} from '@thunder/logger/react';
 import {
@@ -298,9 +297,6 @@ export default function GroupEditPage(): JSX.Element {
               </>
             )}
           </Stack>
-
-          {/* Group ID */}
-          <CopyableId value={group.id} copyLabel={t('groups:edit.general.sections.quickCopy.copyGroupId')} />
         </PageTitle.SubHeader>
       </PageTitle>
 

--- a/frontend/apps/thunder-console/src/features/groups/pages/__tests__/GroupEditPage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/pages/__tests__/GroupEditPage.test.tsx
@@ -217,12 +217,6 @@ describe('GroupEditPage', () => {
     expect(screen.getByText('A test group')).toBeInTheDocument();
   });
 
-  it('should render group ID', () => {
-    renderWithProviders(<GroupEditPage />);
-
-    expect(screen.getByText('g1')).toBeInTheDocument();
-  });
-
   it('should render back button and navigate on click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<GroupEditPage />);
@@ -469,39 +463,6 @@ describe('GroupEditPage', () => {
     await waitFor(() => {
       expect(screen.getByText('No description')).toBeInTheDocument();
     });
-  });
-
-  it('should copy group ID to clipboard on click', async () => {
-    renderWithProviders(<GroupEditPage />);
-
-    const groupIdElement = screen.getByText('g1');
-    const copyButton = groupIdElement.closest('[role="button"]');
-    expect(copyButton).toBeTruthy();
-    fireEvent.click(copyButton!);
-
-    await waitFor(() => {
-      expect(mockWriteText).toHaveBeenCalledWith('g1');
-    });
-  });
-
-  it('should copy group ID on keyboard Enter', () => {
-    renderWithProviders(<GroupEditPage />);
-
-    const groupIdElement = screen.getByText('g1');
-    const copyButton = groupIdElement.closest('[role="button"]');
-    fireEvent.keyDown(copyButton!, {key: 'Enter'});
-
-    expect(mockWriteText).toHaveBeenCalledWith('g1');
-  });
-
-  it('should copy group ID on keyboard Space', () => {
-    renderWithProviders(<GroupEditPage />);
-
-    const groupIdElement = screen.getByText('g1');
-    const copyButton = groupIdElement.closest('[role="button"]');
-    fireEvent.keyDown(copyButton!, {key: ' '});
-
-    expect(mockWriteText).toHaveBeenCalledWith('g1');
   });
 
   it('should save changes when save button is clicked', async () => {

--- a/frontend/apps/thunder-console/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {CopyableId, ResourceAvatar, UnsavedChangesBar} from '@thunder/components';
+import {ResourceAvatar, UnsavedChangesBar} from '@thunder/components';
 import {useLogger} from '@thunder/logger/react';
 import {
   Box,
@@ -328,12 +328,6 @@ export default function OrganizationUnitEditPage(): JSX.Element {
               </>
             )}
           </Stack>
-
-          {/* Organization Unit ID */}
-          <CopyableId
-            value={organizationUnit.id}
-            copyLabel={t('organizationUnits:edit.page.copyOuId', 'Copy Organization Unit ID')}
-          />
         </PageTitle.SubHeader>
       </PageTitle>
 

--- a/frontend/apps/thunder-console/src/features/roles/components/RolesList.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/RolesList.tsx
@@ -18,8 +18,8 @@
 
 import {useDataGridLocaleText} from '@thunder/hooks';
 import {useLogger} from '@thunder/logger/react';
-import {Box, Avatar, IconButton, Typography, Tooltip, DataGrid, ListingTable, useTheme} from '@wso2/oxygen-ui';
-import {ShieldCheck, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Box, IconButton, Typography, Tooltip, DataGrid, ListingTable, useTheme} from '@wso2/oxygen-ui';
+import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -73,29 +73,6 @@ export default function RolesList(): JSX.Element {
 
   const columns: DataGrid.GridColDef<RoleSummary>[] = useMemo(
     () => [
-      {
-        field: 'avatar',
-        headerName: '',
-        width: 70,
-        sortable: false,
-        filterable: false,
-        renderCell: (): JSX.Element => (
-          <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-            <Avatar
-              sx={{
-                p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
-                width: 30,
-                height: 30,
-                fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {backgroundColor: theme.vars?.palette.grey[900]}),
-              }}
-            >
-              <ShieldCheck size={14} />
-            </Avatar>
-          </Box>
-        ),
-      },
       {
         field: 'name',
         headerName: t('roles:listing.columns.name'),

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
@@ -17,10 +17,21 @@
  */
 
 import {SettingsCard} from '@thunder/components';
-import {Stack, TextField, Button, IconButton, Typography, InputAdornment, Tooltip} from '@wso2/oxygen-ui';
+import {
+  Stack,
+  TextField,
+  Button,
+  IconButton,
+  Typography,
+  InputAdornment,
+  Tooltip,
+  FormControl,
+  FormLabel,
+} from '@wso2/oxygen-ui';
 import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useRef, useEffect, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import QuickCopySection from './QuickCopySection';
 import type {Role} from '../../../models/role';
 
 interface EditGeneralSettingsProps {
@@ -53,47 +64,54 @@ export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSe
 
   return (
     <Stack spacing={3}>
+      <QuickCopySection role={role} copiedField={copiedField} onCopyToClipboard={handleCopyToClipboard} />
+
       {/* Organization Unit */}
       <SettingsCard
         title={t('roles:edit.general.sections.organizationUnit.title')}
         description={t('roles:edit.general.sections.organizationUnit.description')}
       >
         <Stack spacing={2}>
-          <TextField
-            label={t('roles:edit.general.sections.organizationUnit.idLabel', 'ID')}
-            value={role.ouId}
-            fullWidth
-            size="small"
-            slotProps={{
-              input: {
-                readOnly: true,
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip
-                      title={
-                        copiedField === 'ouId'
-                          ? t('common:actions.copied')
-                          : t('roles:edit.general.sections.organizationUnit.copyId')
-                      }
-                    >
-                      <IconButton
-                        aria-label={t('roles:edit.general.sections.organizationUnit.copyId')}
-                        onClick={() => {
-                          handleCopyToClipboard(role.ouId, 'ouId').catch(() => {
-                            /* noop */
-                          });
-                        }}
-                        edge="end"
+          <FormControl fullWidth>
+            <FormLabel htmlFor="ou-id-input">
+              {t('roles:edit.general.sections.organizationUnit.idLabel', 'ID')}
+            </FormLabel>
+            <TextField
+              id="ou-id-input"
+              value={role.ouId}
+              fullWidth
+              size="small"
+              slotProps={{
+                input: {
+                  readOnly: true,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Tooltip
+                        title={
+                          copiedField === 'ouId'
+                            ? t('common:actions.copied')
+                            : t('roles:edit.general.sections.organizationUnit.copyId')
+                        }
                       >
-                        {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              },
-            }}
-            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-          />
+                        <IconButton
+                          aria-label={t('roles:edit.general.sections.organizationUnit.copyId')}
+                          onClick={() => {
+                            handleCopyToClipboard(role.ouId, 'ouId').catch(() => {
+                              /* noop */
+                            });
+                          }}
+                          edge="end"
+                        >
+                          {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+            />
+          </FormControl>
         </Stack>
       </SettingsCard>
 

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/QuickCopySection.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/QuickCopySection.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunder/components';
+import {Stack, TextField, InputAdornment, Tooltip, IconButton, FormControl, FormLabel} from '@wso2/oxygen-ui';
+import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {useTranslation} from 'react-i18next';
+import type {Role} from '../../../models/role';
+
+interface QuickCopySectionProps {
+  role: Role;
+  copiedField: string | null;
+  onCopyToClipboard: (text: string, fieldName: string) => Promise<void>;
+}
+
+export default function QuickCopySection({role, copiedField, onCopyToClipboard}: QuickCopySectionProps) {
+  const {t} = useTranslation();
+
+  return (
+    <SettingsCard
+      title={t('roles:edit.general.sections.quickCopy.title', 'Quick Copy')}
+      description={t(
+        'roles:edit.general.sections.quickCopy.description',
+        'Copy role identifiers for use in your application.',
+      )}
+    >
+      <Stack spacing={3}>
+        <FormControl fullWidth>
+          <FormLabel htmlFor="role-id-input">{t('roles:edit.general.labels.roleId', 'Role ID')}</FormLabel>
+          <TextField
+            fullWidth
+            id="role-id-input"
+            value={role.id}
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip
+                    title={
+                      copiedField === 'role_id'
+                        ? t('common:actions.copied')
+                        : t('roles:edit.general.sections.quickCopy.copyRoleId')
+                    }
+                  >
+                    <IconButton
+                      aria-label={
+                        copiedField === 'role_id'
+                          ? t('common:actions.copied')
+                          : t('roles:edit.general.sections.quickCopy.copyRoleId')
+                      }
+                      onClick={() => {
+                        onCopyToClipboard(role.id, 'role_id').catch(() => null);
+                      }}
+                      edge="end"
+                    >
+                      {copiedField === 'role_id' ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& input': {
+                fontFamily: 'monospace',
+                fontSize: '0.875rem',
+              },
+            }}
+          />
+        </FormControl>
+      </Stack>
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/thunder-console/src/features/roles/pages/RoleEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/pages/RoleEditPage.tsx
@@ -16,11 +16,9 @@
  * under the License.
  */
 
-import {CopyableId} from '@thunder/components';
 import {useToast} from '@thunder/contexts';
 import {useLogger} from '@thunder/logger/react';
 import {
-  Avatar,
   Box,
   Stack,
   Typography,
@@ -35,7 +33,7 @@ import {
   PageContent,
   PageTitle,
 } from '@wso2/oxygen-ui';
-import {ArrowLeft, Edit, ShieldCheck} from '@wso2/oxygen-ui-icons-react';
+import {ArrowLeft, Edit} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useMemo} from 'react';
 import type {ReactNode, SyntheticEvent, JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -185,11 +183,6 @@ export default function RoleEditPage(): JSX.Element {
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to={listUrl} />}>{t('roles:edit.page.back')}</PageTitle.BackButton>
-        <PageTitle.Avatar>
-          <Avatar>
-            <ShieldCheck size={32} />
-          </Avatar>
-        </PageTitle.Avatar>
         <PageTitle.Header>
           <Stack direction="row" alignItems="center" spacing={1} mb={1}>
             {isEditingName ? (
@@ -283,8 +276,6 @@ export default function RoleEditPage(): JSX.Element {
               </>
             )}
           </Stack>
-
-          <CopyableId value={role.id} copyLabel={t('roles:edit.general.sections.quickCopy.copyRoleId')} />
         </PageTitle.SubHeader>
       </PageTitle>
 

--- a/frontend/apps/thunder-console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../components/edit-role/assignments-settings/EditAssignmentsSettings
 }));
 
 vi.mock('@thunder/components', () => ({
-  CopyableId: ({value}: {value: string}) => <span data-testid="copyable-id">{value}</span>,
+  CopyableId: vi.fn(() => null),
 }));
 
 vi.mock('react-router', async () => {
@@ -165,16 +165,10 @@ describe('RoleEditPage', () => {
       expect(screen.getByText('Admin Role')).toBeInTheDocument();
     });
 
-    it('should display role description', () => {
+    it('should render role description', () => {
       render(<RoleEditPage />);
 
       expect(screen.getByText('Administrator role')).toBeInTheDocument();
-    });
-
-    it('should render CopyableId with role.id', () => {
-      render(<RoleEditPage />);
-
-      expect(screen.getByTestId('copyable-id')).toHaveTextContent('role-1');
     });
 
     it('should render two tabs', () => {

--- a/frontend/apps/thunder-console/src/features/user-types/components/edit-user-type/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/edit-user-type/general-settings/EditGeneralSettings.tsx
@@ -20,7 +20,9 @@ import {SettingsCard} from '@thunder/components';
 import {useResolveDisplayName} from '@thunder/hooks';
 import {Stack, Typography, Button, Select, MenuItem} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
+import {useState, useCallback, useRef, useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
+import QuickCopySection from './QuickCopySection';
 import OrganizationUnitTreePicker from '../../../../organization-units/components/OrganizationUnitTreePicker';
 import type {ApiUserSchema, SchemaPropertyInput} from '../../../types/user-types';
 
@@ -49,6 +51,28 @@ export default function EditGeneralSettings({
 }: EditGeneralSettingsProps): JSX.Element {
   const {t} = useTranslation();
   const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopyToClipboard = useCallback(async (text: string, fieldName: string): Promise<void> => {
+    await navigator.clipboard.writeText(text);
+    setCopiedField(fieldName);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+    }
+    copyTimeoutRef.current = setTimeout(() => {
+      setCopiedField(null);
+    }, 2000);
+  }, []);
 
   const effectiveOuId = editedOuId ?? userType.ouId;
   const effectiveAllowSelfRegistration = editedAllowSelfRegistration ?? userType.allowSelfRegistration;
@@ -56,6 +80,8 @@ export default function EditGeneralSettings({
 
   return (
     <Stack spacing={3}>
+      <QuickCopySection userType={userType} copiedField={copiedField} onCopyToClipboard={handleCopyToClipboard} />
+
       {/* Organization Unit */}
       <SettingsCard
         title={t('userTypes:edit.general.organizationUnit.title', 'Organization Unit')}

--- a/frontend/apps/thunder-console/src/features/user-types/components/edit-user-type/general-settings/QuickCopySection.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/edit-user-type/general-settings/QuickCopySection.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunder/components';
+import {Stack, TextField, InputAdornment, Tooltip, IconButton, FormControl, FormLabel} from '@wso2/oxygen-ui';
+import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {useTranslation} from 'react-i18next';
+import type {ApiUserSchema} from '../../../types/user-types';
+
+interface QuickCopySectionProps {
+  userType: ApiUserSchema;
+  copiedField: string | null;
+  onCopyToClipboard: (text: string, fieldName: string) => Promise<void>;
+}
+
+export default function QuickCopySection({userType, copiedField, onCopyToClipboard}: QuickCopySectionProps) {
+  const {t} = useTranslation();
+
+  return (
+    <SettingsCard
+      title={t('userTypes:edit.general.sections.quickCopy.title', 'Quick Copy')}
+      description={t(
+        'userTypes:edit.general.sections.quickCopy.description',
+        'Copy user type identifiers for use in your application.',
+      )}
+    >
+      <Stack spacing={3}>
+        <FormControl fullWidth>
+          <FormLabel htmlFor="user-type-id-input">
+            {t('userTypes:edit.general.labels.userTypeId', 'User Type ID')}
+          </FormLabel>
+          <TextField
+            fullWidth
+            id="user-type-id-input"
+            value={userType.id}
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip
+                    title={
+                      copiedField === 'user_type_id'
+                        ? t('common:actions.copied', 'Copied')
+                        : t('userTypes:edit.copyId', 'Copy user type ID')
+                    }
+                  >
+                    <IconButton
+                      aria-label={
+                        copiedField === 'user_type_id'
+                          ? t('common:actions.copied', 'Copied')
+                          : t('userTypes:edit.copyId', 'Copy user type ID')
+                      }
+                      onClick={() => {
+                        onCopyToClipboard(userType.id, 'user_type_id').catch(() => null);
+                      }}
+                      edge="end"
+                    >
+                      {copiedField === 'user_type_id' ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& input': {
+                fontFamily: 'monospace',
+                fontSize: '0.875rem',
+              },
+            }}
+          />
+        </FormControl>
+      </Stack>
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/thunder-console/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {CopyableId, UnsavedChangesBar} from '@thunder/components';
+import {UnsavedChangesBar} from '@thunder/components';
 import {useToast} from '@thunder/contexts';
 import {useLogger} from '@thunder/logger/react';
 import {
@@ -358,6 +358,7 @@ export default function ViewUserTypePage(): JSX.Element {
                   }
                 }}
                 size="small"
+                inputProps={{'aria-label': t('userTypes:edit.nameInputAriaLabel', 'User type name')}}
               />
             ) : (
               <>
@@ -380,9 +381,6 @@ export default function ViewUserTypePage(): JSX.Element {
             )}
           </Stack>
         </PageTitle.Header>
-        <PageTitle.SubHeader>
-          <CopyableId value={userType.id} copyLabel={t('userTypes:edit.copyId', 'Copy user type ID')} />
-        </PageTitle.SubHeader>
       </PageTitle>
 
       {/* Tabs */}

--- a/frontend/apps/thunder-console/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
@@ -232,7 +232,7 @@ describe('ViewUserTypePage', () => {
       render(<ViewUserTypePage />);
 
       expect(screen.getByText('Employee Schema')).toBeInTheDocument();
-      expect(screen.getByText('schema-123')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('schema-123')).toBeInTheDocument();
     });
 
     it('displays General and Schema tabs', () => {
@@ -258,7 +258,7 @@ describe('ViewUserTypePage', () => {
       await user.click(editNameButton);
 
       // Should show a text field with the current name
-      const nameInput = screen.getByRole('textbox');
+      const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       expect(nameInput).toHaveValue('Employee Schema');
 
       // Edit the name
@@ -775,7 +775,7 @@ describe('ViewUserTypePage', () => {
       const editNameButton = screen.getByRole('button', {name: /edit user type name/i});
       await user.click(editNameButton);
 
-      const nameInput = screen.getByRole('textbox');
+      const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       await user.clear(nameInput);
       await user.type(nameInput, 'New Name{Enter}');
 
@@ -849,7 +849,7 @@ describe('ViewUserTypePage', () => {
       const editNameButton = screen.getByRole('button', {name: /edit user type name/i});
       await user.click(editNameButton);
 
-      const nameInput = screen.getByRole('textbox');
+      const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       await user.clear(nameInput);
       await user.type(nameInput, 'Updated Schema{Enter}');
 
@@ -1241,7 +1241,7 @@ describe('ViewUserTypePage', () => {
       // Edit name to trigger save bar (since OU is empty, no change to OU)
       const editNameButton = screen.getByRole('button', {name: /edit user type name/i});
       await user.click(editNameButton);
-      const nameInput = screen.getByRole('textbox');
+      const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       await user.clear(nameInput);
       await user.type(nameInput, 'New Name{Enter}');
 
@@ -1619,7 +1619,7 @@ describe('ViewUserTypePage', () => {
       const editNameButton = screen.getByRole('button', {name: /edit user type name/i});
       await user.click(editNameButton);
 
-      const nameInput = screen.getByRole('textbox');
+      const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       await user.clear(nameInput);
       await user.type(nameInput, 'Temp Name{Escape}');
 
@@ -1640,7 +1640,7 @@ describe('ViewUserTypePage', () => {
       await user.click(editNameButton);
 
       // Verify input is shown, then blur without changing the name
-      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', {name: /user type name/i})).toBeInTheDocument();
       await user.tab();
 
       // No unsaved changes bar should appear

--- a/frontend/apps/thunder-console/src/features/users/components/edit-user/QuickCopySection.tsx
+++ b/frontend/apps/thunder-console/src/features/users/components/edit-user/QuickCopySection.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunder/components';
+import {Stack, TextField, InputAdornment, Tooltip, IconButton, FormControl, FormLabel} from '@wso2/oxygen-ui';
+import {Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {useTranslation} from 'react-i18next';
+import type {ApiUser} from '../../models/users';
+
+interface QuickCopySectionProps {
+  user: ApiUser;
+  copiedField: string | null;
+  onCopyToClipboard: (text: string, fieldName: string) => Promise<void>;
+}
+
+export default function QuickCopySection({user, copiedField, onCopyToClipboard}: QuickCopySectionProps) {
+  const {t} = useTranslation();
+
+  return (
+    <SettingsCard
+      title={t('users:manageUser.sections.quickCopy.title', 'Quick Copy')}
+      description={t(
+        'users:manageUser.sections.quickCopy.description',
+        'Copy user identifiers for use in your application.',
+      )}
+    >
+      <Stack spacing={3}>
+        <FormControl fullWidth>
+          <FormLabel htmlFor="user-id-input">{t('users:manageUser.sections.quickCopy.userId', 'User ID')}</FormLabel>
+          <TextField
+            fullWidth
+            id="user-id-input"
+            value={user.id}
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip
+                    title={
+                      copiedField === 'userId'
+                        ? t('common:actions.copied', 'Copied')
+                        : t('users:manageUser.sections.quickCopy.copyUserId', 'Copy User ID')
+                    }
+                  >
+                    <IconButton
+                      aria-label={
+                        copiedField === 'userId'
+                          ? t('common:actions.copied', 'Copied')
+                          : t('users:manageUser.sections.quickCopy.copyUserId', 'Copy User ID')
+                      }
+                      onClick={() => {
+                        onCopyToClipboard(user.id, 'userId').catch(() => null);
+                      }}
+                      edge="end"
+                    >
+                      {copiedField === 'userId' ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& input': {
+                fontFamily: 'monospace',
+                fontSize: '0.875rem',
+              },
+            }}
+          />
+        </FormControl>
+      </Stack>
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {CopyableId, ResourceAvatar, SettingsCard} from '@thunder/components';
+import {ResourceAvatar, SettingsCard} from '@thunder/components';
 import {useResolveDisplayName} from '@thunder/hooks';
 import {useLogger} from '@thunder/logger/react';
 import {
@@ -35,6 +35,8 @@ import {
   IconButton,
   PageContent,
   PageTitle,
+  FormControl,
+  FormLabel,
 } from '@wso2/oxygen-ui';
 import {ArrowLeft, Save, X, Copy, Check} from '@wso2/oxygen-ui-icons-react';
 import {useState, useEffect, useMemo, useCallback, useRef, type SyntheticEvent, type ReactNode, type JSX} from 'react';
@@ -45,6 +47,7 @@ import useGetUser from '../api/useGetUser';
 import useGetUserSchema from '../api/useGetUserSchema';
 import useGetUserSchemas from '../api/useGetUserSchemas';
 import useUpdateUser from '../api/useUpdateUser';
+import QuickCopySection from '../components/edit-user/QuickCopySection';
 import UserDeleteDialog from '../components/UserDeleteDialog';
 import renderSchemaField from '../utils/renderSchemaField';
 import getInitials from '@/utils/getInitials';
@@ -262,7 +265,6 @@ export default function UserEditPage() {
           <Stack direction="row" alignItems="center" spacing={1}>
             <Chip label={user.type} size="small" sx={{px: 0.5}} />
           </Stack>
-          <CopyableId value={user.id} copyLabel={t('users:manageUser.copyUserId', 'Copy User ID')} />
         </PageTitle.SubHeader>
       </PageTitle>
 
@@ -281,6 +283,8 @@ export default function UserEditPage() {
         {/* General Tab */}
         <TabPanel value={activeTab} index={0}>
           <Stack spacing={3}>
+            <QuickCopySection user={user} copiedField={copiedField} onCopyToClipboard={handleCopyToClipboard} />
+
             {/* User Attributes */}
             <SettingsCard
               title={t('users:manageUser.sections.attributes.title', 'User Attributes')}
@@ -400,81 +404,91 @@ export default function UserEditPage() {
               )}
             >
               <Stack spacing={2}>
-                <TextField
-                  label={t('users:manageUser.sections.organizationUnit.handleLabel', 'Handle')}
-                  value={user.ouHandle ?? '-'}
-                  fullWidth
-                  size="small"
-                  slotProps={{
-                    input: {
-                      readOnly: true,
-                      endAdornment: user.ouHandle ? (
-                        <InputAdornment position="end">
-                          <Tooltip
-                            title={
-                              copiedField === 'ouHandle'
-                                ? t('common:actions.copied')
-                                : t(
-                                    'users:manageUser.sections.organizationUnit.copyHandle',
-                                    'Copy Organization Unit Handle',
-                                  )
-                            }
-                          >
-                            <IconButton
-                              aria-label={t(
-                                'users:manageUser.sections.organizationUnit.copyHandle',
-                                'Copy Organization Unit Handle',
-                              )}
-                              onClick={() => {
-                                handleCopyToClipboard(user.ouHandle!, 'ouHandle').catch(() => null);
-                              }}
-                              edge="end"
+                <FormControl fullWidth>
+                  <FormLabel htmlFor="ou-handle-input">
+                    {t('users:manageUser.sections.organizationUnit.handleLabel', 'Handle')}
+                  </FormLabel>
+                  <TextField
+                    id="ou-handle-input"
+                    value={user.ouHandle ?? '-'}
+                    fullWidth
+                    size="small"
+                    slotProps={{
+                      input: {
+                        readOnly: true,
+                        endAdornment: user.ouHandle ? (
+                          <InputAdornment position="end">
+                            <Tooltip
+                              title={
+                                copiedField === 'ouHandle'
+                                  ? t('common:actions.copied')
+                                  : t(
+                                      'users:manageUser.sections.organizationUnit.copyHandle',
+                                      'Copy Organization Unit Handle',
+                                    )
+                              }
                             >
-                              {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
-                            </IconButton>
-                          </Tooltip>
-                        </InputAdornment>
-                      ) : undefined,
-                    },
-                  }}
-                  sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-                />
-                <TextField
-                  label={t('users:manageUser.sections.organizationUnit.idLabel', 'ID')}
-                  value={user.ouId}
-                  fullWidth
-                  size="small"
-                  slotProps={{
-                    input: {
-                      readOnly: true,
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <Tooltip
-                            title={
-                              copiedField === 'ouId'
-                                ? t('common:actions.copied')
-                                : t('users:manageUser.sections.organizationUnit.copyId', 'Copy Organization Unit ID')
-                            }
-                          >
-                            <IconButton
-                              aria-label={t(
-                                'users:manageUser.sections.organizationUnit.copyId',
-                                'Copy Organization Unit ID',
-                              )}
-                              onClick={() => {
-                                handleCopyToClipboard(user.ouId, 'ouId').catch(() => null);
-                              }}
-                              edge="end"
+                              <IconButton
+                                aria-label={t(
+                                  'users:manageUser.sections.organizationUnit.copyHandle',
+                                  'Copy Organization Unit Handle',
+                                )}
+                                onClick={() => {
+                                  handleCopyToClipboard(user.ouHandle!, 'ouHandle').catch(() => null);
+                                }}
+                                edge="end"
+                              >
+                                {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                              </IconButton>
+                            </Tooltip>
+                          </InputAdornment>
+                        ) : undefined,
+                      },
+                    }}
+                    sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+                  />
+                </FormControl>
+                <FormControl fullWidth>
+                  <FormLabel htmlFor="ou-id-input">
+                    {t('users:manageUser.sections.organizationUnit.idLabel', 'ID')}
+                  </FormLabel>
+                  <TextField
+                    id="ou-id-input"
+                    value={user.ouId}
+                    fullWidth
+                    size="small"
+                    slotProps={{
+                      input: {
+                        readOnly: true,
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <Tooltip
+                              title={
+                                copiedField === 'ouId'
+                                  ? t('common:actions.copied')
+                                  : t('users:manageUser.sections.organizationUnit.copyId', 'Copy Organization Unit ID')
+                              }
                             >
-                              {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
-                            </IconButton>
-                          </Tooltip>
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                  sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-                />
+                              <IconButton
+                                aria-label={t(
+                                  'users:manageUser.sections.organizationUnit.copyId',
+                                  'Copy Organization Unit ID',
+                                )}
+                                onClick={() => {
+                                  handleCopyToClipboard(user.ouId, 'ouId').catch(() => null);
+                                }}
+                                edge="end"
+                              >
+                                {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                              </IconButton>
+                            </Tooltip>
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                    sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+                  />
+                </FormControl>
               </Stack>
             </SettingsCard>
 

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -371,6 +371,10 @@ const translations = {
     'manageUser.title': 'Manage User',
     'manageUser.subtitle': 'View and manage user information',
     'manageUser.back': 'Back to Users',
+    'manageUser.sections.quickCopy.title': 'Quick Copy',
+    'manageUser.sections.quickCopy.description': 'Copy user identifiers for use in your application.',
+    'manageUser.sections.quickCopy.userId': 'User ID',
+    'manageUser.sections.quickCopy.copyUserId': 'Copy User ID',
 
     // Create page
     'createUser.title': 'Create User',
@@ -1348,6 +1352,10 @@ const translations = {
     'edit.general.sections.dangerZone.regenerateSecret.description':
       'Regenerating the client secret will immediately invalidate the current client secret and cannot be undone.',
     'edit.general.sections.dangerZone.regenerateSecret.button': 'Regenerate Client Secret',
+    'edit.general.sections.dangerZone.deleteApplication.title': 'Delete Application',
+    'edit.general.sections.dangerZone.deleteApplication.description':
+      'Permanently delete this application and all associated data. This action cannot be undone.',
+    'edit.general.sections.dangerZone.deleteApplication.button': 'Delete Application',
 
     // Flows section
     'edit.flows.labels.authFlow': 'Authentication Flow',


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request enhances the "Danger Zone" section in the application's general settings by adding a dedicated "Delete Application" action, improving the UI/UX, and updating related tests to ensure correct behavior. The main changes include always displaying the delete option, conditionally displaying the regenerate secret option, and ensuring both actions are well tested and documented.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->


**Danger Zone Section Improvements:**

* The `DangerZoneSection` component now always displays a "Delete Application" button and only shows the "Regenerate Client Secret" option for confidential clients, with improved descriptions and accessibility. [[1]](diffhunk://#diff-70df2d9540454886d4a1dd82f55e430dece858cb765b951630b6c2b45b6f5258L31-R93) [[2]](diffhunk://#diff-70df2d9540454886d4a1dd82f55e430dece858cb765b951630b6c2b45b6f5258L20-R20)

**General Settings Integration:**

* The `EditGeneralSettings` component integrates the enhanced `DangerZoneSection`, manages the new delete confirmation dialog, and exposes an `onDeleteSuccess` callback for parent components. [[1]](diffhunk://#diff-0f07a32b600417f1d5ef1ad6bc5519c30b8a4d50f66de972433812d1ce36ff1bR28) [[2]](diffhunk://#diff-0f07a32b600417f1d5ef1ad6bc5519c30b8a4d50f66de972433812d1ce36ff1bR64-R67) [[3]](diffhunk://#diff-0f07a32b600417f1d5ef1ad6bc5519c30b8a4d50f66de972433812d1ce36ff1bR88-R92) [[4]](diffhunk://#diff-0f07a32b600417f1d5ef1ad6bc5519c30b8a4d50f66de972433812d1ce36ff1bL121-R132) [[5]](diffhunk://#diff-0f07a32b600417f1d5ef1ad6bc5519c30b8a4d50f66de972433812d1ce36ff1bR149-R156)

**Testing Updates:**

* Tests for `DangerZoneSection` are expanded to cover the new delete application functionality, conditional rendering of both actions, and their respective callbacks. [[1]](diffhunk://#diff-b483b8b6263f69df93b1cac212427164b563c01d2e7e89049636ea976b0f7989L30-R38) [[2]](diffhunk://#diff-b483b8b6263f69df93b1cac212427164b563c01d2e7e89049636ea976b0f7989R47) [[3]](diffhunk://#diff-b483b8b6263f69df93b1cac212427164b563c01d2e7e89049636ea976b0f7989L53-R145)
* Tests for `EditGeneralSettings` are updated to account for the always-present Danger Zone section and the conditional rendering of the regenerate secret action, with new mocks for the delete dialog. [[1]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6L61-R78) [[2]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6R118-R141) [[3]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6R348-R351) [[4]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6L330-R372) [[5]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6L344-R387) [[6]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6L364-R405) [[7]](diffhunk://#diff-e6bc353209e90cb6a5707d857d1b1de1f51f1e19498c35773b3b08abbc0f1bf6R427)

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2237

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application deletion with confirmation dialog added.
  * Quick Copy sections added for groups, roles, user types, and users.

* **Improvements**
  * Danger zone now always shows Delete and conditionally shows Regenerate Secret.
  * Removed header quick-copy controls; copy UI moved into dedicated sections.
  * Improved form accessibility with explicit labels and input associations.
  * Added localization text for danger-zone delete and quick-copy UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->