### PR TITLE
Remove NONE app certificate type

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -1064,7 +1064,6 @@ components:
           type: string
           description: The type of the certificate.
           enum:
-            - "NONE"
             - "JWKS"
             - "JWKS_URI"
           example: "JWKS_URI"

--- a/backend/cmd/server/bootstrap/02-sample-resources.sh
+++ b/backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -246,10 +246,6 @@ read -r -d '' REACT_SDK_APP_PAYLOAD <<JSON || true
     "validityPeriod": 3600,
     "userAttributes": null
   },
-  "certificate": {
-    "type": "NONE",
-    "value": ""
-  },
   "userAttributes": ["given_name","family_name","email","groups","name"],
   "allowedUserTypes": ["Customer"],
   "inboundAuthConfig": [{

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -1379,7 +1379,7 @@ func validateTokenEndpointAuthMethod(oauthConfig *model.OAuthAppConfigDTO) *serv
 		return &ErrorInvalidTokenEndpointAuthMethod
 	}
 
-	hasCert := oauthConfig.Certificate != nil && oauthConfig.Certificate.Type != cert.CertificateTypeNone
+	hasCert := oauthConfig.Certificate != nil && oauthConfig.Certificate.Type != ""
 
 	switch oauthConfig.TokenEndpointAuthMethod {
 	case oauth2const.TokenEndpointAuthMethodPrivateKeyJWT:
@@ -1708,7 +1708,7 @@ func resolveClientSecret(
 func (as *applicationService) getValidatedCertificateForCreate(appID string, certificate *model.ApplicationCertificate,
 	certRefType cert.CertificateReferenceType) (
 	*cert.Certificate, *serviceerror.ServiceError) {
-	if certificate == nil || certificate.Type == "" || certificate.Type == cert.CertificateTypeNone {
+	if certificate == nil || certificate.Type == "" {
 		return nil, nil
 	}
 	return getValidatedCertificateInput(appID, "", certificate, certRefType)
@@ -1718,7 +1718,7 @@ func (as *applicationService) getValidatedCertificateForCreate(appID string, cer
 func (as *applicationService) getValidatedCertificateForUpdate(appID, certID string,
 	certificate *model.ApplicationCertificate, certRefType cert.CertificateReferenceType) (
 	*cert.Certificate, *serviceerror.ServiceError) {
-	if certificate == nil || certificate.Type == "" || certificate.Type == cert.CertificateTypeNone {
+	if certificate == nil || certificate.Type == "" {
 		return nil, nil
 	}
 	return getValidatedCertificateInput(appID, certID, certificate, certRefType)
@@ -1758,32 +1758,26 @@ func getValidatedCertificateInput(appID, certID string, certificate *model.Appli
 // createApplicationCertificate creates a certificate for the application.
 func (as *applicationService) createApplicationCertificate(ctx context.Context, certificate *cert.Certificate) (
 	*model.ApplicationCertificate, *serviceerror.ServiceError) {
-	var returnCert *model.ApplicationCertificate
-	if certificate != nil {
-		_, svcErr := as.certService.CreateCertificate(ctx, certificate)
-		if svcErr != nil {
-			if svcErr.Type == serviceerror.ClientErrorType {
-				errorDescription := "Failed to create application certificate: " +
-					svcErr.ErrorDescription
-				return nil, serviceerror.CustomServiceError(
-					ErrorCertificateClientError, errorDescription)
-			}
-			as.logger.Error("Failed to create application certificate", log.Any("serviceError", svcErr))
-			return nil, &ErrorCertificateServerError
-		}
-
-		returnCert = &model.ApplicationCertificate{
-			Type:  certificate.Type,
-			Value: certificate.Value,
-		}
-	} else {
-		returnCert = &model.ApplicationCertificate{
-			Type:  cert.CertificateTypeNone,
-			Value: "",
-		}
+	if certificate == nil {
+		return nil, nil
 	}
 
-	return returnCert, nil
+	_, svcErr := as.certService.CreateCertificate(ctx, certificate)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			errorDescription := "Failed to create application certificate: " +
+				svcErr.ErrorDescription
+			return nil, serviceerror.CustomServiceError(
+				ErrorCertificateClientError, errorDescription)
+		}
+		as.logger.Error("Failed to create application certificate", log.Any("serviceError", svcErr))
+		return nil, &ErrorCertificateServerError
+	}
+
+	return &model.ApplicationCertificate{
+		Type:  certificate.Type,
+		Value: certificate.Value,
+	}, nil
 }
 
 // deleteApplicationCertificate deletes the certificate associated with the application.
@@ -1831,10 +1825,7 @@ func (as *applicationService) getApplicationCertificate(ctx context.Context, app
 
 	if certErr != nil {
 		if certErr.Code == cert.ErrorCertificateNotFound.Code {
-			return &model.ApplicationCertificate{
-				Type:  cert.CertificateTypeNone,
-				Value: "",
-			}, nil
+			return nil, nil
 		}
 
 		if certErr.Type == serviceerror.ClientErrorType {
@@ -1849,10 +1840,7 @@ func (as *applicationService) getApplicationCertificate(ctx context.Context, app
 	}
 
 	if certificate == nil {
-		return &model.ApplicationCertificate{
-			Type:  cert.CertificateTypeNone,
-			Value: "",
-		}, nil
+		return nil, nil
 	}
 
 	return &model.ApplicationCertificate{
@@ -1939,11 +1927,6 @@ func (as *applicationService) updateApplicationCertificate(ctx context.Context, 
 					log.String("appID", appID))
 				return nil, &ErrorCertificateServerError
 			}
-		}
-
-		returnCert = &model.ApplicationCertificate{
-			Type:  cert.CertificateTypeNone,
-			Value: "",
 		}
 	}
 

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -547,11 +547,11 @@ func (suite *ServiceTestSuite) TestValidateTokenEndpointAuthMethod() {
 			expectError: true,
 		},
 		{
-			name: "private_key_jwt with certificate type NONE",
+			name: "private_key_jwt with empty certificate type",
 			oauthConfig: &model.OAuthAppConfigDTO{
 				TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodPrivateKeyJWT,
 				Certificate: &model.ApplicationCertificate{
-					Type: cert.CertificateTypeNone,
+					Type: "",
 				},
 			},
 			expectError: true,
@@ -607,11 +607,11 @@ func (suite *ServiceTestSuite) TestValidateTokenEndpointAuthMethod_PrivateKeyJWT
 			expectedErrDesc: "private_key_jwt authentication method requires a certificate",
 		},
 		{
-			name: "private_key_jwt requires certificate - NONE type",
+			name: "private_key_jwt requires certificate - empty type",
 			oauthConfig: &model.OAuthAppConfigDTO{
 				TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodPrivateKeyJWT,
 				Certificate: &model.ApplicationCertificate{
-					Type: cert.CertificateTypeNone,
+					Type: "",
 				},
 			},
 			expectedErrCode: ErrorInvalidOAuthConfiguration.Code,
@@ -1291,40 +1291,6 @@ func (suite *ServiceTestSuite) TestGetOAuthApplication_Success() {
 		(*entityprovider.EntityProviderError)(nil))
 
 	mockCertService.EXPECT().GetCertificateByReference(mock.Anything,
-		cert.CertificateReferenceTypeOAuthApp, "client123").Return(&cert.Certificate{
-		Type:  cert.CertificateTypeNone,
-		Value: "",
-	}, nil)
-
-	result, svcErr := service.GetOAuthApplication(context.Background(), "client123")
-
-	assert.NotNil(suite.T(), result)
-	assert.Nil(suite.T(), svcErr)
-	assert.Equal(suite.T(), "client123", result.ClientID)
-}
-
-func (suite *ServiceTestSuite) TestGetOAuthApplication_CertificateNotFound() {
-	service, mockStore, mockCertService, _ := suite.setupTestService()
-
-	mockEP := resetIdentifyEntity(service)
-	entityID := testServiceAppID
-	mockEP.On("IdentifyEntity",
-		map[string]interface{}{"clientId": "client123"}).
-		Return(
-			&entityID, (*entityprovider.EntityProviderError)(nil))
-
-	mockStore.On("GetOAuthConfigByAppID", mock.Anything, testServiceAppID).
-		Return(&oauthConfigDAO{
-			AppID:       testServiceAppID,
-			OAuthConfig: &oAuthConfig{},
-		}, nil)
-
-	mockEP.On("GetEntity", testServiceAppID).Unset()
-	mockEP.On("GetEntity", testServiceAppID).Return(
-		&entityprovider.Entity{ID: testServiceAppID},
-		(*entityprovider.EntityProviderError)(nil))
-
-	mockCertService.EXPECT().GetCertificateByReference(mock.Anything,
 		cert.CertificateReferenceTypeOAuthApp, "client123").Return(nil, &cert.ErrorCertificateNotFound)
 
 	result, svcErr := service.GetOAuthApplication(context.Background(), "client123")
@@ -1332,9 +1298,7 @@ func (suite *ServiceTestSuite) TestGetOAuthApplication_CertificateNotFound() {
 	assert.NotNil(suite.T(), result)
 	assert.Nil(suite.T(), svcErr)
 	assert.Equal(suite.T(), "client123", result.ClientID)
-	assert.NotNil(suite.T(), result.Certificate)
-	assert.Equal(suite.T(), cert.CertificateTypeNone, result.Certificate.Type)
-	assert.Equal(suite.T(), "", result.Certificate.Value)
+	assert.Nil(suite.T(), result.Certificate)
 }
 
 func (suite *ServiceTestSuite) TestGetOAuthApplication_CertificateServerError() {
@@ -1471,7 +1435,7 @@ func (suite *ServiceTestSuite) TestGetApplication_WithInboundAuthConfig_Success(
 	assert.True(suite.T(), inboundAuth.OAuthAppConfig.PKCERequired)
 	assert.False(suite.T(), inboundAuth.OAuthAppConfig.PublicClient)
 	assert.Equal(suite.T(), []string{"openid", "profile"}, inboundAuth.OAuthAppConfig.Scopes)
-	assert.Equal(suite.T(), cert.CertificateTypeNone, inboundAuth.OAuthAppConfig.Certificate.Type)
+	assert.Nil(suite.T(), inboundAuth.OAuthAppConfig.Certificate)
 }
 
 func (suite *ServiceTestSuite) TestGetApplicationList_Success() {
@@ -2260,9 +2224,8 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_NotFound() {
 	result, err := service.getApplicationCertificate(
 		context.Background(), testServiceAppID, cert.CertificateReferenceTypeApplication)
 
-	assert.NotNil(suite.T(), result)
+	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), cert.CertificateTypeNone, result.Type)
 }
 
 func (suite *ServiceTestSuite) TestGetApplicationCertificate_NilCertificate() {
@@ -2274,9 +2237,8 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_NilCertificate() {
 	result, err := service.getApplicationCertificate(
 		context.Background(), testServiceAppID, cert.CertificateReferenceTypeApplication)
 
-	assert.NotNil(suite.T(), result)
+	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), cert.CertificateTypeNone, result.Type)
 }
 
 func (suite *ServiceTestSuite) TestGetApplicationCertificate_Success() {
@@ -2321,9 +2283,8 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_Nil() {
 
 	result, svcErr := service.createApplicationCertificate(context.Background(), nil)
 
-	assert.NotNil(suite.T(), result)
+	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), svcErr)
-	assert.Equal(suite.T(), cert.CertificateTypeNone, result.Type)
 }
 
 func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ClientError() {
@@ -2347,12 +2308,12 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ClientError() {
 	assert.NotNil(suite.T(), err)
 }
 
-func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_None() {
+func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_EmptyType() {
 	service, _, _, _ := suite.setupTestService()
 
 	app := &model.ApplicationDTO{
 		Certificate: &model.ApplicationCertificate{
-			Type: "NONE",
+			Type: "",
 		},
 	}
 
@@ -2584,22 +2545,6 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ServerError() {
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-}
-
-func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_EmptyType() {
-	service, _, _, _ := suite.setupTestService()
-
-	app := &model.ApplicationDTO{
-		Certificate: &model.ApplicationCertificate{
-			Type: "",
-		},
-	}
-
-	result, svcErr := service.getValidatedCertificateForCreate(testServiceAppID, app.Certificate,
-		cert.CertificateReferenceTypeApplication)
-
-	assert.Nil(suite.T(), result)
-	assert.Nil(suite.T(), svcErr)
 }
 
 func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_NilCertificate() {

--- a/backend/internal/cert/cache_backed_store.go
+++ b/backend/internal/cert/cache_backed_store.go
@@ -69,12 +69,23 @@ func (s *cacheBackedStore) GetCertificateByReference(ctx context.Context, refTyp
 	cacheKey := getCertByReferenceCacheKey(refType, refID)
 	cachedCert, ok := s.certByReferenceCache.Get(ctx, cacheKey)
 	if ok {
+		if cachedCert == nil {
+			return nil, ErrCertificateNotFound
+		}
 		return cachedCert, nil
 	}
 
 	cert, err := s.store.GetCertificateByReference(ctx, refType, refID)
-	if err != nil || cert == nil {
-		return cert, err
+	if err != nil {
+		if errors.Is(err, ErrCertificateNotFound) {
+			// Cache the absence so subsequent lookups skip the DB.
+			_ = s.certByReferenceCache.Set(ctx, cacheKey, nil)
+		}
+		return nil, err
+	}
+	if cert == nil {
+		_ = s.certByReferenceCache.Set(ctx, cacheKey, nil)
+		return nil, ErrCertificateNotFound
 	}
 	s.cacheCertificate(ctx, cert)
 

--- a/backend/internal/cert/constants.go
+++ b/backend/internal/cert/constants.go
@@ -36,8 +36,6 @@ const (
 type CertificateType string
 
 const (
-	// CertificateTypeNone represents no certificate.
-	CertificateTypeNone CertificateType = "NONE"
 	// CertificateTypeJWKS represents a JSON Web Key Set (JWKS) certificate.
 	CertificateTypeJWKS CertificateType = "JWKS"
 	// CertificateTypeJWKSURI represents a JWKS URI certificate.

--- a/backend/internal/cert/service.go
+++ b/backend/internal/cert/service.go
@@ -305,7 +305,7 @@ func isValidReferenceType(refType CertificateReferenceType) bool {
 // isValidCertificateType checks if the provided certificate type is valid.
 func isValidCertificateType(certType CertificateType) bool {
 	switch certType {
-	case CertificateTypeNone, CertificateTypeJWKS, CertificateTypeJWKSURI:
+	case CertificateTypeJWKS, CertificateTypeJWKSURI:
 		return true
 	default:
 		return false

--- a/backend/internal/cert/service_test.go
+++ b/backend/internal/cert/service_test.go
@@ -811,7 +811,6 @@ func (suite *ServiceTestSuite) TestIsValidCertificateType() {
 		certType CertificateType
 		expected bool
 	}{
-		{"None type", CertificateTypeNone, true},
 		{"JWKS type", CertificateTypeJWKS, true},
 		{"JWKS URI type", CertificateTypeJWKSURI, true},
 		{"Invalid type", CertificateType("INVALID"), false},

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -233,7 +233,7 @@ func validateClientAssertion(
 	jwtService jwt.JWTServiceInterface,
 	discoveryService discovery.DiscoveryServiceInterface,
 	clientID, clientAssertion string) error {
-	if oauthApp.Certificate == nil || oauthApp.Certificate.Type == cert.CertificateTypeNone {
+	if oauthApp.Certificate == nil {
 		return fmt.Errorf("no certificate configured for client assertion validation")
 	}
 

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -1008,22 +1008,6 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NilCertificate() {
 	assert.Contains(suite.T(), err.Error(), "no certificate configured")
 }
 
-func (suite *ClientAuthTestSuite) TestValidateClientAssertion_CertificateTypeNone() {
-	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
-		ClientID: "test-client",
-		Certificate: &appmodel.ApplicationCertificate{
-			Type:  cert.CertificateTypeNone,
-			Value: "",
-		},
-	}
-
-	err := validateClientAssertion(
-		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
-		"some.jwt.token")
-	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "no certificate configured")
-}
-
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Success() {
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		ClientID: "test-client",

--- a/docs/content/guides/guides/applications.mdx
+++ b/docs/content/guides/guides/applications.mdx
@@ -235,7 +235,6 @@ For applications that sign JWT assertions or use mutual TLS, you can attach a ce
 
 | Certificate Type | Description |
 |-----------------|-------------|
-| `NONE` | No certificate configured. |
 | `JWKS` | Provide the JSON Web Key Set (JWKS) inline. |
 | `JWKS_URI` | Provide the URL of the application's JWKS endpoint (for example, `https://yourapp.example.com/.well-known/jwks`). Thunder fetches the public keys from this URL to verify signed requests. |
 

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -9294,7 +9294,6 @@ components:
           type: string
           description: The type of the certificate.
           enum:
-            - NONE
             - JWKS
             - JWKS_URI
           example: JWKS_URI

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -51,10 +51,7 @@ var (
 		URL:                       "https://testapp.example.com",
 		LogoURL:                   "https://testapp.example.com/logo.png",
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -79,10 +76,7 @@ var (
 		Template:                  "spa",
 		URL:                       "https://apptocreate.example.com",
 		LogoURL:                   "https://apptocreate.example.com/logo.png",
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -107,10 +101,7 @@ var (
 		Template:                  "mobile",
 		URL:                       "https://appToUpdate.example.com",
 		LogoURL:                   "https://appToUpdate.example.com/logo.png",
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -275,10 +266,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationListingWithLogoURL() {
 		IsRegistrationFlowEnabled: false,
 		URL:                       "https://appwithlogo.example.com",
 		LogoURL:                   "https://appwithlogo.example.com/logo.png",
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -304,10 +292,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationListingWithLogoURL() {
 		RegistrationFlowID:        defaultRegistrationFlowID,
 		IsRegistrationFlowEnabled: false,
 		URL:                       "https://appwithoutlogo.example.com",
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -547,13 +532,6 @@ func retrieveAndValidateApplicationDetails(ts *ApplicationAPITestSuite, expected
 		appForComparison.InboundAuthConfig[0].OAuthAppConfig.ClientSecret = ""
 	}
 
-	// Ensure certificate is set in expected app if it's null
-	if appForComparison.Certificate == nil {
-		appForComparison.Certificate = &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		}
-	}
 	appForComparison.AuthFlowID = defaultAuthFlowID
 	appForComparison.RegistrationFlowID = defaultRegistrationFlowID
 
@@ -658,10 +636,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithDefaults() {
 		IsRegistrationFlowEnabled: false,
 		AuthFlowID:                defaultAuthFlowID,
 		RegistrationFlowID:        defaultRegistrationFlowID,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -732,10 +707,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithInvalidTokenEndpoi
 		AuthFlowID:                defaultAuthFlowID,
 		RegistrationFlowID:        defaultRegistrationFlowID,
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -767,10 +739,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithInvalidTokenEndpoi
 		AuthFlowID:                defaultAuthFlowID,
 		RegistrationFlowID:        defaultRegistrationFlowID,
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -839,10 +808,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithPartialDefaults() 
 		AuthFlowID:                defaultAuthFlowID,
 		RegistrationFlowID:        defaultRegistrationFlowID,
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -980,7 +946,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithPrivateKeyJWT() {
 			expectedCertValue: jwksJSON,
 		},
 		{
-			name: "failure - private_key_jwt without certificate (NONE type)",
+			name: "failure - private_key_jwt with empty certificate type",
 			app: Application{
 				OUID:                      testOUID,
 				Name:                      "Private Key JWT No Cert App",
@@ -990,7 +956,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithPrivateKeyJWT() {
 				RegistrationFlowID:        defaultRegistrationFlowID,
 				IsRegistrationFlowEnabled: false,
 				Certificate: &ApplicationCert{
-					Type:  "NONE",
+					Type:  "",
 					Value: "",
 				},
 				InboundAuthConfig: []InboundAuthConfig{
@@ -1471,7 +1437,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCertificateUpdate() {
 		Name:        "Certificate Update Test App",
 		Description: "Test certificate updates",
 		URL:         "https://certupdate.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1528,7 +1494,7 @@ func (ts *ApplicationAPITestSuite) TestOAuthAppCertificateUpdate() {
 		Name:        "OAuth Cert Update Test",
 		Description: "Test OAuth certificate updates",
 		URL:         "https://oauthcertupdate.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1651,7 +1617,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationPublicClientValidations() {
 		Name:        "Public Client Invalid Auth",
 		Description: "Test public client validations",
 		URL:         "https://publicclienttest.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1687,7 +1653,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationOAuthConfigValidations() {
 		Name:        "OAuth Config No RedirectURIs",
 		Description: "Test OAuth config validations",
 		URL:         "https://oauthconfigtest.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1728,7 +1694,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithTokenConfiguration() {
 		Name:        "Token Config Test App",
 		Description: "Test application with token configuration",
 		URL:         "https://tokenconfig.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1777,7 +1743,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaims() {
 		Name:        "ID Token Scope Claims Test",
 		Description: "Test ID token scope claims",
 		URL:         "https://idtokenclaims.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1824,7 +1790,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithTokenConfigChanges()
 		Name:        "Token Config Update Test",
 		Description: "Test token config updates",
 		URL:         "https://tokenconfigupdate.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1888,7 +1854,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithPKCERequired() {
 		Name:        "PKCE Required Test",
 		Description: "Test PKCE required configuration",
 		URL:         "https://pkce.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -1927,7 +1893,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationListRetrievesMultiple() {
 			Name:        fmt.Sprintf("List Test App %d", i),
 			Description: fmt.Sprintf("Test application %d", i),
 			URL:         fmt.Sprintf("https://listtest%d.example.com", i),
-			Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+			Certificate: nil,
 			InboundAuthConfig: []InboundAuthConfig{
 				{
 					Type: "oauth2",
@@ -1976,7 +1942,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateCompleteOAuthConfig() {
 		Name:        "Complete OAuth Update Test",
 		Description: "Test complete OAuth config update",
 		URL:         "https://completeoauth.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2067,7 +2033,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyAccessToken() {
 		Name:        "Only Access Token Test",
 		Description: "Test with only access token config",
 		URL:         "https://accesstokenonly.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2109,7 +2075,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyIDToken() {
 		Name:        "Only ID Token Test",
 		Description: "Test with only ID token config",
 		URL:         "https://idtokenonly.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2155,7 +2121,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithBothTokenTypes() {
 		Name:        "Both Token Types Test",
 		Description: "Test with both access and ID tokens",
 		URL:         "https://bothtokens.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2206,7 +2172,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateRemoveOAuthConfig() {
 		Name:        "Remove OAuth Config Test",
 		Description: "Test removing OAuth config",
 		URL:         "https://removeoauth.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2251,7 +2217,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithMultipleGrantAndResponseTy
 		Name:        "Multiple Grant Types Test",
 		Description: "Test with multiple grant and response types",
 		URL:         "https://multiplegrants.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2295,7 +2261,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithMinimalTokenConfig() {
 		Name:        "Minimal Token Config Test",
 		Description: "Test with minimal token config",
 		URL:         "https://minimaltoken.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2330,7 +2296,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithComplexScopeClaims() {
 		Name:        "Complex Scope Claims Test",
 		Description: "Test with complex scope claims",
 		URL:         "https://complexscopes.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2418,7 +2384,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationGetByName() {
 		Name:        uniqueName,
 		Description: "Test get by name",
 		URL:         "https://getbyname.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2484,7 +2450,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationValidationGrantTypeResponseTyp
 		Name:        "Grant Response Incompat Test",
 		Description: "Test incompatible grant and response types",
 		URL:         "https://grantresponseincompat.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2510,7 +2476,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationMultipleRedirectURIValidation(
 		Name:        "Multiple Redirect URI Validation Test",
 		Description: "Test validation of multiple redirect URIs",
 		URL:         "https://multiredirect.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2541,7 +2507,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateAddOAuthConfig() {
 		Name:              "Add OAuth Config Test",
 		Description:       "Test adding OAuth config via update",
 		URL:               "https://addoauth.example.com",
-		Certificate:       &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate:       nil,
 		InboundAuthConfig: []InboundAuthConfig{}, // No OAuth initially
 	}
 
@@ -2591,7 +2557,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationTotalCountRetrieval() {
 			Name:        fmt.Sprintf("Count Test App %d", i),
 			Description: "Test count",
 			URL:         fmt.Sprintf("https://counttest%d.example.com", i),
-			Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+			Certificate: nil,
 			InboundAuthConfig: []InboundAuthConfig{
 				{
 					Type: "oauth2",
@@ -2641,7 +2607,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithCompleteMetadata() {
 		TosURI:      "https://completemeta.example.com/tos",
 		PolicyURI:   "https://completemeta.example.com/privacy",
 		Contacts:    []string{"admin@completemeta.example.com", "support@completemeta.example.com"},
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		Assertion: &AssertionConfig{
 			ValidityPeriod: 7200,
 			UserAttributes: []string{"email", "username", "groups"},
@@ -2728,7 +2694,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyRootToken() {
 		OUID:        testOUID,
 		Name:        "Root Token Only App",
 		Description: "App with only root token",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		Assertion: &AssertionConfig{
 			ValidityPeriod: 5400,
 		},
@@ -2751,7 +2717,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateMetadataFields() {
 		OUID:        testOUID,
 		Name:        "Update Metadata App",
 		Description: "Initial description",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2804,7 +2770,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationPublicClientWithoutSecret() {
 		OUID:        testOUID,
 		Name:        "Public Client No Secret",
 		Description: "Public client without secret",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2838,7 +2804,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationPublicClientPKCEValidation() {
 		OUID:        testOUID,
 		Name:        "Public Client PKCE Validation",
 		Description: "Public client with PKCE explicitly set to false should fail",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2868,7 +2834,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithRefreshTokenGrant() {
 		OUID:        testOUID,
 		Name:        "Refresh Token App",
 		Description: "App with refresh token grant",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -2900,7 +2866,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateTokenConfiguration() {
 		OUID:        testOUID,
 		Name:        "Update Token Config App",
 		Description: "App to update token config",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		Assertion: &AssertionConfig{
 			ValidityPeriod: 3600,
 		},
@@ -2951,7 +2917,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithEmptyContacts() {
 		OUID:        testOUID,
 		Name:        "Empty Contacts App",
 		Description: "App with empty contacts",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		Contacts:    []string{},
 	}
 
@@ -2970,7 +2936,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationClientCredentialsGrant() {
 		OUID:        testOUID,
 		Name:        "Client Credentials App",
 		Description: "App with client credentials grant",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3000,7 +2966,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaimsOnly() {
 		OUID:        testOUID,
 		Name:        "ID Token Scope Claims App",
 		Description: "App with ID token scope claims only",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3049,7 +3015,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithMultipleRedirectURIsAndSco
 		OUID:        testOUID,
 		Name:        "Multiple URIs and Scopes App",
 		Description: "App with multiple redirect URIs and scopes",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3088,7 +3054,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateNonExistent() {
 		OUID:        testOUID,
 		Name:        "Non-Existent App Update",
 		Description: "Attempting to update non-existent app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3134,7 +3100,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithInvalidAuthFlowID() {
 		Name:        "Invalid Auth Flow App",
 		Description: "App with invalid auth flow ID",
 		AuthFlowID:  "edc013d0-e893-4dc0-990c-3e1d203e005b",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	_, err := createApplication(app)
@@ -3149,7 +3115,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithInvalidRegistrationFlowID(
 		Description:               "App with invalid registration flow ID",
 		RegistrationFlowID:        "80024fb3-29ed-4c33-aa48-8aee5e96d522",
 		IsRegistrationFlowEnabled: true,
-		Certificate:               &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate:               nil,
 	}
 
 	_, err := createApplication(app)
@@ -3162,7 +3128,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithDuplicateName() {
 		OUID:        testOUID,
 		Name:        "Duplicate Name Test App",
 		Description: "First app with this name",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID1, err := createApplication(app)
@@ -3174,7 +3140,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithDuplicateName() {
 		OUID:        testOUID,
 		Name:        "Duplicate Name Test App", // Same name
 		Description: "Second app with duplicate name",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	_, err = createApplication(app2)
@@ -3187,7 +3153,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithEmptyName() {
 		OUID:        testOUID,
 		Name:        "", // Empty name
 		Description: "App with empty name",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	_, err := createApplication(app)
@@ -3206,7 +3172,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithVeryLongName() {
 		OUID:        testOUID,
 		Name:        longName,
 		Description: "App with very long name",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID, err := createApplication(app)
@@ -3226,7 +3192,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithSpecialCharactersInName() 
 		OUID:        testOUID,
 		Name:        "Test App with 特殊文字 and émojis 🚀",
 		Description: "App with unicode and special characters",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID, err := createApplication(app)
@@ -3245,7 +3211,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithEmptyOAuthGrantTypes() {
 		OUID:        testOUID,
 		Name:        "Empty Grant Types App",
 		Description: "App with empty OAuth grant types",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3277,7 +3243,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateInvalidAuthFlow() {
 		OUID:        testOUID,
 		Name:        "Update Auth Flow Test App",
 		Description: "App to test auth flow update",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID, err := createApplication(app)
@@ -3290,7 +3256,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateInvalidAuthFlow() {
 		Name:        "Updated with Invalid Auth Flow",
 		Description: "Updated description",
 		AuthFlowID:  "edc013d0-e893-4dc0-990c-3e1d203e005b",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3342,7 +3308,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithNullOptionalFields() {
 		Description: "", // Empty description (optional)
 		URL:         "", // Empty URL (optional)
 		LogoURL:     "", // Empty logo URL (optional)
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID, err := createApplication(app)
@@ -3361,7 +3327,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithEmptyAppID() {
 		OUID:        testOUID,
 		Name:        "Update Test",
 		Description: "Test update with empty app ID",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3393,7 +3359,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithEmptyName() {
 		OUID:        testOUID,
 		Name:        "", // Empty name
 		Description: "Updated description",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3421,7 +3387,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithDuplicateName() {
 		OUID:        testOUID,
 		Name:        "Duplicate Name Update Test App 1",
 		Description: "First app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 	appID1, err := createApplication(app1)
 	ts.Require().NoError(err)
@@ -3432,7 +3398,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithDuplicateName() {
 		OUID:        testOUID,
 		Name:        "Duplicate Name Update Test App 2",
 		Description: "Second app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 	appID2, err := createApplication(app2)
 	ts.Require().NoError(err)
@@ -3443,7 +3409,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithDuplicateName() {
 		OUID:        testOUID,
 		Name:        "Duplicate Name Update Test App 1", // Same as app1
 		Description: "Updated description",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3476,7 +3442,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithInvalidURL() {
 		Name:        "Update Invalid URL",
 		Description: "Test update with invalid URL",
 		URL:         "://invalid-url", // Invalid URL
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3509,7 +3475,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithInvalidLogoURL() {
 		Name:        "Update Invalid LogoURL",
 		Description: "Test update with invalid LogoURL",
 		LogoURL:     "://invalid-logo-url", // Invalid URL
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3538,7 +3504,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithClientIDGeneration()
 		Name:              "Client ID Generation Test",
 		Description:       "Test client ID generation during update",
 		URL:               "https://clientidgen.example.com",
-		Certificate:       &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate:       nil,
 		InboundAuthConfig: []InboundAuthConfig{}, // No OAuth initially
 	}
 
@@ -3594,7 +3560,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithClientIDChange() {
 		Name:        "Client ID Change Test",
 		Description: "Test client ID change during update",
 		URL:         "https://clientidchange.example.com",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3649,7 +3615,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithDuplicateClientID() 
 		OUID:        testOUID,
 		Name:        "Duplicate Client ID Test App 1",
 		Description: "First app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3672,7 +3638,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithDuplicateClientID() 
 		OUID:        testOUID,
 		Name:        "Duplicate Client ID Test App 2",
 		Description: "Second app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3717,7 +3683,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithDefaultAuthFlowID() 
 		OUID:        testOUID,
 		Name:        "Default Auth Flow Test",
 		Description: "Test default auth flow ID",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		// AuthFlowID not set - should use default
 	}
 
@@ -3742,7 +3708,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithInferredRegistration
 		IsRegistrationFlowEnabled: true,
 		AuthFlowID:                defaultAuthFlowID,
 		// RegistrationFlowID not set - should be inferred from auth flow
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appID, err := createApplication(app)
@@ -3780,7 +3746,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateRemoveCertificate() {
 		OUID:        testOUID,
 		Name:        "Remove Certificate Test",
 		Description: "Updated description",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""}, // Remove certificate
+		Certificate: nil, // Remove certificate
 	}
 
 	appJSON, err := json.Marshal(updateApp)
@@ -3805,8 +3771,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateRemoveCertificate() {
 	ts.Require().NoError(err)
 
 	// Verify certificate was removed
-	ts.Assert().Equal("NONE", updatedApp.Certificate.Type)
-	ts.Assert().Equal("", updatedApp.Certificate.Value)
+	ts.Assert().Nil(updatedApp.Certificate)
 }
 
 // TestApplicationCreateWithDuplicateClientID tests creating application with duplicate client ID
@@ -3816,7 +3781,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithDuplicateClientID() 
 		OUID:        testOUID,
 		Name:        "Duplicate Client ID Create Test App 1",
 		Description: "First app",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3839,7 +3804,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithDuplicateClientID() 
 		OUID:        testOUID,
 		Name:        "Duplicate Client ID Create Test App 2",
 		Description: "Second app with duplicate client ID",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -3865,7 +3830,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithInvalidURL() {
 		Name:        "Invalid URL Create Test",
 		Description: "Test create with invalid URL",
 		URL:         "://invalid-url", // Invalid URL
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(app)
@@ -3893,7 +3858,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreateWithInvalidLogoURL() {
 		Name:        "Invalid LogoURL Create Test",
 		Description: "Test create with invalid LogoURL",
 		LogoURL:     "://invalid-logo-url", // Invalid URL
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 	}
 
 	appJSON, err := json.Marshal(app)
@@ -4108,7 +4073,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithThemeAndLayoutID() {
 		Description: "Application with theme and layout configuration",
 		ThemeID:     themeID,
 		LayoutID:    layoutID,
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4140,7 +4105,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithInvalidThemeAndLayoutID() 
 		Name:        "App With Invalid Theme",
 		Description: "Application with invalid theme ID",
 		ThemeID:     "00000000-0000-0000-0000-000000000000",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4214,7 +4179,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithThemeAndLayout() {
 		OUID:        testOUID,
 		Name:        "App To Update Design",
 		Description: "Application to update with theme and layout",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4264,7 +4229,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithInvalidThemeAndLayou
 		OUID:        testOUID,
 		Name:        "App To Update Invalid Design",
 		Description: "Application to update with invalid theme/layout",
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4335,7 +4300,7 @@ func (ts *ApplicationAPITestSuite) TestThemeAndLayoutCannotDeleteWhenAssociatedW
 		Name:        "App Preventing Theme Delete",
 		Description: "Application that prevents theme deletion",
 		ThemeID:     themeID,
-		Certificate: &ApplicationCert{Type: "NONE", Value: ""},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4433,10 +4398,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithAllowedUserTypes() {
 		Description:               "Application with allowed user types",
 		IsRegistrationFlowEnabled: false,
 		AllowedUserTypes:          []string{"employee", "customer"},
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4477,10 +4439,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithInvalidAllowedUserTypes() 
 		Description:               "Application with invalid user types",
 		IsRegistrationFlowEnabled: false,
 		AllowedUserTypes:          []string{"nonexistent_type_1", "nonexistent_type_2"},
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4571,10 +4530,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithAllowedUserTypes() {
 		Name:                      "App To Update With User Types",
 		Description:               "Application to update",
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4635,10 +4591,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithInvalidAllowedUserTy
 		Name:                      "App To Update With Invalid Types",
 		Description:               "Application to update",
 		IsRegistrationFlowEnabled: false,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4705,10 +4658,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithEmptyAllowedUserTypes() {
 		Description:               "Application with empty allowed user types",
 		IsRegistrationFlowEnabled: false,
 		AllowedUserTypes:          []string{},
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -4771,10 +4721,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithPartialInvalidAllowedUserT
 		Description:               "Application with mix of valid and invalid user types",
 		IsRegistrationFlowEnabled: false,
 		AllowedUserTypes:          []string{"valid_user_type", "invalid_user_type"},
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",

--- a/tests/integration/application/model.go
+++ b/tests/integration/application/model.go
@@ -212,15 +212,11 @@ func (app *Application) equals(expectedApp Application) bool {
 		return false
 	}
 
-	// Check certificate - allow nil in expected if actual has default empty certificate
-	if (app.Certificate != nil) && (expectedApp.Certificate == nil) {
-		// If expected has no certificate but actual does, check if it's the default empty one
-		if app.Certificate.Type != "NONE" || app.Certificate.Value != "" {
-			return false
-		}
-	} else if (app.Certificate == nil) && (expectedApp.Certificate != nil) {
+	// Check certificate
+	if (app.Certificate == nil) != (expectedApp.Certificate == nil) {
 		return false
-	} else if app.Certificate != nil && expectedApp.Certificate != nil {
+	}
+	if app.Certificate != nil && expectedApp.Certificate != nil {
 		if app.Certificate.Type != expectedApp.Certificate.Type ||
 			app.Certificate.Value != expectedApp.Certificate.Value {
 			return false
@@ -295,14 +291,11 @@ func (app *Application) equals(expectedApp Application) bool {
 				}
 				// If expected UserInfo is nil, we accept any value in actual (including empty object)
 
-				// Compare OAuth certificate - allow nil expected when actual is default empty
-				if oauth.Certificate != nil && expectedOAuth.Certificate == nil {
-					if oauth.Certificate.Type != "NONE" || oauth.Certificate.Value != "" {
-						return false
-					}
-				} else if oauth.Certificate == nil && expectedOAuth.Certificate != nil {
+				// Compare OAuth certificate
+				if (oauth.Certificate == nil) != (expectedOAuth.Certificate == nil) {
 					return false
-				} else if oauth.Certificate != nil && expectedOAuth.Certificate != nil {
+				}
+				if oauth.Certificate != nil && expectedOAuth.Certificate != nil {
 					if oauth.Certificate.Type != expectedOAuth.Certificate.Type ||
 						oauth.Certificate.Value != expectedOAuth.Certificate.Value {
 						return false

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -79,10 +79,7 @@ func (ts *ExportAPITestSuite) TestApplicationExportYAML() {
 		URL:                       "https://exporttest.example.com",
 		LogoURL:                   "https://exporttest.example.com/logo.png",
 		IsRegistrationFlowEnabled: true,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
@@ -331,10 +328,7 @@ func (ts *ExportAPITestSuite) TestMixedResourcesExportYAML() {
 		Description:               "Test application for mixed export",
 		URL:                       "https://mixedexport.example.com",
 		IsRegistrationFlowEnabled: true,
-		Certificate: &ApplicationCert{
-			Type:  "NONE",
-			Value: "",
-		},
+		Certificate: nil,
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -221,10 +221,6 @@ func CreateApplication(app Application) (string, error) {
 		"isRegistrationFlowEnabled": app.IsRegistrationFlowEnabled,
 		"authFlowId":                app.AuthFlowID,
 		"registrationFlowId":        app.RegistrationFlowID,
-		"certificate": map[string]interface{}{
-			"type":  "NONE",
-			"value": "",
-		},
 		"inboundAuthConfig": []map[string]interface{}{
 			{
 				"type": "oauth2",


### PR DESCRIPTION
This pull request removes the concept of a "NONE" certificate type throughout the codebase, replacing it with the use of `nil` to indicate the absence of a certificate. This simplifies the certificate handling logic and improves clarity. The changes affect certificate validation, application logic, API schema, and related tests.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The `NONE` certificate type is removed. When no certificate is configured, the `certificate` field is omitted from API responses instead of returning `{"type": "NONE", "value": ""}`.

#### 💥 Impact
- **GET responses**: `certificate` field is absent (not `null`, not `{type:"NONE"}`) when no cert is configured.
- **POST/PUT requests**: Sending `{"type": "NONE"}` as certificate type now returns `400 Invalid certificate type`. Omit the field instead.

#### 🔄 Migration Guide

**Response handling** (before → after):
```diff
- if (app.certificate.type === "NONE") { /* no cert */ }
+ if (!app.certificate) { /* no cert */ }
```


**Certificate handling and validation:**

* Removed `CertificateTypeNone` ("NONE") from the certificate type enum and all related logic; absence of a certificate is now represented by `nil` or an empty string. [[1]](diffhunk://#diff-01850ec756e43ec5905c6060b29af2f5b37e38a0bab6c182198879ac8d719f48L39-L40) [[2]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211L1067) [[3]](diffhunk://#diff-86b8e2ba5e91f51875b57667c2eac02692fadf02d44f24c2344ee0a49e29863dL308-R308) [[4]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1382-R1382) [[5]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1711-R1711) [[6]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1721-R1721) [[7]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1761-R1764) [[8]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1775-R1780) [[9]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1834-R1828) [[10]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1852-R1843) [[11]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1943-L1947) [[12]](diffhunk://#diff-ef5867f4f1cd34f103d352ad1892842c5c3e5553126a09032f09225f2f77c533L236-R236)

**Testing updates:**

* Updated all relevant tests to expect `nil` instead of a certificate object with type "NONE" when no certificate is present, and removed tests for the "NONE" type. [[1]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L550-R554) [[2]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L610-R614) [[3]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1275-L1308) [[4]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1335-R1301) [[5]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1474-R1438) [[6]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L2263-L2265) [[7]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L2277-L2279) [[8]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L2324-L2326) [[9]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L2350-R2316) [[10]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L2589-L2604) [[11]](diffhunk://#diff-74b4340d615f21445713910cb80575dd168f686fd2064f74889815114dc8eaa8L814) [[12]](diffhunk://#diff-79da07e121583862b00ca3a8febfe1bd80ea675a28bde34b7436bf6843fb2376L1011-L1026)

**Certificate caching improvements:**

* Enhanced the certificate cache logic to use a sentinel value for negative lookups, ensuring that the absence of a certificate is cached and handled consistently. [[1]](diffhunk://#diff-1f1f9d70fda8bd68aa13ef4c5879430f6dff8bbc48e27b4d2b5aedd29925c56cR31-R33) [[2]](diffhunk://#diff-1f1f9d70fda8bd68aa13ef4c5879430f6dff8bbc48e27b4d2b5aedd29925c56cR75-R90) [[3]](diffhunk://#diff-1f1f9d70fda8bd68aa13ef4c5879430f6dff8bbc48e27b4d2b5aedd29925c56cR166-R168) [[4]](diffhunk://#diff-1f1f9d70fda8bd68aa13ef4c5879430f6dff8bbc48e27b4d2b5aedd29925c56cR191-R201)

These changes make certificate presence and absence handling more idiomatic and reduce unnecessary complexity in the API and application logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the NONE certificate type from certificate configuration options. Applications now support only JWKS and JWKS_URI certificate types.

* **Documentation**
  * Updated OpenAPI schema and application configuration guides to reflect the removal of the NONE certificate type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->