### PR TITLE
Add E2E test coverage for application onboarding and edit flows

### DIFF
--- a/frontend/apps/thunder-console/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/ApplicationsList.tsx
@@ -186,7 +186,7 @@ export default function ApplicationsList(): JSX.Element {
   }
 
   return (
-    <>
+    <Box data-testid="applications-list">
       <ListingTable.Provider variant="data-grid-card" loading={isLoading}>
         <ListingTable.Container disablePaper>
           <ListingTable.DataGrid
@@ -219,6 +219,6 @@ export default function ApplicationsList(): JSX.Element {
         applicationId={selectedAppId}
         onClose={handleDeleteDialogClose}
       />
-    </>
+    </Box>
   );
 }

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureDesign.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureDesign.tsx
@@ -272,7 +272,7 @@ export default function ConfigureDesign({
   }
 
   return (
-    <Stack direction="column" spacing={4}>
+    <Stack direction="column" spacing={4} data-testid="application-configure-design">
       <Stack direction="column" spacing={1}>
         <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.design.title')}

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureDetails.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureDetails.tsx
@@ -465,7 +465,7 @@ export default function ConfigureDetails({
   }
 
   return (
-    <Stack spacing={3}>
+    <Stack spacing={3} data-testid="application-configure-details">
       <Stack direction="column" spacing={1}>
         <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.details.title')}

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureExperience.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureExperience.tsx
@@ -157,7 +157,7 @@ export default function ConfigureExperience({
   };
 
   return (
-    <Stack direction="column" spacing={3}>
+    <Stack direction="column" spacing={3} data-testid="application-configure-experience">
       <Stack direction="column" spacing={1}>
         <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.experience.title')}

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureName.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureName.tsx
@@ -109,7 +109,7 @@ export default function ConfigureName({
   };
 
   return (
-    <Stack direction="column" spacing={4} data-testid="configure-name">
+    <Stack direction="column" spacing={4} data-testid="application-configure-name">
       <Typography variant="h1" gutterBottom>
         {t('applications:onboarding.configure.name.title')}
       </Typography>

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureOrganizationUnit.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureOrganizationUnit.tsx
@@ -42,7 +42,7 @@ export default function ConfigureOrganizationUnit({
   }, [selectedOuId, onReadyChange]);
 
   return (
-    <Stack direction="column" spacing={4}>
+    <Stack direction="column" spacing={4} data-testid="application-configure-organization-unit">
       <Typography variant="h1" gutterBottom>
         {t('applications:onboarding.organizationUnit.title')}
       </Typography>

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureStack.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ConfigureStack.tsx
@@ -231,7 +231,7 @@ export default function ConfigureStack({
   };
 
   return (
-    <Stack direction="column" spacing={3}>
+    <Stack direction="column" spacing={3} data-testid="application-configure-stack">
       {stackTypes.technology && (
         <>
           <Stack direction="column" spacing={1}>

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/ShowClientSecret.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/ShowClientSecret.tsx
@@ -68,7 +68,7 @@ export default function ShowClientSecret({
   };
 
   return (
-    <Stack direction="column" spacing={4} sx={{width: '100%'}}>
+    <Stack direction="column" spacing={4} sx={{width: '100%'}} data-testid="application-show-client-secret">
       {/* Warning Icon */}
       <Box
         sx={{
@@ -120,6 +120,7 @@ export default function ShowClientSecret({
             </Typography>
             <TextField
               fullWidth
+              data-testid="application-client-secret-value"
               type={showSecret ? 'text' : 'password'}
               value={clientSecret}
               InputProps={{
@@ -172,7 +173,7 @@ export default function ShowClientSecret({
         >
           {copied ? t('applications:clientSecret.copied') : t('applications:clientSecret.copySecret')}
         </Button>
-        <Button variant="outlined" fullWidth onClick={onContinue}>
+        <Button data-testid="application-client-secret-continue" variant="outlined" fullWidth onClick={onContinue}>
           {t('common:actions.continue')}
         </Button>
       </Stack>

--- a/frontend/apps/thunder-console/src/features/applications/components/create-application/configure-signin-options/ConfigureSignInOptions.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/create-application/configure-signin-options/ConfigureSignInOptions.tsx
@@ -264,7 +264,7 @@ export default function ConfigureSignInOptions({
   };
 
   return (
-    <Stack direction="column" spacing={4}>
+    <Stack direction="column" spacing={4} data-testid="application-configure-sign-in">
       <Stack direction="column" spacing={1}>
         <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.SignInOptions.title')}

--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
@@ -89,7 +89,7 @@ export default function DangerZoneSection({
           'Permanently delete this application and all associated data. This action cannot be undone.',
         )}
       </Typography>
-      <Button variant="contained" color="error" onClick={onDeleteClick}>
+      <Button data-testid="delete-application-button" variant="contained" color="error" onClick={onDeleteClick}>
         {t('applications:edit.general.sections.dangerZone.deleteApplication.button', 'Delete Application')}
       </Button>
     </SettingsCard>

--- a/frontend/apps/thunder-console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -685,6 +685,7 @@ export default function ApplicationCreatePage(): JSX.Element {
                     <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
                       {createFlow.isPending && <CircularProgress size={20} />}
                       <Button
+                        data-testid="application-wizard-next-button"
                         variant="contained"
                         disabled={
                           !stepReady[currentStep] ||

--- a/frontend/apps/thunder-console/src/features/applications/pages/ApplicationsListPage.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/pages/ApplicationsListPage.tsx
@@ -37,6 +37,7 @@ export default function ApplicationsListPage(): JSX.Element {
         <PageTitle.SubHeader>{t('applications:listing.subtitle')}</PageTitle.SubHeader>
         <PageTitle.Actions>
           <Button
+            data-testid="application-add-button"
             variant="contained"
             startIcon={<Plus size={18} />}
             onClick={() => {

--- a/frontend/apps/thunder-console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -129,6 +129,14 @@ vi.mock('../../utils/getConfigurationTypeFromTemplate', () => ({
   default: vi.fn(() => 'URL'),
 }));
 
+vi.mock('../../../organization-units/api/useHasMultipleOUs', () => ({
+  default: () => ({
+    hasMultipleOUs: false,
+    isLoading: false,
+    ouList: [],
+  }),
+}));
+
 // Mock child components
 vi.mock('../../components/create-application/ConfigureName', () => ({
   default: ({
@@ -140,7 +148,7 @@ vi.mock('../../components/create-application/ConfigureName', () => ({
     onAppNameChange: (name: string) => void;
     onReadyChange: (ready: boolean) => void;
   }) => (
-    <div data-testid="configure-name">
+    <div data-testid="application-configure-name">
       <input
         data-testid="app-name-input"
         value={appName}
@@ -167,7 +175,7 @@ vi.mock('../../components/create-application/ConfigureDesign', () => ({
     onReadyChange: (ready: boolean) => void;
     onThemeSelect?: (themeId: string, themeConfig: Theme) => void;
   }) => (
-    <div data-testid="configure-design">
+    <div data-testid="application-configure-design">
       {appLogo ? <span data-testid="preview-logo">{appLogo}</span> : null}
       <button type="button" data-testid="logo-select-btn" onClick={() => onLogoSelect('test-logo.png')}>
         Select Logo
@@ -210,7 +218,7 @@ vi.mock('../../components/create-application/configure-signin-options/ConfigureS
         }, 0);
 
         return (
-          <div data-testid="configure-sign-in">
+          <div data-testid="application-configure-sign-in">
             <button type="button" data-testid="toggle-integration" onClick={() => onIntegrationToggle('basic_auth')}>
               Toggle Integration
             </button>
@@ -236,7 +244,7 @@ vi.mock('../../components/create-application/ConfigureExperience', () => ({
   }) => {
     setTimeout(() => onReadyChange(true), 0);
     return (
-      <div data-testid="configure-experience">
+      <div data-testid="application-configure-experience">
         <span data-testid="current-approach">{selectedApproach}</span>
         <button type="button" data-testid="select-embedded-approach" onClick={() => onApproachChange('EMBEDDED')}>
           Select Embedded
@@ -252,7 +260,7 @@ vi.mock('../../components/create-application/ConfigureExperience', () => ({
 vi.mock('../../components/create-application/ConfigureStack', () => ({
   default: ({onReadyChange}: {onReadyChange: (ready: boolean) => void}) => {
     setTimeout(() => onReadyChange(true), 0);
-    return <div data-testid="configure-stack">Configure Stack</div>;
+    return <div data-testid="application-configure-stack">Configure Stack</div>;
   },
 }));
 
@@ -269,7 +277,7 @@ vi.mock('../../components/create-application/ConfigureDetails', () => ({
   }) => {
     setTimeout(() => onReadyChange(true), 0);
     return (
-      <div data-testid="configure-details">
+      <div data-testid="application-configure-details">
         <input
           data-testid="callback-url-input"
           onChange={(e) => onCallbackUrlChange(e.target.value)}
@@ -295,10 +303,10 @@ vi.mock('../../components/create-application/ShowClientSecret', () => ({
     onCopySecret: () => void;
     onContinue: () => void;
   }) => (
-    <div data-testid="show-client-secret">
+    <div data-testid="application-show-client-secret">
       <div data-testid="client-secret-app-name">{appName}</div>
-      <div data-testid="client-secret-value">{clientSecret}</div>
-      <button type="button" data-testid="client-secret-continue" onClick={onContinue}>
+      <div data-testid="application-client-secret-value">{clientSecret}</div>
+      <button type="button" data-testid="application-client-secret-continue" onClick={onContinue}>
         Continue
       </button>
     </div>
@@ -331,8 +339,8 @@ describe('ApplicationCreatePage', () => {
     it('should render the name step by default', () => {
       renderWithProviders();
 
-      expect(screen.getByTestId('configure-name')).toBeInTheDocument();
-      expect(screen.queryByTestId('configure-design')).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-design')).not.toBeInTheDocument();
     });
 
     it('should not show preview on first step', () => {
@@ -382,8 +390,8 @@ describe('ApplicationCreatePage', () => {
       const continueButton = screen.getByRole('button', {name: /continue/i});
       await user.click(continueButton);
 
-      expect(screen.getByTestId('configure-design')).toBeInTheDocument();
-      expect(screen.queryByTestId('configure-name')).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-design')).toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-name')).not.toBeInTheDocument();
     });
 
     it('should show preview from design step onwards', async () => {
@@ -404,30 +412,30 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 2: Design
-      expect(screen.getByTestId('configure-design')).toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-design')).toBeInTheDocument();
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 4: Experience
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 5: Stack
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 6: Configure Details
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
     });
 
@@ -447,8 +455,8 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.click(screen.getByRole('button', {name: /back/i}));
 
-      expect(screen.getByTestId('configure-name')).toBeInTheDocument();
-      expect(screen.queryByTestId('configure-design')).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-design')).not.toBeInTheDocument();
     });
   });
 
@@ -478,7 +486,7 @@ describe('ApplicationCreatePage', () => {
       const firstBreadcrumb = screen.getByText('Create an Application');
       await user.click(firstBreadcrumb);
 
-      expect(screen.getByTestId('configure-name')).toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
     });
   });
 
@@ -545,22 +553,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -588,22 +596,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -630,13 +638,13 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Select embedded approach
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       const selectEmbeddedBtn = screen.getByTestId('select-embedded-approach');
       await user.click(selectEmbeddedBtn);
@@ -644,7 +652,7 @@ describe('ApplicationCreatePage', () => {
 
       // Continue from stack - should create app immediately
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -672,24 +680,24 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByTestId('select-embedded-approach'));
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should NOT show configure details step
       await waitFor(() => {
-        expect(screen.queryByTestId('configure-details')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('application-configure-details')).not.toBeInTheDocument();
         expect(mockCreateApplication).toHaveBeenCalled();
       });
     });
@@ -708,22 +716,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -747,22 +755,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -800,22 +808,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -838,13 +846,13 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
 
       const toggleButton = screen.getByTestId('toggle-integration');
       await user.click(toggleButton);
 
-      expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
     });
   });
 
@@ -857,22 +865,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
 
       const callbackInput = screen.getByTestId('callback-url-input');
@@ -908,32 +916,32 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step with client secret
       await waitFor(() => {
-        expect(screen.getByTestId('show-client-secret')).toBeInTheDocument();
+        expect(screen.getByTestId('application-show-client-secret')).toBeInTheDocument();
       });
 
       expect(screen.getByTestId('client-secret-app-name')).toHaveTextContent('My App');
-      expect(screen.getByTestId('client-secret-value')).toHaveTextContent('test_secret_12345');
+      expect(screen.getByTestId('application-client-secret-value')).toHaveTextContent('test_secret_12345');
     });
 
     it('should not show COMPLETE step when application is created without clientSecret', async () => {
@@ -952,22 +960,22 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -977,7 +985,7 @@ describe('ApplicationCreatePage', () => {
       });
 
       // Should not show COMPLETE step
-      expect(screen.queryByTestId('show-client-secret')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('application-show-client-secret')).not.toBeInTheDocument();
     });
 
     it('should navigate to application details when continue is clicked on COMPLETE step', async () => {
@@ -1005,32 +1013,32 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
       await waitFor(() => {
-        expect(screen.getByTestId('show-client-secret')).toBeInTheDocument();
+        expect(screen.getByTestId('application-show-client-secret')).toBeInTheDocument();
       });
 
       // Click continue on COMPLETE step
-      const continueButton = screen.getByTestId('client-secret-continue');
+      const continueButton = screen.getByTestId('application-client-secret-continue');
       await user.click(continueButton);
 
       // Should navigate to application details page
@@ -1064,28 +1072,28 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
       await waitFor(() => {
-        expect(screen.getByTestId('show-client-secret')).toBeInTheDocument();
+        expect(screen.getByTestId('application-show-client-secret')).toBeInTheDocument();
       });
 
       // Back button should not be present
@@ -1123,28 +1131,28 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-experience')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-stack')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
-        expect(screen.getByTestId('configure-details')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
       await waitFor(() => {
-        expect(screen.getByTestId('show-client-secret')).toBeInTheDocument();
+        expect(screen.getByTestId('application-show-client-secret')).toBeInTheDocument();
       });
 
       // Preview should not be visible on COMPLETE step
@@ -1187,7 +1195,7 @@ describe('ApplicationCreatePage', () => {
           };
 
           return (
-            <div data-testid="configure-sign-in">
+            <div data-testid="application-configure-sign-in">
               <button type="button" data-testid="setup-flow-generation" onClick={handleSetup}>
                 Setup Flow Generation
               </button>
@@ -1205,7 +1213,7 @@ describe('ApplicationCreatePage', () => {
 
       // At Options step
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
 
       // Trigger setup
@@ -1253,7 +1261,7 @@ describe('ApplicationCreatePage', () => {
           };
 
           return (
-            <div data-testid="configure-sign-in">
+            <div data-testid="application-configure-sign-in">
               <button type="button" data-testid="setup-flow-generation-error" onClick={handleSetup}>
                 Setup Flow Generation Error
               </button>
@@ -1271,7 +1279,7 @@ describe('ApplicationCreatePage', () => {
 
       // Options step
       await waitFor(() => {
-        expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
 
       // Trigger setup

--- a/tests/e2e/fixtures/console/console-pom.fixture.ts
+++ b/tests/e2e/fixtures/console/console-pom.fixture.ts
@@ -28,12 +28,14 @@
 import { test as base } from "./console-auth.fixture";
 import { ConsoleSigninPage } from "../../pages/authentication";
 import { UsersPage } from "../../pages/user-management";
+import { ApplicationsPage } from "../../pages/applications";
 
 const baseUrl = process.env.BASE_URL || "";
 
 type POMFixtures = {
   signinPage: ConsoleSigninPage;
   usersPage: UsersPage;
+  applicationsPage: ApplicationsPage;
 };
 
 export const test = base.extend<POMFixtures>({
@@ -46,8 +48,14 @@ export const test = base.extend<POMFixtures>({
   usersPage: async ({ authenticatedPage }, use) => {
     await use(new UsersPage(authenticatedPage, baseUrl));
   },
+
+  // Applications page requires auth, uses authenticatedPage fixture
+  applicationsPage: async ({ authenticatedPage }, use) => {
+    await use(new ApplicationsPage(authenticatedPage, baseUrl));
+  },
 });
 
 export { expect } from "@playwright/test";
 export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
+export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";

--- a/tests/e2e/fixtures/console/index.ts
+++ b/tests/e2e/fixtures/console/index.ts
@@ -40,3 +40,4 @@ export { routes, ConsoleRoutes };
 // Re-export page objects
 export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
+export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -384,7 +384,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -603,7 +602,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1028,7 +1026,6 @@
       "integrity": "sha512-IMryZ5SudxzQvuod6rUdIUz29qFItWx281VhtFVc2Psy/ZhlCeD/5DT6lBIJ4H3G+iamGJoTln1v+QSuPw0p7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2062,7 +2059,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2095,7 +2091,6 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -2594,7 +2589,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/tests/e2e/pages/applications/applications.page.ts
+++ b/tests/e2e/pages/applications/applications.page.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Page, Locator, expect } from "@playwright/test";
+import { ConsoleRoutes } from "../../configs/routes/console-routes";
+import { BasePage } from "../base.page";
+import { Timeouts } from "../../constants/timeouts";
+
+export type ApplicationFormData = {
+  name: string;
+  redirectUri?: string;
+};
+
+export class ApplicationsPage extends BasePage {
+  readonly baseUrl: string;
+
+  // List page
+  readonly addApplicationButton: Locator;
+  readonly applicationsList: Locator;
+  readonly searchInput: Locator;
+
+  // Create wizard — shared
+  readonly nextButton: Locator;
+  readonly backButton: Locator;
+  readonly errorAlert: Locator;
+
+  // Create wizard — steps
+  readonly configureNameStep: Locator;
+  readonly appNameInput: Locator;
+  readonly configureOrganizationUnitStep: Locator;
+  readonly configureDesignStep: Locator;
+  readonly configureSignInStep: Locator;
+  readonly configureExperienceStep: Locator;
+  readonly configureStackStep: Locator;
+  readonly configureDetailsStep: Locator;
+  readonly showClientSecretStep: Locator;
+  readonly clientSecretValue: Locator;
+  readonly clientSecretContinue: Locator;
+
+  // Edit page — shared
+  readonly saveButton: Locator;
+
+  // Edit page — General tab
+  readonly applicationIdField: Locator;
+  readonly clientIdField: Locator;
+  readonly applicationUrlInput: Locator;
+  readonly addUriButton: Locator;
+  readonly deleteApplicationButton: Locator;
+
+  constructor(page: Page, baseUrl: string) {
+    super(page);
+    this.baseUrl = baseUrl;
+
+    // List page
+    this.addApplicationButton = page.locator('[data-testid="application-add-button"]');
+
+    this.applicationsList = page.locator('[data-testid="applications-list"]');
+    this.searchInput = page
+      .locator('input[placeholder*="Search" i]')
+      .or(page.locator('[data-testid="applications-list"] input[type="text"]'));
+
+    // Create wizard — shared
+    this.nextButton = page
+      .locator('[data-testid="application-wizard-next-button"]')
+      .or(page.locator("button.MuiButton-contained").filter({ hasText: /continue/i }))
+      .or(page.getByRole("button", { name: /^continue$/i }));
+
+    this.backButton = page.getByRole("button", { name: /^back$/i }).or(page.locator('button:has-text("Back")'));
+
+    this.errorAlert = page.locator(
+      '[role="alert"].MuiAlert-standardError, [role="alert"].MuiAlert-filledError, [role="alert"].MuiAlert-outlinedError'
+    );
+
+    // Create wizard — steps
+    this.configureNameStep = page.locator('[data-testid="application-configure-name"]');
+    this.appNameInput = page.locator('[data-testid="app-name-input"]');
+    this.configureOrganizationUnitStep = page.locator('[data-testid="application-configure-organization-unit"]');
+    this.configureDesignStep = page.locator('[data-testid="application-configure-design"]');
+    this.configureSignInStep = page.locator('[data-testid="application-configure-sign-in"]');
+    this.configureExperienceStep = page.locator('[data-testid="application-configure-experience"]');
+    this.configureStackStep = page.locator('[data-testid="application-configure-stack"]');
+    this.configureDetailsStep = page.locator('[data-testid="application-configure-details"]');
+    this.showClientSecretStep = page.locator('[data-testid="application-show-client-secret"]');
+    this.clientSecretValue = page.locator('[data-testid="application-client-secret-value"]');
+    this.clientSecretContinue = page.locator('[data-testid="application-client-secret-continue"]');
+
+    // Edit page — shared
+    this.saveButton = page.getByRole("button", { name: /^save$/i }).or(page.locator('button:has-text("Save")'));
+
+    // Edit page — General tab
+    this.applicationIdField = page.locator("#application-id-input").or(page.getByLabel("Application ID"));
+    this.clientIdField = page.getByLabel("Client ID");
+    this.applicationUrlInput = page.locator("#application-url-input").or(page.getByLabel("Application URL"));
+    this.addUriButton = page.getByRole("button", { name: /add uri/i }).or(page.locator('button:has-text("Add URI")'));
+    this.deleteApplicationButton = page.locator('[data-testid="delete-application-button"]');
+  }
+
+  /** Navigate to the applications list page */
+  async goto(): Promise<void> {
+    await this.page.goto(`${this.baseUrl}${ConsoleRoutes.applications}`, {
+      waitUntil: "networkidle",
+      timeout: Timeouts.PAGE_LOAD,
+    });
+  }
+
+  /** Navigate directly to an application's edit page */
+  async gotoEdit(appId: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}${ConsoleRoutes.applicationDetails(appId)}`, {
+      waitUntil: "networkidle",
+      timeout: Timeouts.PAGE_LOAD,
+    });
+  }
+
+  /** Verify the applications list page is loaded */
+  async verifyPageLoaded(): Promise<void> {
+    const url = this.page.url();
+    if (url.includes(ConsoleRoutes.signin)) {
+      throw new Error("Authentication failed: Redirected to signin page");
+    }
+    expect(url).toContain(ConsoleRoutes.applications);
+    await expect(this.applicationsList).toBeVisible({ timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /** Click the Add Application button to open the create wizard */
+  async clickAddApplication(): Promise<void> {
+    await this.addApplicationButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.addApplicationButton.first().scrollIntoViewIfNeeded();
+    await this.addApplicationButton.first().click();
+  }
+
+  /** Type in the search box to filter the applications list */
+  async searchApplications(name: string): Promise<void> {
+    await this.searchInput.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.searchInput.first().fill(name);
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /** Get a locator for an application row by its name */
+  getApplicationRowByName(name: string): Locator {
+    return this.page
+      .locator('[role="gridcell"]')
+      .filter({ hasText: name })
+      .or(this.page.locator(".MuiDataGrid-cell").filter({ hasText: name }));
+  }
+
+  /** Wait for a wizard step to be visible by its data-testid */
+  async waitForStep(testid: string, timeout: number = Timeouts.FORM_LOAD): Promise<void> {
+    await this.page.locator(`[data-testid="${testid}"]`).waitFor({ state: "visible", timeout });
+  }
+
+  /** Fill the application name on Step 1 */
+  async fillAppName(name: string): Promise<void> {
+    await this.appNameInput.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.appNameInput.fill(name);
+  }
+
+  /** Click the Next / Continue button in the wizard */
+  async clickNext(): Promise<void> {
+    const btn = this.nextButton.first();
+    await btn.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await btn.scrollIntoViewIfNeeded();
+    await expect(btn).toBeEnabled({ timeout: Timeouts.ELEMENT_VISIBILITY });
+    await btn.click();
+  }
+
+  /**
+   * Handle the optional Organization Unit selection step that appears when the server has multiple OUs.
+   * If the step is not visible it returns immediately; otherwise selects the first OU and advances.
+   */
+  async handleOptionalOuStep(): Promise<void> {
+    try {
+      await this.configureOrganizationUnitStep.waitFor({ state: "visible", timeout: 5000 });
+    } catch {
+      return;
+    }
+    // Wait for the tree to finish loading
+    await this.page
+      .locator('[data-testid="application-configure-organization-unit"] [role="progressbar"]')
+      .waitFor({ state: "detached", timeout: Timeouts.ELEMENT_VISIBILITY })
+      .catch(() => {});
+    // Select the first real tree item (not a placeholder)
+    const firstItem = this.configureOrganizationUnitStep
+      .locator('[role="treeitem"]:not([aria-disabled="true"])')
+      .first();
+    await firstItem.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await firstItem.click();
+    await this.clickNext();
+  }
+
+  /** Select the INBUILT experience option on the experience step (INBUILT is the default, only call if switching) */
+  async selectInbuiltExperience(): Promise<void> {
+    const inbuiltCard = this.page.locator('div:has(input[value="INBUILT"])').first();
+    await inbuiltCard.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await inbuiltCard.click();
+  }
+
+  /** Select the EMBEDDED experience option on the experience step */
+  async selectEmbeddedExperience(): Promise<void> {
+    const embeddedCard = this.page.locator('div:has(input[value="EMBEDDED"])').first();
+    await embeddedCard.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await embeddedCard.click();
+  }
+
+  /** Read the client secret value from the final wizard step */
+  async getClientSecretValue(): Promise<string> {
+    await this.clientSecretValue.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    const nestedInput = this.clientSecretValue.locator("input");
+    const inputCount = await nestedInput.count();
+    if (inputCount > 0) {
+      return nestedInput.first().inputValue();
+    }
+    return this.clientSecretValue.innerText();
+  }
+
+  /** Click the Continue / Done button on the client secret step */
+  async clickDoneAfterCreate(): Promise<void> {
+    await this.clientSecretContinue.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.clientSecretContinue.click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /**
+   * Wait for wizard completion after the last step is submitted.
+   * Some app types show a client-secret screen; others navigate directly to the edit page.
+   * Returns the final edit page URL.
+   */
+  async completeWizardCreation(): Promise<string> {
+    const editUrlPattern = /\/console\/applications\/(?!create)[^/]+$/;
+    await Promise.race([
+      this.showClientSecretStep.waitFor({ state: "visible", timeout: 30000 }),
+      this.page.waitForURL(editUrlPattern, { timeout: 30000 }),
+    ]);
+    if (editUrlPattern.test(this.page.url())) {
+      return this.page.url();
+    }
+    await this.clickDoneAfterCreate();
+    await this.page.waitForURL(editUrlPattern, { timeout: 15000 });
+    return this.page.url();
+  }
+
+  /** Click a tab on the edit page by its visible label */
+  async clickTab(tabName: string): Promise<void> {
+    const tab = this.page.getByRole("tab", { name: new RegExp(tabName, "i") });
+    await tab.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await tab.click();
+  }
+
+  /** Add a redirect / callback URI on the General tab */
+  async addRedirectUri(uri: string): Promise<void> {
+    await this.addUriButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.addUriButton.first().click();
+    const newInput = this.page
+      .locator('input[placeholder*="callback" i], input[placeholder*="uri" i], input[placeholder*="redirect" i]')
+      .last();
+    await newInput.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await newInput.fill(uri);
+    await newInput.blur();
+  }
+
+  /** Click Save on the edit page */
+  async saveChanges(): Promise<void> {
+    await this.saveButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.saveButton.first().click();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /** Click the Delete Application button in the Danger Zone */
+  async clickDeleteApplication(): Promise<void> {
+    await this.deleteApplicationButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.deleteApplicationButton.first().scrollIntoViewIfNeeded();
+    await this.deleteApplicationButton.first().click();
+  }
+
+  /** Confirm the delete dialog */
+  async confirmDelete(): Promise<void> {
+    const dialog = this.page.getByRole("dialog");
+    await dialog.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    const confirmButton = dialog
+      .getByRole("button", { name: /^delete$/i })
+      .or(dialog.getByRole("button", { name: /confirm/i }));
+    await confirmButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await confirmButton.first().click();
+    await this.page.waitForLoadState("networkidle");
+  }
+}

--- a/tests/e2e/pages/applications/index.ts
+++ b/tests/e2e/pages/applications/index.ts
@@ -16,6 +16,8 @@
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
+/**
+ * Applications Pages Index
+ */
+
+export { ApplicationsPage, type ApplicationFormData } from "./applications.page";

--- a/tests/e2e/pages/authentication/console-signin.page.ts
+++ b/tests/e2e/pages/authentication/console-signin.page.ts
@@ -113,7 +113,7 @@ export class ConsoleSigninPage extends BasePage {
 
   /** Wait for successful login */
   async waitForLoginSuccess() {
-    await this.page.waitForURL(`**${ConsoleRoutes.home}/**`, { timeout: Timeouts.PAGE_LOAD });
+    await this.page.waitForURL(/\/console(\/|$)/, { timeout: Timeouts.PAGE_LOAD });
     await this.page.waitForLoadState("networkidle");
   }
 

--- a/tests/e2e/tests/applications/application-edit.spec.ts
+++ b/tests/e2e/tests/applications/application-edit.spec.ts
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Application Edit E2E Tests
+ *
+ * Covers the application edit page tabs and the delete flow.
+ * A test application is created via API in beforeAll and deleted in afterAll,
+ * avoiding wizard dependency for edit tests.
+ *
+ * Required environment variables:
+ * - BASE_URL: Console base URL
+ * - THUNDER_URL: Thunder API base URL (defaults to https://localhost:8090)
+ * - ADMIN_USERNAME: Admin username (defaults to admin)
+ * - ADMIN_PASSWORD: Admin password (defaults to admin)
+ * - SAMPLE_APP_ID: Application ID used to obtain admin token
+ * - DEFAULT_OU_ID: (optional) OU ID for the test application; fetched from the API when not set
+ */
+
+import { test, expect } from "../../fixtures/console";
+import { TestDataFactory } from "../../utils/test-data";
+import { getAdminToken } from "../../utils/authentication";
+
+const thunderUrl = process.env.THUNDER_URL || "https://localhost:8090";
+const defaultOuId = process.env.DEFAULT_OU_ID || "";
+
+test.describe("Application Edit", () => {
+  let testAppId: string;
+  let testAppName: string;
+  let suiteOuId: string;
+
+  test.beforeAll(async ({ request }) => {
+    if (!process.env.SAMPLE_APP_ID) throw new Error("SAMPLE_APP_ID env var is required for Application Edit tests");
+
+    console.log("\n=== Application Edit Suite Setup ===");
+    const appData = TestDataFactory.createApplication({ name: `TestApp_EDIT_${Date.now()}` });
+    testAppName = appData.name;
+
+    const adminToken = await getAdminToken(request);
+
+    let resolvedOuId = defaultOuId;
+    if (!resolvedOuId) {
+      const ouResponse = await request.get(`${thunderUrl}/organization-units?limit=1`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        ignoreHTTPSErrors: true,
+      });
+      if (ouResponse.ok()) {
+        const ouData = await ouResponse.json();
+        resolvedOuId = ouData.organizationUnits?.[0]?.id ?? "";
+      }
+    }
+    if (!resolvedOuId) throw new Error("Could not determine an OU ID for Application Edit tests");
+    suiteOuId = resolvedOuId;
+
+    const createResponse = await request.post(`${thunderUrl}/applications`, {
+      data: {
+        name: appData.name,
+        description: appData.description,
+        ouId: resolvedOuId,
+        inboundAuthConfig: [
+          {
+            type: "oauth2",
+            config: { clientType: "PUBLIC", redirectUris: ["http://localhost:3000/callback"] },
+          },
+        ],
+      },
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      ignoreHTTPSErrors: true,
+    });
+
+    if (!createResponse.ok()) {
+      throw new Error(`Failed to create test application: ${await createResponse.text()}`);
+    }
+
+    const created = await createResponse.json();
+    testAppId = created.id;
+    console.log(`Test application created: ${testAppName} (${testAppId})`);
+  });
+
+  test.afterAll(async ({ request }) => {
+    console.log("\n=== Application Edit Suite Cleanup ===");
+    if (!testAppId) return;
+
+    const adminToken = await getAdminToken(request);
+
+    const deleteResponse = await request.delete(`${thunderUrl}/applications/${testAppId}`, {
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+      },
+      ignoreHTTPSErrors: true,
+    });
+
+    if (deleteResponse.ok()) {
+      console.log(`Test application deleted: ${testAppId}`);
+    } else {
+      console.warn(`Failed to delete test application ${testAppId}: ${await deleteResponse.text()}`);
+    }
+  });
+
+  /** TC006: Edit page - General tab is default and shows Quick Copy fields */
+  test("TC006: Edit page - General tab is default and shows Quick Copy fields", async ({ applicationsPage }) => {
+    await test.step("Navigate to application edit page", async () => {
+      console.log(`Navigating to edit page for app: ${testAppId}`);
+      await applicationsPage.gotoEdit(testAppId);
+      await applicationsPage.screenshot("tc006-edit-page");
+    });
+
+    await test.step("Verify General tab is selected by default", async () => {
+      const generalTab = applicationsPage.page.getByRole("tab", { name: /general/i });
+      await expect(generalTab).toBeVisible();
+      await expect(generalTab).toHaveAttribute("aria-selected", "true");
+      console.log("General tab is active by default");
+    });
+
+    await test.step("Verify Application ID field is visible in Quick Copy section", async () => {
+      await expect(applicationsPage.applicationIdField).toBeVisible();
+      console.log("Application ID field visible");
+      await applicationsPage.screenshot("tc006-quick-copy-fields");
+    });
+  });
+
+  /** TC007: Edit page - Add and save a redirect URI */
+  test("TC007: Edit page - Add and save a redirect URI", async ({ applicationsPage }) => {
+    const testUri = "https://example.com/callback";
+
+    await test.step("Navigate to application edit page", async () => {
+      await applicationsPage.gotoEdit(testAppId);
+      await applicationsPage.screenshot("tc007-edit-page");
+    });
+
+    await test.step("Add a redirect URI", async () => {
+      console.log("Adding redirect URI:", testUri);
+      await applicationsPage.addRedirectUri(testUri);
+      await applicationsPage.screenshot("tc007-uri-added");
+    });
+
+    await test.step("Save changes and verify no error alert", async () => {
+      await applicationsPage.saveChanges();
+      await expect(applicationsPage.errorAlert).not.toBeVisible();
+      console.log("Saved successfully with no error");
+      await applicationsPage.screenshot("tc007-saved");
+    });
+
+    await test.step("Verify URI remains after save", async () => {
+      const uriInput = applicationsPage.page.locator('input[placeholder*="callback" i]').last();
+      await expect(uriInput).toHaveValue(testUri);
+      console.log("URI still present after save:", testUri);
+    });
+  });
+
+  /** TC008: Edit page - Application URL rejects invalid URL */
+  test("TC008: Edit page - Application URL rejects invalid URL", async ({ applicationsPage }) => {
+    await test.step("Navigate to application edit page", async () => {
+      await applicationsPage.gotoEdit(testAppId);
+    });
+
+    await test.step("Type an invalid URL into Application URL field", async () => {
+      await applicationsPage.applicationUrlInput.waitFor({ state: "visible" });
+      await applicationsPage.applicationUrlInput.fill("not-a-valid-url");
+      await applicationsPage.applicationUrlInput.blur();
+      console.log("Entered invalid URL value");
+      await applicationsPage.screenshot("tc008-invalid-url");
+    });
+
+    await test.step("Verify inline validation error is shown for invalid URL", async () => {
+      const validationError = applicationsPage.page
+        .getByText(/please enter a valid url/i)
+        .or(applicationsPage.page.getByText(/invalid url/i));
+      await expect(validationError.first()).toBeVisible();
+      console.log("Inline validation error shown for invalid URL — correct");
+      await applicationsPage.screenshot("tc008-validation-error");
+    });
+  });
+
+  /** TC009: Edit page - Flows tab renders flow selectors */
+  test("TC009: Edit page - Flows tab renders flow selectors", async ({ applicationsPage }) => {
+    await test.step("Navigate to application edit page", async () => {
+      await applicationsPage.gotoEdit(testAppId);
+    });
+
+    await test.step("Click Flows tab", async () => {
+      await applicationsPage.clickTab("Flows");
+      console.log("Clicked Flows tab");
+      await applicationsPage.screenshot("tc009-flows-tab");
+    });
+
+    await test.step("Verify authentication and registration flow selectors are visible", async () => {
+      const authFlowSelector = applicationsPage.page
+        .getByText(/authentication flow/i)
+        .or(applicationsPage.page.getByLabel(/authentication flow/i));
+      const registrationFlowSelector = applicationsPage.page
+        .getByText(/registration flow/i)
+        .or(applicationsPage.page.getByLabel(/registration flow/i));
+
+      await expect(authFlowSelector.first()).toBeVisible();
+      await expect(registrationFlowSelector.first()).toBeVisible();
+      console.log("Authentication and Registration flow selectors visible");
+      await applicationsPage.screenshot("tc009-flow-selectors");
+    });
+  });
+
+  /** TC010: Edit page - Customization tab renders contact fields */
+  test("TC010: Edit page - Customization tab renders contact fields", async ({ applicationsPage }) => {
+    await test.step("Navigate to application edit page", async () => {
+      await applicationsPage.gotoEdit(testAppId);
+    });
+
+    await test.step("Click Customization tab", async () => {
+      await applicationsPage.clickTab("Customization");
+      console.log("Clicked Customization tab");
+      await applicationsPage.screenshot("tc010-customization-tab");
+    });
+
+    await test.step("Verify Terms of Service and Privacy Policy URI fields are visible", async () => {
+      const tosField = applicationsPage.page
+        .locator('input[placeholder*="terms" i]')
+        .or(applicationsPage.page.locator('input[placeholder*="example.com/terms" i]'));
+      const privacyField = applicationsPage.page
+        .locator('input[placeholder*="privacy" i]')
+        .or(applicationsPage.page.locator('input[placeholder*="example.com/privacy" i]'));
+
+      await expect(tosField.first()).toBeVisible();
+      await expect(privacyField.first()).toBeVisible();
+      console.log("Terms of Service and Privacy Policy URI fields visible");
+      await applicationsPage.screenshot("tc010-fields-visible");
+    });
+  });
+
+  /** TC011: Edit page - Inline name edit persists */
+  test("TC011: Edit page - Inline name edit persists", async ({ applicationsPage }) => {
+    const newName = `TestApp_RENAMED_${Date.now()}`;
+
+    await test.step("Navigate to application edit page", async () => {
+      await applicationsPage.gotoEdit(testAppId);
+      await applicationsPage.screenshot("tc011-edit-page");
+    });
+
+    await test.step("Click the edit icon next to the application name and rename it", async () => {
+      const nameHeading = applicationsPage.page.locator("h3").filter({ hasText: testAppName }).first();
+      await nameHeading.waitFor({ state: "visible" });
+
+      // Click the Edit pencil IconButton that sits next to the h3 heading
+      const editNameButton = nameHeading.locator("..").getByRole("button").first();
+      await editNameButton.click();
+
+      const nameInput = applicationsPage.page.locator(`input[value*="TestApp"]`).first();
+      await nameInput.waitFor({ state: "visible" });
+      await nameInput.fill(newName);
+      await nameInput.press("Enter");
+      console.log("Renamed application to:", newName);
+      await applicationsPage.screenshot("tc011-renamed");
+    });
+
+    await test.step("Verify heading shows new name", async () => {
+      const updatedHeading = applicationsPage.page.locator("h3").filter({ hasText: newName });
+      await expect(updatedHeading.first()).toBeVisible();
+      console.log("Heading updated to new name");
+    });
+
+    await test.step("Save changes", async () => {
+      await applicationsPage.saveChanges();
+      console.log("Saved name change");
+      await applicationsPage.screenshot("tc011-saved");
+    });
+
+    await test.step("Reload page and verify new name persists", async () => {
+      await applicationsPage.page.reload({ waitUntil: "networkidle" });
+      const persistedHeading = applicationsPage.page.locator("h3").filter({ hasText: newName });
+      await expect(persistedHeading.first()).toBeVisible();
+      console.log("New name persists after page reload:", newName);
+      await applicationsPage.screenshot("tc011-name-persisted");
+      testAppName = newName;
+    });
+  });
+
+  /** TC012: Delete application from Danger Zone */
+  test("TC012: Delete application from Danger Zone", async ({ applicationsPage, request }) => {
+    let deleteTestAppId: string | undefined;
+    let deleteTestAppName: string = "";
+
+    try {
+      await test.step("Create a dedicated application for delete test", async () => {
+        const appData = TestDataFactory.createApplication({ name: `TestApp_DELETE_${Date.now()}` });
+        deleteTestAppName = appData.name;
+        const adminToken = await getAdminToken(request);
+
+        const createResponse = await request.post(`${thunderUrl}/applications`, {
+          data: {
+            name: appData.name,
+            description: appData.description,
+            ouId: suiteOuId,
+          },
+          headers: {
+            Authorization: `Bearer ${adminToken}`,
+            "Content-Type": "application/json",
+          },
+          ignoreHTTPSErrors: true,
+        });
+
+        expect(createResponse.ok()).toBeTruthy();
+
+        const created = await createResponse.json();
+        deleteTestAppId = created.id;
+        if (!deleteTestAppId) throw new Error("Delete test app creation failed — cannot proceed with delete test");
+        console.log(`Created delete test app: ${deleteTestAppId}`);
+      });
+
+      await test.step("Navigate to application edit page", async () => {
+        await applicationsPage.gotoEdit(deleteTestAppId!);
+        await applicationsPage.screenshot("tc012-before-delete");
+      });
+
+      await test.step("Click Delete Application and confirm", async () => {
+        await applicationsPage.clickDeleteApplication();
+        await applicationsPage.confirmDelete();
+        console.log("Delete confirmed");
+        deleteTestAppId = undefined;
+      });
+
+      await test.step("Verify redirected to applications list", async () => {
+        await applicationsPage.page.waitForURL(/\/console\/applications$/, { timeout: 15000 });
+        await applicationsPage.verifyPageLoaded();
+        console.log("Redirected to applications list after delete");
+        await applicationsPage.screenshot("tc012-after-delete");
+      });
+
+      await test.step("Verify deleted app no longer appears in list", async () => {
+        const deletedRow = applicationsPage.page
+          .locator('[data-testid="applications-list"]')
+          .getByText(deleteTestAppName);
+        await expect(deletedRow).not.toBeVisible();
+        console.log("Deleted app not found in list — correct");
+      });
+    } finally {
+      if (deleteTestAppId) {
+        const adminToken = await getAdminToken(request).catch(() => null);
+        if (adminToken) {
+          await request
+            .delete(`${thunderUrl}/applications/${deleteTestAppId}`, {
+              headers: { Authorization: `Bearer ${adminToken}` },
+              ignoreHTTPSErrors: true,
+            })
+            .catch(() => {});
+        }
+      }
+    }
+  });
+});

--- a/tests/e2e/tests/applications/application-onboarding.spec.ts
+++ b/tests/e2e/tests/applications/application-onboarding.spec.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Application Onboarding E2E Tests
+ *
+ * Covers the applications list page and the create application wizard.
+ *
+ * Required environment variables:
+ * - BASE_URL: Console base URL
+ * - ADMIN_USERNAME: Admin credentials for authentication
+ * - ADMIN_PASSWORD: Admin password for authentication
+ */
+
+import { test, expect } from "../../fixtures/console";
+import { TestDataFactory } from "../../utils/test-data";
+import { getAdminToken } from "../../utils/authentication";
+
+const thunderUrl = process.env.THUNDER_URL || "https://localhost:8090";
+
+async function deleteApplication(request: import("@playwright/test").APIRequestContext, appId: string): Promise<void> {
+  try {
+    const token = await getAdminToken(request);
+    await request.delete(`${thunderUrl}/applications/${appId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      ignoreHTTPSErrors: true,
+    });
+    console.log(`Cleaned up test app: ${appId}`);
+  } catch (e) {
+    console.warn(`Failed to clean up test app ${appId}:`, e);
+  }
+}
+
+test.describe("Application Onboarding", () => {
+  test.describe("Applications List Page", () => {
+    /** TC001: Applications list page loads */
+    test("TC001: Applications list page loads", async ({ applicationsPage }) => {
+      await test.step("Navigate to Applications page", async () => {
+        console.log("Navigating to applications list page...");
+        await applicationsPage.goto();
+        console.log("Applications page navigated");
+        await applicationsPage.screenshot("tc001-applications-page");
+      });
+
+      await test.step("Verify applications list is visible", async () => {
+        await applicationsPage.verifyPageLoaded();
+        console.log("Applications list container visible");
+      });
+
+      await test.step("Verify Add Application button is present", async () => {
+        await expect(applicationsPage.addApplicationButton.first()).toBeVisible();
+        console.log("Add Application button is present");
+        await applicationsPage.screenshot("tc001-verified");
+      });
+    });
+  });
+
+  test.describe("Create Application Wizard", () => {
+    const createdAppIds: string[] = [];
+
+    test.afterAll(async ({ request }) => {
+      for (const appId of createdAppIds) {
+        await deleteApplication(request, appId);
+      }
+    });
+
+    /** TC002: Full INBUILT wizard flow */
+    test("TC002: Create application - full INBUILT wizard flow", async ({ applicationsPage }) => {
+      const appData = TestDataFactory.createApplication({ name: `TestApp_INBUILT_${Date.now()}` });
+      let createdAppUrl: string;
+
+      await test.step("Navigate to Applications page and open wizard", async () => {
+        console.log("Navigating to applications list...");
+        await applicationsPage.goto();
+        await applicationsPage.verifyPageLoaded();
+        await applicationsPage.clickAddApplication();
+        console.log("Opened create application wizard");
+        await applicationsPage.screenshot("tc002-wizard-opened");
+      });
+
+      await test.step("Step 1 [configure-name]: Fill app name and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-name");
+        console.log("Step 1 visible - filling app name:", appData.name);
+        await applicationsPage.fillAppName(appData.name);
+        await applicationsPage.clickNext();
+        console.log("Clicked Next on Step 1");
+        await applicationsPage.screenshot("tc002-step1-done");
+        await applicationsPage.handleOptionalOuStep();
+      });
+
+      await test.step("Step 3 [configure-design]: Skip and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-design");
+        console.log("Step 3 (configure-design) visible - skipping");
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc002-step3-done");
+      });
+
+      await test.step("Step 4 [configure-sign-in]: Skip and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-sign-in");
+        console.log("Step 4 (configure-sign-in) visible - skipping");
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc002-step4-done");
+      });
+
+      await test.step("Step 5 [configure-experience]: Verify INBUILT is default and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-experience");
+        console.log("Step 5 (configure-experience) visible - INBUILT is default, clicking Next");
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc002-step5-done");
+      });
+
+      await test.step("Step 6 [configure-stack]: Skip and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-stack");
+        console.log("Step 6 (configure-stack) visible - skipping");
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc002-step6-done");
+      });
+
+      await test.step("Step 7: Wait for wizard completion (secret screen or edit page)", async () => {
+        createdAppUrl = await applicationsPage.completeWizardCreation();
+        createdAppIds.push(createdAppUrl.split("/").pop()!);
+        await applicationsPage.screenshot("tc002-wizard-done");
+        console.log("Wizard complete, edit URL:", createdAppUrl);
+      });
+
+      await test.step("Verify created app edit page is reachable", async () => {
+        await applicationsPage.page.goto(createdAppUrl, { waitUntil: "networkidle" });
+        expect(applicationsPage.page.url()).toMatch(/\/console\/applications\/[^/]+$/);
+        console.log("Created app edit page still reachable:", createdAppUrl);
+        await applicationsPage.screenshot("tc002-app-verified");
+      });
+    });
+
+    /** TC003: Next button blocked on empty name */
+    test("TC003: Create application wizard - Next blocked on empty name", async ({ applicationsPage }) => {
+      await test.step("Navigate to Applications and open wizard", async () => {
+        await applicationsPage.goto();
+        await applicationsPage.verifyPageLoaded();
+        await applicationsPage.clickAddApplication();
+        await applicationsPage.waitForStep("application-configure-name");
+        console.log("Step 1 visible with empty name input");
+        await applicationsPage.screenshot("tc003-empty-name");
+      });
+
+      await test.step("Verify Next is disabled when name is empty", async () => {
+        await expect(applicationsPage.nextButton.first()).toBeDisabled();
+        console.log("Next button is disabled with empty name — correct");
+      });
+
+      await test.step("Type a name and verify Next becomes enabled", async () => {
+        await applicationsPage.fillAppName(`TestApp_${Date.now()}`);
+        await expect(applicationsPage.nextButton.first()).toBeEnabled();
+        console.log("Next button enabled after typing name — correct");
+        await applicationsPage.screenshot("tc003-name-filled");
+      });
+    });
+
+    /** TC004: EMBEDDED experience skips configure-details */
+    test("TC004: Create application - EMBEDDED experience skips configure-details", async ({ applicationsPage }) => {
+      const appData = TestDataFactory.createApplication({ name: `TestApp_EMBEDDED_${Date.now()}` });
+
+      await test.step("Navigate and open wizard", async () => {
+        await applicationsPage.goto();
+        await applicationsPage.verifyPageLoaded();
+        await applicationsPage.clickAddApplication();
+      });
+
+      await test.step("Step 1: Fill name and advance", async () => {
+        await applicationsPage.waitForStep("application-configure-name");
+        await applicationsPage.fillAppName(appData.name);
+        await applicationsPage.clickNext();
+        await applicationsPage.handleOptionalOuStep();
+      });
+
+      await test.step("Steps 3 & 4: Skip design and sign-in", async () => {
+        await applicationsPage.waitForStep("application-configure-design");
+        await applicationsPage.clickNext();
+        await applicationsPage.waitForStep("application-configure-sign-in");
+        await applicationsPage.clickNext();
+      });
+
+      await test.step("Step 5: Select EMBEDDED and advance", async () => {
+        await applicationsPage.waitForStep("application-configure-experience");
+        console.log("Selecting EMBEDDED experience");
+        await applicationsPage.selectEmbeddedExperience();
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc004-embedded-selected");
+      });
+
+      await test.step("Step 6: Skip configure-stack and verify configure-details is skipped", async () => {
+        await applicationsPage.waitForStep("application-configure-stack");
+        await expect(applicationsPage.configureDetailsStep).not.toBeVisible();
+        await applicationsPage.clickNext();
+        console.log("configure-details was never shown - correct EMBEDDED behaviour");
+        // EMBEDDED without passkey creates app directly and navigates to edit page
+        await applicationsPage.page.waitForURL(/\/console\/applications\/(?!create)[^/]+$/, { timeout: 30000 });
+        createdAppIds.push(applicationsPage.page.url().split("/").pop()!);
+        console.log("Navigated to edit page directly — EMBEDDED skips both configure-details and secret screen");
+        await applicationsPage.screenshot("tc004-details-skipped");
+      });
+    });
+
+    /** TC005: Created application persists after navigation */
+    test("TC005: Created application persists in list after navigation", async ({ applicationsPage }) => {
+      const appData = TestDataFactory.createApplication({ name: `TestApp_PERSIST_${Date.now()}` });
+      let createdAppUrl: string;
+
+      await test.step("Create application via wizard", async () => {
+        await applicationsPage.goto();
+        await applicationsPage.verifyPageLoaded();
+        await applicationsPage.clickAddApplication();
+
+        await applicationsPage.waitForStep("application-configure-name");
+        await applicationsPage.fillAppName(appData.name);
+        await applicationsPage.clickNext();
+        await applicationsPage.handleOptionalOuStep();
+
+        await applicationsPage.waitForStep("application-configure-design");
+        await applicationsPage.clickNext();
+        await applicationsPage.waitForStep("application-configure-sign-in");
+        await applicationsPage.clickNext();
+        await applicationsPage.waitForStep("application-configure-experience");
+        await applicationsPage.clickNext();
+        await applicationsPage.waitForStep("application-configure-stack");
+        await applicationsPage.clickNext();
+
+        createdAppUrl = await applicationsPage.completeWizardCreation();
+        createdAppIds.push(createdAppUrl.split("/").pop()!);
+        console.log("Application created, edit URL:", createdAppUrl);
+      });
+
+      await test.step("Navigate away then back to applications", async () => {
+        await applicationsPage.page.goto(`${process.env.BASE_URL || ""}/console/dashboard`, {
+          waitUntil: "networkidle",
+        });
+        console.log("Navigated away to dashboard");
+        await applicationsPage.goto();
+        await applicationsPage.verifyPageLoaded();
+        console.log("Navigated back to applications list");
+      });
+
+      await test.step("Verify app edit page still reachable after navigation", async () => {
+        await applicationsPage.page.goto(createdAppUrl, { waitUntil: "networkidle" });
+        expect(applicationsPage.page.url()).toMatch(/\/console\/applications\/[^/]+$/);
+        console.log("App still reachable after navigation:", createdAppUrl);
+        await applicationsPage.screenshot("tc005-app-persists");
+      });
+    });
+  });
+});

--- a/tests/e2e/utils/authentication/admin-api-auth.ts
+++ b/tests/e2e/utils/authentication/admin-api-auth.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Obtain a short-lived admin bearer token via the flow execution API.
+ * Reads THUNDER_URL, ADMIN_USERNAME, ADMIN_PASSWORD, and SAMPLE_APP_ID from environment variables.
+ */
+export async function getAdminToken(
+  request: import("@playwright/test").APIRequestContext
+): Promise<string> {
+  const thunderUrl = process.env.THUNDER_URL || "https://localhost:8090";
+  const adminUsername = process.env.ADMIN_USERNAME || "admin";
+  const adminPassword = process.env.ADMIN_PASSWORD || "admin";
+  const applicationId = process.env.SAMPLE_APP_ID || "";
+
+  const flowResponse = await request.post(`${thunderUrl}/flow/execute`, {
+    data: { applicationId, flowType: "AUTHENTICATION" },
+    ignoreHTTPSErrors: true,
+  });
+  if (!flowResponse.ok()) throw new Error(`Failed to start authentication flow: ${await flowResponse.text()}`);
+  const flowData = await flowResponse.json();
+
+  const authResponse = await request.post(`${thunderUrl}/flow/execute`, {
+    data: {
+      executionId: flowData.executionId,
+      ...(flowData.challengeToken && { challengeToken: flowData.challengeToken }),
+      inputs: { username: adminUsername, password: adminPassword, requested_permissions: "system" },
+      action: "action_001",
+    },
+    ignoreHTTPSErrors: true,
+  });
+  if (!authResponse.ok()) throw new Error(`Admin authentication failed: ${await authResponse.text()}`);
+  const { assertion } = await authResponse.json();
+  return assertion;
+}

--- a/tests/e2e/utils/authentication/index.ts
+++ b/tests/e2e/utils/authentication/index.ts
@@ -17,3 +17,4 @@
  */
 
 export * from "../authentication/console-admin-auth-utils";
+export * from "../authentication/admin-api-auth";


### PR DESCRIPTION
### Purpose
The Applications feature had zero functional and accessibility e2e coverage despite being the primary onboarding path for product users — spanning the list page, an 8-step create wizard, and a 6-tab edit page.

This PR adds full Playwright e2e coverage for all high-priority application scenarios (TC001–TC012), and adds the data-testid attributes to the production components required to make those tests reliable.

### Approach

**Frontend — data-testid instrumentation**

The create wizard step components lacked stable test hooks. The following attributes were added to their root elements so tests can assert step transitions without fragile CSS selectors:

- ApplicationsList — root fragment replaced with <Box data-testid="applications-list"> so the list container is addressable
- ConfigureDesign, ConfigureSignInOptions, ConfigureExperience, ConfigureStack, ConfigureDetails — data-testid added to each step's root <Stack>
- ShowClientSecret — data-testid on the root stack, the secret TextField, and the Continue Button
- ApplicationCreatePage — data-testid="wizard-next-button" on the shared Next/Continue button

**Tests — Page Object + Fixtures**

A new ApplicationsPage page object (tests/e2e/pages/applications/) encapsulates all locators and action methods. It is wired into the existing console-pom.fixture.ts as an applicationsPage fixture so specs receive it directly.

Two spec files cover the full scenario matrix:

- application-onboarding.spec.ts — list page load, full INBUILT wizard flow, name validation gate, EMBEDDED path (skips configure-details), post-navigation persistence (TC001–TC005)
- application-edit.spec.ts — General tab defaults, redirect URI add/save, URL validation, Flows tab, Customization tab, inline name rename + persist, Danger Zone delete (TC006–TC012). Edit tests create/delete a test application via API in beforeAll/afterAll, avoiding any wizard dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end suites, page objects, and fixtures for applications: onboarding, creation wizard, edit flows, and deletion, plus new UI-driven tests and helpers.
* **Chores**
  * Added deterministic UI test identifiers across applications list, create-wizard steps, client-secret view, and delete controls to improve test stability and observability.
* **Bug Fixes**
  * Tightened console signin-page URL waiting to reduce flaky navigation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->