### PR TITLE
Introduce ConfigCryptoProvider Interface and adapt it's usage

### DIFF
--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -31,7 +31,7 @@ import (
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
-	"github.com/asgardeo/thunder/internal/system/crypto/encrypt"
+	"github.com/asgardeo/thunder/internal/system/crypto/config"
 )
 
 // EngineContext holds the overall context used by the flow engine during execution.
@@ -133,16 +133,16 @@ func (f *FlowContextDB) isEncrypted() bool {
 }
 
 // decrypt decrypts the Context field in-place if it is still encrypted.
-func (f *FlowContextDB) decrypt() error {
+func (f *FlowContextDB) decrypt(ctx context.Context) error {
 	if !f.isEncrypted() {
 		return nil
 	}
-	encryptionService := encrypt.GetEncryptionService()
-	decrypted, err := encryptionService.DecryptString(f.Context)
+	encryptionService := config.GetEncryptionService()
+	decrypted, err := encryptionService.Decrypt(ctx, []byte(f.Context))
 	if err != nil {
 		return err
 	}
-	f.Context = decrypted
+	f.Context = string(decrypted)
 	return nil
 }
 
@@ -168,18 +168,22 @@ type flowContextContent struct {
 }
 
 // encrypt marshals and encrypts the content, returning the encrypted string.
-func (c *flowContextContent) encrypt() (string, error) {
+func (c *flowContextContent) encrypt(ctx context.Context) (string, error) {
 	data, err := json.Marshal(c)
 	if err != nil {
 		return "", err
 	}
-	encryptionService := encrypt.GetEncryptionService()
-	return encryptionService.EncryptString(string(data))
+	encryptionService := config.GetEncryptionService()
+	encrypted, err := encryptionService.Encrypt(ctx, data)
+	if err != nil {
+		return "", err
+	}
+	return string(encrypted), nil
 }
 
 // GetGraphID extracts the graph ID from the context JSON.
-func (f *FlowContextDB) GetGraphID() (string, error) {
-	if err := f.decrypt(); err != nil {
+func (f *FlowContextDB) GetGraphID(ctx context.Context) (string, error) {
+	if err := f.decrypt(ctx); err != nil {
 		return "", err
 	}
 	var content flowContextContent
@@ -190,9 +194,9 @@ func (f *FlowContextDB) GetGraphID() (string, error) {
 }
 
 // ToEngineContext converts the database model to the flow engine context.
-func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContext, error) {
+func (f *FlowContextDB) ToEngineContext(ctx context.Context, graph core.GraphInterface) (EngineContext, error) {
 	// Ensure context is decrypted before parsing
-	if err := f.decrypt(); err != nil {
+	if err := f.decrypt(ctx); err != nil {
 		return EngineContext{}, err
 	}
 	var content flowContextContent
@@ -301,6 +305,7 @@ func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContex
 	}
 
 	return EngineContext{
+		Context:            ctx,
 		ExecutionID:        f.ExecutionID,
 		TraceID:            "", // TraceID is transient and set from request context
 		FlowType:           graph.GetType(),
@@ -438,7 +443,7 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		ChallengeTokenHash:  challengeTokenHash,
 	}
 
-	encryptedContext, err := content.encrypt()
+	encryptedContext, err := content.encrypt(ctx.Context)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -19,6 +19,7 @@
 package flowexec
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestModelTestSuite(t *testing.T) {
 }
 
 func (s *ModelTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
-	err := dbModel.decrypt()
+	err := dbModel.decrypt(context.Background())
 	s.NoError(err)
 	var content flowContextContent
 	err = json.Unmarshal([]byte(dbModel.Context), &content)
@@ -73,6 +74,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		Verbose:     true,
@@ -121,6 +123,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		Verbose:     false,
@@ -160,6 +163,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithEmptyAuthenticatedUser() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
+		Context:           context.Background(),
 		ExecutionID:       "test-flow-id",
 		AppID:             "test-app-id",
 		Verbose:           false,
@@ -193,6 +197,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithToken() {
 
 	// Create the context and convert to DB model to get encrypted token
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		FlowType:    common.FlowTypeAuthentication,
@@ -216,7 +221,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithToken() {
 	s.NotNil(content.Token)
 
 	// Execute - Convert back to EngineContext
-	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
 	// Verify
 	s.NoError(err)
@@ -259,7 +264,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
 	}
 
 	// Execute
-	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
 	// Verify
 	s.NoError(err)
@@ -288,6 +293,7 @@ func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
 		s.Run("Token: "+testToken[:min(20, len(testToken))], func() {
 			// Create context with token
 			ctx := EngineContext{
+				Context:     context.Background(),
 				ExecutionID: "test-flow-id",
 				AppID:       "test-app-id",
 				FlowType:    common.FlowTypeAuthentication,
@@ -311,8 +317,8 @@ func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
 			s.Contains(dbModel.Context, `"ct"`, "context should be encrypted")
 
 			// Decrypt and convert back to EngineContext
-			s.NoError(dbModel.decrypt())
-			resultCtx, err := dbModel.ToEngineContext(mockGraph)
+			s.NoError(dbModel.decrypt(context.Background()))
+			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 			s.NoError(err)
 
 			// Verify original token is restored
@@ -344,7 +350,7 @@ func (s *ModelTestSuite) TestDecrypt_WithInvalidCiphertext() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			dbModel := &FlowContextDB{ExecutionID: "test-flow-id", Context: tc.context}
-			err := dbModel.decrypt()
+			err := dbModel.decrypt(context.Background())
 			s.Error(err)
 		})
 	}
@@ -358,7 +364,7 @@ func (s *ModelTestSuite) TestGetGraphID_WithDecryptionFailure() {
 		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
 	}
 
-	graphID, err := dbModel.GetGraphID()
+	graphID, err := dbModel.GetGraphID(context.Background())
 	s.Error(err)
 	s.Empty(graphID)
 }
@@ -373,7 +379,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithDecryptionFailure() {
 		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
 	}
 
-	result, err := dbModel.ToEngineContext(mockGraph)
+	result, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.Error(err)
 	s.Equal(EngineContext{}, result)
 }
@@ -388,7 +394,7 @@ func (s *ModelTestSuite) TestDecrypt_WithDecryptionFailure() {
 
 	s.True(dbModel.isEncrypted(), "context should be detected as encrypted before attempt")
 
-	err := dbModel.decrypt()
+	err := dbModel.decrypt(context.Background())
 	s.Error(err)
 	// Context should remain unchanged (still in its original encrypted form)
 	s.True(dbModel.isEncrypted(), "context should remain encrypted after failed decryption")
@@ -449,12 +455,12 @@ func (s *ModelTestSuite) TestContextEncryptionRoundTrip() {
 			s.NotContains(dbModel.Context, tc.appID, "appId should not be visible in encrypted context")
 
 			// Decrypt and verify all fields are restored
-			err = dbModel.decrypt()
+			err = dbModel.decrypt(context.Background())
 			s.NoError(err)
 			s.NotContains(dbModel.Context, `"ct"`, "decrypted context should not contain ciphertext field")
 			s.Contains(dbModel.Context, `"appId"`, "decrypted context should expose plain appId field")
 
-			resultCtx, err := dbModel.ToEngineContext(mockGraph)
+			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 			s.NoError(err)
 			s.Equal(tc.appID, resultCtx.AppID)
 			s.Equal(tc.userID, resultCtx.AuthenticatedUser.UserID)
@@ -488,7 +494,7 @@ func (s *ModelTestSuite) TestIsEncrypted() {
 	s.True(dbModel.isEncrypted(), "freshly encrypted context should be detected as encrypted")
 
 	// After decryption, should no longer be detected as encrypted
-	err = dbModel.decrypt()
+	err = dbModel.decrypt(context.Background())
 	s.NoError(err)
 	s.False(dbModel.isEncrypted(), "decrypted context should not be detected as encrypted")
 
@@ -529,12 +535,12 @@ func (s *ModelTestSuite) TestDecrypt_WithEncryptedContext() {
 	s.NoError(err)
 	s.True(dbModel.isEncrypted())
 
-	err = dbModel.decrypt()
+	err = dbModel.decrypt(context.Background())
 	s.NoError(err)
 	s.False(dbModel.isEncrypted(), "context should be decrypted after decrypt")
 
 	// Verify context is usable after decrypt
-	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.Equal("ensure-decrypt-app", resultCtx.AppID)
 	s.Equal("user-ensure", resultCtx.AuthenticatedUser.UserID)
@@ -549,7 +555,7 @@ func (s *ModelTestSuite) TestDecrypt_WithPlainContext() {
 	s.False(dbModel.isEncrypted())
 	originalContext := dbModel.Context
 
-	err := dbModel.decrypt()
+	err := dbModel.decrypt(context.Background())
 	s.NoError(err)
 	s.Equal(originalContext, dbModel.Context, "plain context should be unchanged by decrypt")
 }
@@ -562,6 +568,7 @@ func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
 
 	currentAction := "test-action"
 	ctx := EngineContext{
+		Context:       context.Background(),
 		ExecutionID:   "flow-123",
 		AppID:         "app-123",
 		Verbose:       true,
@@ -638,6 +645,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		Verbose:     true,
@@ -690,6 +698,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutAvailableAttributes() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		Verbose:     false,
@@ -746,6 +755,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 
 	// Create the context and convert to DB model to get serialized available attributes
 	ctx := EngineContext{
+		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		FlowType:    common.FlowTypeAuthentication,
@@ -769,7 +779,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 	s.NotNil(content.AvailableAttributes)
 
 	// Execute - Convert back to EngineContext
-	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
 	// Verify
 	s.NoError(err)
@@ -817,7 +827,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
 	}
 
 	// Execute
-	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
 	// Verify
 	s.NoError(err)
@@ -899,6 +909,7 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 		s.Run(tc.name, func() {
 			// Create context with available attributes
 			ctx := EngineContext{
+				Context:     context.Background(),
 				ExecutionID: "test-flow-id",
 				AppID:       "test-app-id",
 				FlowType:    common.FlowTypeAuthentication,
@@ -921,7 +932,7 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 			s.NotNil(content.AvailableAttributes)
 
 			// Convert back to EngineContext (deserializes available attributes)
-			resultCtx, err := dbModel.ToEngineContext(mockGraph)
+			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 			s.NoError(err)
 
 			// Verify original available attributes are restored

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -266,7 +266,7 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID 
 		return nil, flowCtxErr
 	}
 
-	graphID, err := dbModel.GetGraphID()
+	graphID, err := dbModel.GetGraphID(ctx)
 	if err != nil {
 		logger.Error("Failed to extract graph ID from flow context",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
@@ -280,15 +280,12 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID 
 		return nil, &serviceerror.InternalServerError
 	}
 
-	engineContext, err := dbModel.ToEngineContext(graph)
+	engineContext, err := dbModel.ToEngineContext(ctx, graph)
 	if err != nil {
 		logger.Error("Failed to convert flow context from database format",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
-
-	// Embed the request context so downstream helpers can read it from engineContext.Context.
-	engineContext.Context = ctx
 
 	// Set application context if required
 	if err := s.setApplicationToContext(&engineContext, logger); err != nil {
@@ -572,7 +569,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 		return nil, &ErrorInvalidExecutionID
 	}
 
-	if decryptErr := dbModel.decrypt(); decryptErr != nil {
+	if decryptErr := dbModel.decrypt(ctx); decryptErr != nil {
 		logger.Error("Failed to decrypt flow context",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
 		return nil, &serviceerror.InternalServerError

--- a/backend/internal/flow/flowexec/store_test.go
+++ b/backend/internal/flow/flowexec/store_test.go
@@ -32,7 +32,7 @@ import (
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/system/config"
-	"github.com/asgardeo/thunder/internal/system/crypto/encrypt"
+	cryptoconfig "github.com/asgardeo/thunder/internal/system/crypto/config"
 
 	"github.com/asgardeo/thunder/tests/mocks/database/providermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
@@ -64,7 +64,7 @@ func TestStoreTestSuite(t *testing.T) {
 }
 
 func (s *StoreTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
-	err := dbModel.decrypt()
+	err := dbModel.decrypt(context.Background())
 	s.NoError(err)
 	var content flowContextContent
 	err = json.Unmarshal([]byte(dbModel.Context), &content)
@@ -278,7 +278,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.Token)
 
-	restoredCtx, err := result.ToEngineContext(mockGraph)
+	restoredCtx, err := result.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.Equal(testToken, restoredCtx.AuthenticatedUser.Token)
 
@@ -300,8 +300,9 @@ func (s *StoreTestSuite) TestGetFlowContext_WithoutToken() {
 		GraphID:         "test-graph-id",
 	})
 	s.NoError(err)
-	encryptedContext, err := encrypt.GetEncryptionService().EncryptString(string(contextJSON))
+	encryptedContextBytes, err := cryptoconfig.GetEncryptionService().Encrypt(context.Background(), contextJSON)
 	s.NoError(err)
+	encryptedContext := string(encryptedContextBytes)
 
 	results := []map[string]interface{}{
 		{
@@ -393,7 +394,7 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 	s.Equal(originalToken, *content.Token)
 
 	// Step 4: Convert to EngineContext (context already decrypted by getContextContent)
-	retrievedCtx, err := dbModel.ToEngineContext(mockGraph)
+	retrievedCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 
 	// Step 4: Verify all data is preserved correctly
@@ -473,7 +474,7 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_ContextEncryptionRoundTrip() {
 	s.Equal(sensitiveRuntimeData, runtimeData["runtime_key"])
 
 	// Step 4: Convert to EngineContext and verify all data is preserved
-	retrievedCtx, err := dbModel.ToEngineContext(mockGraph)
+	retrievedCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.Equal(originalCtx.ExecutionID, retrievedCtx.ExecutionID)
 	s.Equal(originalCtx.AppID, retrievedCtx.AppID)
@@ -773,7 +774,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	s.NotNil(content.AvailableAttributes)
 
 	// Verify we can deserialize it back to original
-	restoredCtx, err := result.ToEngineContext(mockGraph)
+	restoredCtx, err := result.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.NotNil(restoredCtx.AuthenticatedUser.AvailableAttributes)
 	s.Len(restoredCtx.AuthenticatedUser.AvailableAttributes.Attributes, 2)
@@ -819,7 +820,7 @@ func (s *StoreTestSuite) TestEngineContextRoundTrip_WithAuthUser() {
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.AuthUser)
 
-	restoredCtx, err := dbModel.ToEngineContext(mockGraph)
+	restoredCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.True(restoredCtx.AuthUser.IsAuthenticated())
 }

--- a/backend/internal/system/cmodels/property.go
+++ b/backend/internal/system/cmodels/property.go
@@ -20,10 +20,12 @@
 package cmodels
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
-	"github.com/asgardeo/thunder/internal/system/crypto/encrypt"
+	"github.com/asgardeo/thunder/internal/system/crypto"
+	"github.com/asgardeo/thunder/internal/system/crypto/config"
 )
 
 // Property represents a generic property with name, value, and isSecret fields.
@@ -74,13 +76,13 @@ func (p *Property) GetValue() (string, error) {
 		return p.value, nil
 	}
 
-	cryptoService := encrypt.GetEncryptionService()
-	decryptedValue, err := cryptoService.DecryptString(p.value)
+	var cryptoProvider crypto.ConfigCryptoProvider = config.GetEncryptionService()
+	decryptedBytes, err := cryptoProvider.Decrypt(context.Background(), []byte(p.value))
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt secret property %s: %w", p.GetName(), err)
 	}
 
-	return decryptedValue, nil
+	return string(decryptedBytes), nil
 }
 
 // Encrypt encrypts the value if it's a secret property
@@ -89,13 +91,13 @@ func (p *Property) Encrypt() error {
 		return nil
 	}
 
-	cryptoService := encrypt.GetEncryptionService()
-	encryptedValue, err := cryptoService.EncryptString(p.value)
+	var cryptoProvider crypto.ConfigCryptoProvider = config.GetEncryptionService()
+	encryptedBytes, err := cryptoProvider.Encrypt(context.Background(), []byte(p.value))
 	if err != nil {
 		return fmt.Errorf("failed to encrypt secret property %s: %w", p.GetName(), err)
 	}
 
-	p.value = encryptedValue
+	p.value = string(encryptedBytes)
 	return nil
 }
 

--- a/backend/internal/system/crypto/config/model.go
+++ b/backend/internal/system/crypto/config/model.go
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package encrypt
+package config
 
 // CryptoAlgorithm represents the supported encryption algorithms
 type CryptoAlgorithm string

--- a/backend/internal/system/crypto/config/service.go
+++ b/backend/internal/system/crypto/config/service.go
@@ -16,10 +16,11 @@
  * under the License.
  */
 
-// Package encrypt provides cryptographic functionality with algorithm agility.
-package encrypt
+// Package config provides cryptographic functionality with algorithm agility.
+package config
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -91,9 +92,26 @@ func newEncryptionService(key []byte) *EncryptionService {
 	}
 }
 
-// Encrypt encrypts the given plaintext and returns a JSON string
+// Encrypt implements ConfigCryptoProvider.Encrypt.
+// Encrypts the given plaintext bytes and returns encrypted bytes containing
+// the encrypted data with metadata.
+func (cs *EncryptionService) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	encryptedStr, err := cs.encryptInto(plaintext)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(encryptedStr), nil
+}
+
+// Decrypt implements ConfigCryptoProvider.Decrypt.
+// Decrypts the given encrypted bytes and returns the original plaintext bytes.
+func (cs *EncryptionService) Decrypt(ctx context.Context, encodedData []byte) ([]byte, error) {
+	return cs.decryptFrom(string(encodedData))
+}
+
+// encryptInto encrypts the given plaintext and returns a JSON string
 // containing the encrypted data.
-func (cs *EncryptionService) Encrypt(plaintext []byte) (string, error) {
+func (cs *EncryptionService) encryptInto(plaintext []byte) (string, error) {
 	encryptionKey := cs.getDefaultEncryptionKey()
 	if len(encryptionKey) == 0 {
 		return "", errors.New("default encryption key not found")
@@ -136,9 +154,9 @@ func (cs *EncryptionService) Encrypt(plaintext []byte) (string, error) {
 	return string(jsonData), nil
 }
 
-// Decrypt decrypts the given JSON string produced by Encrypt
+// decryptFrom decrypts the given JSON string produced by encryptInto
 // and returns the original plaintext.
-func (cs *EncryptionService) Decrypt(encodedData string) ([]byte, error) {
+func (cs *EncryptionService) decryptFrom(encodedData string) ([]byte, error) {
 	// Deserialize JSON
 	var encData EncryptedData
 	if err := json.Unmarshal([]byte(encodedData), &encData); err != nil {
@@ -215,22 +233,6 @@ func (cs *EncryptionService) getKeyForDecrypt(kid string) []byte {
 	}
 
 	return nil
-}
-
-// EncryptString encrypts the given plaintext string and returns a
-// JSON string containing the encrypted data.
-func (cs *EncryptionService) EncryptString(plaintext string) (string, error) {
-	return cs.Encrypt([]byte(plaintext))
-}
-
-// DecryptString decrypts the given JSON string produced by Encrypt
-// and returns the original plaintext string.
-func (cs *EncryptionService) DecryptString(ciphertext string) (string, error) {
-	plaintext, err := cs.Decrypt(ciphertext)
-	if err != nil {
-		return "", err
-	}
-	return string(plaintext), nil
 }
 
 // getKeyID generates a unique identifier for the key.

--- a/backend/internal/system/crypto/config/service_test.go
+++ b/backend/internal/system/crypto/config/service_test.go
@@ -16,9 +16,10 @@
  * under the License.
  */
 
-package encrypt
+package config
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -63,15 +64,15 @@ func (suite *EncryptionTestSuite) TestEncryptionService() {
 	original := "This is a secret message that needs encryption!"
 
 	// Encrypt
-	encrypted, err := service.EncryptString(original)
+	encrypted, err := service.Encrypt(context.Background(), []byte(original))
 	assert.NoError(suite.T(), err, "Encryption should not produce an error")
 
 	// Decrypt
-	decrypted, err := service.DecryptString(encrypted)
+	decrypted, err := service.Decrypt(context.Background(), encrypted)
 	assert.NoError(suite.T(), err, "Decryption should not produce an error")
 
 	// Verify
-	assert.Equal(suite.T(), original, decrypted, "Decrypted data should match the original")
+	assert.Equal(suite.T(), original, string(decrypted), "Decrypted data should match the original")
 }
 
 func (suite *EncryptionTestSuite) TestGetEncryptionService_Singleton() {
@@ -130,12 +131,12 @@ func (suite *EncryptionTestSuite) TestTampering() {
 
 	// Encrypt some data
 	original := "Protected data"
-	encrypted, err := service.EncryptString(original)
+	encrypted, err := service.Encrypt(context.Background(), []byte(original))
 	assert.NoError(suite.T(), err, "Encryption should not produce an error")
 
 	// Parse the JSON to get the encrypted data structure
 	var encData EncryptedData
-	err = json.Unmarshal([]byte(encrypted), &encData)
+	err = json.Unmarshal(encrypted, &encData)
 	assert.NoError(suite.T(), err, "Failed to parse encrypted JSON")
 
 	// Tamper with the ciphertext field
@@ -150,7 +151,7 @@ func (suite *EncryptionTestSuite) TestTampering() {
 	assert.NoError(suite.T(), err, "Failed to marshal tampered data")
 
 	// Attempt to decrypt tampered data
-	_, err = service.DecryptString(string(tamperedJSON))
+	_, err = service.Decrypt(context.Background(), tamperedJSON)
 	assert.Error(suite.T(), err, "Expected decryption of tampered data to fail")
 }
 
@@ -161,12 +162,12 @@ func (suite *EncryptionTestSuite) TestEncryptedObjectFormat() {
 
 	// Encrypt some data
 	original := "Data to encrypt"
-	encrypted, err := service.EncryptString(original)
+	encrypted, err := service.Encrypt(context.Background(), []byte(original))
 	assert.NoError(suite.T(), err, "Encryption should not produce an error")
 
 	// Parse the JSON to verify structure
 	var encData EncryptedData
-	err = json.Unmarshal([]byte(encrypted), &encData)
+	err = json.Unmarshal(encrypted, &encData)
 	assert.NoError(suite.T(), err, "Failed to parse encrypted JSON")
 
 	// Verify the structure
@@ -190,12 +191,12 @@ func (suite *EncryptionTestSuite) TestEncryptDecryptCycle() {
 	}
 
 	for _, tc := range testCases {
-		encrypted, err := service.EncryptString(tc)
+		encrypted, err := service.Encrypt(context.Background(), []byte(tc))
 		assert.NoError(suite.T(), err, "Encryption should not produce an error")
 
-		decrypted, err := service.DecryptString(encrypted)
+		decrypted, err := service.Decrypt(context.Background(), encrypted)
 		assert.NoError(suite.T(), err, "Decryption should not produce an error")
-		assert.Equal(suite.T(), tc, decrypted, "Decrypted data should match the original")
+		assert.Equal(suite.T(), tc, string(decrypted), "Decrypted data should match the original")
 	}
 }
 
@@ -211,10 +212,10 @@ func (suite *EncryptionTestSuite) TestDifferentKeysEncryption() {
 
 	// Encrypt with first service
 	original := "Secret message"
-	encrypted, err := service1.EncryptString(original)
+	encrypted, err := service1.Encrypt(context.Background(), []byte(original))
 	assert.NoError(suite.T(), err, "Encryption with first key should not produce an error")
 	// Try to decrypt with second service (should fail)
-	_, err = service2.DecryptString(encrypted)
+	_, err = service2.Decrypt(context.Background(), encrypted)
 	assert.Error(suite.T(), err, "Expected decryption with different key to fail")
 }
 
@@ -226,7 +227,7 @@ func (suite *EncryptionTestSuite) TestEncryptWithInvalidKey() {
 		},
 	}
 
-	_, err := service.Encrypt([]byte("data"))
+	_, err := service.Encrypt(context.Background(), []byte("data"))
 
 	assert.Error(suite.T(), err)
 }
@@ -236,7 +237,7 @@ func (suite *EncryptionTestSuite) TestDecryptInvalidJSON() {
 	assert.NoError(suite.T(), err, "Key generation should not produce an error")
 	service := newEncryptionService(key)
 
-	_, err = service.Decrypt("not-json")
+	_, err = service.Decrypt(context.Background(), []byte("not-json"))
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid data format")
 }
@@ -253,7 +254,7 @@ func (suite *EncryptionTestSuite) TestDecryptUnsupportedAlgorithm() {
 	}
 	raw, _ := json.Marshal(payload)
 
-	_, err = service.Decrypt(string(raw))
+	_, err = service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "unsupported algorithm")
 }
@@ -269,7 +270,7 @@ func (suite *EncryptionTestSuite) TestDecryptInvalidBase64() {
 	}
 	raw, _ := json.Marshal(payload)
 
-	_, err := service.Decrypt(string(raw))
+	_, err := service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid payload encoding")
 }
@@ -286,7 +287,7 @@ func (suite *EncryptionTestSuite) TestDecryptCiphertextTooShort() {
 	}
 	raw, _ := json.Marshal(payload)
 
-	_, err = service.Decrypt(string(raw))
+	_, err = service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 }
 
@@ -305,7 +306,7 @@ func (suite *EncryptionTestSuite) TestDecryptWithInvalidKeyLength() {
 	}
 	raw, _ := json.Marshal(payload)
 
-	_, err := service.Decrypt(string(raw))
+	_, err := service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 }
 
@@ -319,7 +320,7 @@ func (suite *EncryptionTestSuite) TestDecryptUsesKeyFromKidMap() {
 	secondary := newEncryptionService(key2)
 
 	// Encrypt with the secondary key so payload kid points to that key.
-	encrypted, err := secondary.EncryptString("rotated-secret")
+	encrypted, err := secondary.Encrypt(context.Background(), []byte("rotated-secret"))
 	assert.NoError(suite.T(), err)
 
 	// Decrypt using a service whose active key is key1 but key map contains key2.
@@ -331,9 +332,9 @@ func (suite *EncryptionTestSuite) TestDecryptUsesKeyFromKidMap() {
 		},
 	}
 
-	decrypted, err := service.DecryptString(encrypted)
+	decrypted, err := service.Decrypt(context.Background(), encrypted)
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "rotated-secret", decrypted)
+	assert.Equal(suite.T(), "rotated-secret", string(decrypted))
 }
 
 func (suite *EncryptionTestSuite) TestDecryptFailsWhenKidIsUnknown() {
@@ -348,7 +349,7 @@ func (suite *EncryptionTestSuite) TestDecryptFailsWhenKidIsUnknown() {
 	}
 	raw, _ := json.Marshal(payload)
 
-	_, err = service.Decrypt(string(raw))
+	_, err = service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "decryption key not found")
 }
@@ -358,18 +359,18 @@ func (suite *EncryptionTestSuite) TestDecryptFailsWhenKidMissing() {
 	assert.NoError(suite.T(), err)
 	service := newEncryptionService(key)
 
-	encrypted, err := service.EncryptString("legacy-secret")
+	encrypted, err := service.Encrypt(context.Background(), []byte("legacy-secret"))
 	assert.NoError(suite.T(), err)
 
 	var payload EncryptedData
-	err = json.Unmarshal([]byte(encrypted), &payload)
+	err = json.Unmarshal(encrypted, &payload)
 	assert.NoError(suite.T(), err)
 
 	// Simulate older payload without kid.
 	payload.KeyID = ""
 	raw, _ := json.Marshal(payload)
 
-	_, err = service.DecryptString(string(raw))
+	_, err = service.Decrypt(context.Background(), raw)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "decryption key not found")
 }
@@ -384,13 +385,13 @@ func (suite *EncryptionTestSuite) TestNon32() {
 		assert.NoError(suite.T(), err, "Key generation should not produce an error")
 		service := newEncryptionService(key)
 
-		encrypted, err := service.EncryptString(original)
+		encrypted, err := service.Encrypt(context.Background(), []byte(original))
 		assert.NoError(suite.T(), err, "Encryption should not produce an error")
 
-		decrypted, err := service.DecryptString(encrypted)
+		decrypted, err := service.Decrypt(context.Background(), encrypted)
 		assert.NoError(suite.T(), err, "Decryption should not produce an error")
 
-		assert.Equal(suite.T(), original, decrypted, "Decrypted data should match the original")
+		assert.Equal(suite.T(), original, string(decrypted), "Decrypted data should match the original")
 	}
 }
 
@@ -398,7 +399,7 @@ func (suite *EncryptionTestSuite) TestWrongKeySize() {
 	// Generate a key of incorrect size
 	key, _ := generateRandomKey(30)
 	service := newEncryptionService(key)
-	_, err := service.EncryptString("Test data")
+	_, err := service.Encrypt(context.Background(), []byte("Test data"))
 	assert.Error(suite.T(), err, "Expected error due to wrong key size")
 }
 

--- a/backend/internal/system/crypto/provider.go
+++ b/backend/internal/system/crypto/provider.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package crypto defines interfaces for cryptographic providers.
+package crypto
+
+import "context"
+
+// ConfigCryptoProvider provides symmetric encryption and decryption functionality
+// using statically configured keys.
+type ConfigCryptoProvider interface {
+	Encrypt(ctx context.Context, content []byte) ([]byte, error)
+	Decrypt(ctx context.Context, content []byte) ([]byte, error)
+}
+
+// RuntimeCryptoProvider provides asymmetric cryptographic operations including
+// encryption, decryption, signing, and key discovery.
+// Implementation deferred to next phase.
+type RuntimeCryptoProvider interface {
+	// Placeholder for asymmetric operations.
+	// Will be implemented in subsequent phases.
+}


### PR DESCRIPTION
### Summary
This PR introduces config-time crypto abstraction by adding ConfigCryptoProvider and migrating existing symmetric encryption call sites to use the interface instead of calling concrete string-based helpers directly.

### What changed
1. Added config-time crypto contract:
- provider.go
  - Added ConfigCryptoProvider with Encrypt and Decrypt methods.
  - Added RuntimeCryptoProvider placeholder for the next phase.

2. Updated encryption service to implement the provider contract:
- service.go
  - Added provider-compatible Encrypt and Decrypt methods.
  - Kept EncryptString and DecryptString behavior intact through internal helpers.

3. Migrated flow context token crypto to provider calls:
- model.go
  - ToEngineContext now accepts request context and uses provider Decrypt for token restoration.
  - FromEngineContext uses provider Encrypt for token persistence.
  - Engine context propagation remains intact via ToEngineContext(ctx, graph).

4. Migrated auth provider manager token crypto to provider calls:
- model.go
  - MarshalJSON and UnmarshalJSON now use provider Encrypt and Decrypt with context.Background() internally.

5. Migrated common secret property crypto to provider calls:
- property.go
  - GetValue and Encrypt now use provider Decrypt and Encrypt with context.Background().

6. Updated tests for signature and behavior changes:
- service_test.go
- model_test.go
- store_test.go
- model_test.go

### Scope notes
- This PR is config-time crypto only.
- Runtime crypto provider remains a placeholder and is intentionally not implemented in this change.

Issue : https://github.com/asgardeo/thunder/issues/2347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encryption APIs updated to accept context and operate on binary payloads; system components now propagate request context into execution contexts.
  * Secret/property handling switched to the new encryption API and stores ciphertext as binary-backed strings.

* **Tests**
  * Test suites updated to exercise the new context-aware encryption/decryption signatures and serialization round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->