### PR TITLE
Add redis and DB retry on failure support

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -58,3 +58,7 @@ Rolldown
 JWTs
 ACL
 ACLs
+[Bb]ackoff
+[Rr]etryable
+[Uu]psert
+[Ii]dempotency

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -33,7 +33,10 @@
         "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
         "max_open_conns": 500,
         "max_idle_conns": 100,
-        "conn_max_lifetime": 3600
+        "conn_max_lifetime": 3600,
+        "max_retries": 3,
+        "min_retry_backoff_ms": 50,
+        "max_retry_backoff_ms": 2000
       }
     },
     "runtime": {
@@ -43,14 +46,23 @@
         "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
         "max_open_conns": 500,
         "max_idle_conns": 100,
-        "conn_max_lifetime": 3600
+        "conn_max_lifetime": 3600,
+        "max_retries": 3,
+        "min_retry_backoff_ms": 50,
+        "max_retry_backoff_ms": 2000
       },
       "redis": {
         "address": "",
         "username": "",
         "password": "",
         "db": 0,
-        "key_prefix": ""
+        "key_prefix": "",
+        "max_retries": 5,
+        "min_retry_backoff_ms": 10,
+        "max_retry_backoff_ms": 100,
+        "dial_timeout_ms": 5000,
+        "read_timeout_ms": 3000,
+        "write_timeout_ms": 3000
       }
     },
     "user": {
@@ -60,7 +72,10 @@
         "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
         "max_open_conns": 500,
         "max_idle_conns": 100,
-        "conn_max_lifetime": 3600
+        "conn_max_lifetime": 3600,
+        "max_retries": 3,
+        "min_retry_backoff_ms": 50,
+        "max_retry_backoff_ms": 2000
       }
     }
   },
@@ -77,7 +92,13 @@
       "username": "",
       "password": "",
       "db": 0,
-      "key_prefix": "thunder"
+      "key_prefix": "thunder",
+      "max_retries": 5,
+      "min_retry_backoff_ms": 10,
+      "max_retry_backoff_ms": 100,
+      "dial_timeout_ms": 5000,
+      "read_timeout_ms": 3000,
+      "write_timeout_ms": 3000
     }
   },
   "jwt": {

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -84,10 +84,16 @@ func (cm *CacheManager) Init() {
 
 	if getCacheType(cacheConfig) == cacheTypeRedis {
 		cm.redisClient = redis.NewClient(&redis.Options{
-			Addr:     cacheConfig.Redis.Address,
-			Username: cacheConfig.Redis.Username,
-			Password: cacheConfig.Redis.Password,
-			DB:       cacheConfig.Redis.DB,
+			Addr:            cacheConfig.Redis.Address,
+			Username:        cacheConfig.Redis.Username,
+			Password:        cacheConfig.Redis.Password,
+			DB:              cacheConfig.Redis.DB,
+			MaxRetries:      cacheConfig.Redis.MaxRetries,
+			MinRetryBackoff: time.Duration(cacheConfig.Redis.MinRetryBackoffMS) * time.Millisecond,
+			MaxRetryBackoff: time.Duration(cacheConfig.Redis.MaxRetryBackoffMS) * time.Millisecond,
+			DialTimeout:     time.Duration(cacheConfig.Redis.DialTimeoutMS) * time.Millisecond,
+			ReadTimeout:     time.Duration(cacheConfig.Redis.ReadTimeoutMS) * time.Millisecond,
+			WriteTimeout:    time.Duration(cacheConfig.Redis.WriteTimeoutMS) * time.Millisecond,
 		})
 		if err := cm.redisClient.Ping(context.Background()).Err(); err != nil {
 			logger.Error("Failed to connect to Redis. Cache initialization aborted.", log.Error(err))

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -96,33 +96,45 @@ type DataSource struct {
 
 // PostgresDataSource holds PostgreSQL-specific connection details.
 type PostgresDataSource struct {
-	Hostname        string `yaml:"hostname" json:"hostname"`
-	Port            int    `yaml:"port" json:"port"`
-	Name            string `yaml:"name" json:"name"`
-	Username        string `yaml:"username" json:"username"`
-	Password        string `yaml:"password" json:"password"`
-	SSLMode         string `yaml:"sslmode" json:"sslmode"`
-	MaxOpenConns    int    `yaml:"max_open_conns" json:"max_open_conns"`
-	MaxIdleConns    int    `yaml:"max_idle_conns" json:"max_idle_conns"`
-	ConnMaxLifetime int    `yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
+	Hostname          string `yaml:"hostname" json:"hostname"`
+	Port              int    `yaml:"port" json:"port"`
+	Name              string `yaml:"name" json:"name"`
+	Username          string `yaml:"username" json:"username"`
+	Password          string `yaml:"password" json:"password"`
+	SSLMode           string `yaml:"sslmode" json:"sslmode"`
+	MaxOpenConns      int    `yaml:"max_open_conns" json:"max_open_conns"`
+	MaxIdleConns      int    `yaml:"max_idle_conns" json:"max_idle_conns"`
+	ConnMaxLifetime   int    `yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
+	MaxRetries        int    `yaml:"max_retries" json:"max_retries"`
+	MinRetryBackoffMS int    `yaml:"min_retry_backoff_ms" json:"min_retry_backoff_ms"`
+	MaxRetryBackoffMS int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
 }
 
 // SQLiteDataSource holds SQLite-specific connection details.
 type SQLiteDataSource struct {
-	Path            string `yaml:"path" json:"path"`
-	Options         string `yaml:"options" json:"options"`
-	MaxOpenConns    int    `yaml:"max_open_conns" json:"max_open_conns"`
-	MaxIdleConns    int    `yaml:"max_idle_conns" json:"max_idle_conns"`
-	ConnMaxLifetime int    `yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
+	Path              string `yaml:"path" json:"path"`
+	Options           string `yaml:"options" json:"options"`
+	MaxOpenConns      int    `yaml:"max_open_conns" json:"max_open_conns"`
+	MaxIdleConns      int    `yaml:"max_idle_conns" json:"max_idle_conns"`
+	ConnMaxLifetime   int    `yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
+	MaxRetries        int    `yaml:"max_retries" json:"max_retries"`
+	MinRetryBackoffMS int    `yaml:"min_retry_backoff_ms" json:"min_retry_backoff_ms"`
+	MaxRetryBackoffMS int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
 }
 
 // RedisDataSource holds Redis-specific connection details.
 type RedisDataSource struct {
-	Address   string `yaml:"address" json:"address"`
-	Username  string `yaml:"username" json:"username"`
-	Password  string `yaml:"password" json:"password"`
-	DB        int    `yaml:"db" json:"db"`
-	KeyPrefix string `yaml:"key_prefix" json:"key_prefix"`
+	Address           string `yaml:"address" json:"address"`
+	Username          string `yaml:"username" json:"username"`
+	Password          string `yaml:"password" json:"password"`
+	DB                int    `yaml:"db" json:"db"`
+	KeyPrefix         string `yaml:"key_prefix" json:"key_prefix"`
+	MaxRetries        int    `yaml:"max_retries" json:"max_retries"`
+	MinRetryBackoffMS int    `yaml:"min_retry_backoff_ms" json:"min_retry_backoff_ms"`
+	MaxRetryBackoffMS int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
+	DialTimeoutMS     int    `yaml:"dial_timeout_ms" json:"dial_timeout_ms"`
+	ReadTimeoutMS     int    `yaml:"read_timeout_ms" json:"read_timeout_ms"`
+	WriteTimeoutMS    int    `yaml:"write_timeout_ms" json:"write_timeout_ms"`
 }
 
 // DatabaseConfig holds the different database configuration details.
@@ -155,11 +167,17 @@ type CacheConfig struct {
 
 // RedisConfig holds the Redis connection configuration.
 type RedisConfig struct {
-	Address   string `yaml:"address" json:"address"`
-	Username  string `yaml:"username" json:"username"`
-	Password  string `yaml:"password" json:"password"`
-	DB        int    `yaml:"db" json:"db"`
-	KeyPrefix string `yaml:"key_prefix" json:"key_prefix"`
+	Address           string `yaml:"address" json:"address"`
+	Username          string `yaml:"username" json:"username"`
+	Password          string `yaml:"password" json:"password"`
+	DB                int    `yaml:"db" json:"db"`
+	KeyPrefix         string `yaml:"key_prefix" json:"key_prefix"`
+	MaxRetries        int    `yaml:"max_retries" json:"max_retries"`
+	MinRetryBackoffMS int    `yaml:"min_retry_backoff_ms" json:"min_retry_backoff_ms"`
+	MaxRetryBackoffMS int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
+	DialTimeoutMS     int    `yaml:"dial_timeout_ms" json:"dial_timeout_ms"`
+	ReadTimeoutMS     int    `yaml:"read_timeout_ms" json:"read_timeout_ms"`
+	WriteTimeoutMS    int    `yaml:"write_timeout_ms" json:"write_timeout_ms"`
 }
 
 // JWTConfig holds the JWT configuration details.

--- a/backend/internal/system/database/provider/dbclient.go
+++ b/backend/internal/system/database/provider/dbclient.go
@@ -50,17 +50,19 @@ type DBClientInterface interface {
 
 // DBClient is the implementation of DBClientInterface.
 type DBClient struct {
-	db     model.DBInterface
-	dbType string
-	dbName string
+	db          model.DBInterface
+	dbType      string
+	dbName      string
+	retryConfig retryConfig
 }
 
 // NewDBClient creates a new instance of DBClient with the provided database connection.
-func NewDBClient(db model.DBInterface, dbType string, dbName string) DBClientInterface {
+func NewDBClient(db model.DBInterface, dbType string, dbName string, rc retryConfig) DBClientInterface {
 	return &DBClient{
-		db:     db,
-		dbType: dbType,
-		dbName: dbName,
+		db:          db,
+		dbType:      dbType,
+		dbName:      dbName,
+		retryConfig: normalizeRetryConfig(rc),
 	}
 }
 
@@ -87,7 +89,12 @@ func (client *DBClient) QueryContext(
 	if tx := transaction.KeyedTxFromContext(ctx, client.dbName); tx != nil {
 		rows, err = tx.QueryContext(ctx, sqlQuery, args...)
 	} else {
-		rows, err = client.db.Query(sqlQuery, args...)
+		err = withRetryDB(ctx, client.dbType, client.dbName, query.GetID(), client.retryConfig,
+			func(execCtx context.Context) error {
+				var queryErr error
+				rows, queryErr = client.db.GetSQLDB().QueryContext(execCtx, sqlQuery, args...)
+				return queryErr
+			})
 	}
 
 	if err != nil {
@@ -150,7 +157,7 @@ func (client *DBClient) ExecuteContext(ctx context.Context, query model.DBQuery,
 	if tx := transaction.KeyedTxFromContext(ctx, client.dbName); tx != nil {
 		res, err = tx.ExecContext(ctx, sqlQuery, args...)
 	} else {
-		res, err = client.db.Exec(sqlQuery, args...)
+		res, err = client.db.GetSQLDB().ExecContext(ctx, sqlQuery, args...)
 	}
 
 	if err != nil {

--- a/backend/internal/system/database/provider/dbclient_test.go
+++ b/backend/internal/system/database/provider/dbclient_test.go
@@ -23,9 +23,14 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"net"
+	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
 
 	"github.com/asgardeo/thunder/internal/system/database/model"
 	"github.com/asgardeo/thunder/internal/system/transaction"
@@ -53,7 +58,7 @@ func (suite *DBClientTestSuite) SetupTest() {
 	}
 
 	db := model.NewDB(suite.mockDB)
-	suite.dbClient = NewDBClient(db, "mock", "test")
+	suite.dbClient = NewDBClient(db, "mock", "test", retryConfig{})
 }
 
 func (suite *DBClientTestSuite) TearDownTest() {
@@ -320,6 +325,57 @@ func (suite *DBClientTestSuite) TestQueryContextError() {
 	assert.Equal(suite.T(), expectedErr, err)
 }
 
+func (suite *DBClientTestSuite) TestQueryContextRetriesOnTransientError() {
+	retryClient := NewDBClient(model.NewDB(suite.mockDB), "mock", "test", retryConfig{
+		MaxAttempts: 2,
+		MinBackoff:  time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		RandFloat64: func() float64 { return 0 },
+	})
+
+	testQuery := model.DBQuery{
+		ID:    "test_query_ctx_retry",
+		Query: "SELECT id FROM users WHERE id = ?",
+	}
+
+	suite.mock.ExpectQuery("SELECT id FROM users WHERE id = ?").
+		WithArgs(1).
+		WillReturnError(&net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+		})
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+	suite.mock.ExpectQuery("SELECT id FROM users WHERE id = ?").
+		WithArgs(1).
+		WillReturnRows(rows)
+
+	results, err := retryClient.QueryContext(context.Background(), testQuery, 1)
+
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), results, 1)
+	assert.Equal(suite.T(), int64(1), results[0]["id"])
+}
+
+func (suite *DBClientTestSuite) TestQueryContextDoesNotRetryOnNonRetryableError() {
+	testQuery := model.DBQuery{
+		ID:    "test_query_ctx_no_retry",
+		Query: "SELECT id FROM users WHERE id = ?",
+	}
+
+	expectedErr := errors.New("syntax error at or near SELECT")
+	suite.mock.ExpectQuery("SELECT id FROM users WHERE id = ?").
+		WithArgs(1).
+		WillReturnError(expectedErr)
+
+	results, err := suite.dbClient.QueryContext(context.Background(), testQuery, 1)
+
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), expectedErr, err)
+	assert.Nil(suite.T(), results)
+}
+
 func (suite *DBClientTestSuite) TestExecuteContextWithoutTransaction() {
 	testQuery := model.DBQuery{
 		ID:    "test_execute_ctx_no_tx",
@@ -394,4 +450,37 @@ func (suite *DBClientTestSuite) TestExecuteContextRowsAffectedError() {
 
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), int64(0), rowsAffected)
+}
+
+func (suite *DBClientTestSuite) TestExecuteContextDoesNotRetryToAvoidDuplicateWrites() {
+	testQuery := model.DBQuery{
+		ID:    "test_execute_ctx_no_retry",
+		Query: "INSERT INTO users(name) VALUES (?)",
+	}
+
+	suite.mock.ExpectExec(`INSERT INTO users\(name\) VALUES \(\?\)`).
+		WithArgs("Alice").
+		WillReturnError(&net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+		})
+
+	rowsAffected, err := suite.dbClient.ExecuteContext(context.Background(), testQuery, "Alice")
+
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), int64(0), rowsAffected)
+}
+
+func (suite *DBClientTestSuite) TestIsRetryableDBError() {
+	assert.True(suite.T(), isRetryableDBError(driver.ErrBadConn))
+	assert.True(suite.T(), isRetryableDBError(context.DeadlineExceeded))
+	assert.True(suite.T(), isRetryableDBError(&pq.Error{Code: "40P01"}))
+	assert.True(suite.T(), isRetryableDBError(&net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNRESET},
+	}))
+	assert.False(suite.T(), isRetryableDBError(sql.ErrNoRows))
+	assert.False(suite.T(), isRetryableDBError(errors.New("syntax error near FROM")))
 }

--- a/backend/internal/system/database/provider/dbprovider.go
+++ b/backend/internal/system/database/provider/dbprovider.go
@@ -264,7 +264,23 @@ func (d *dbProvider) initializeClient(clientPtr *DBClientInterface, dataSource c
 		}
 	}
 
-	*clientPtr = NewDBClient(model.NewDB(db), dbConfig.driverName, dbName)
+	var rc retryConfig
+	switch dataSource.Type {
+	case dataSourceTypePostgres:
+		rc = retryConfig{
+			MaxAttempts: dataSource.Postgres.MaxRetries,
+			MinBackoff:  time.Duration(dataSource.Postgres.MinRetryBackoffMS) * time.Millisecond,
+			MaxBackoff:  time.Duration(dataSource.Postgres.MaxRetryBackoffMS) * time.Millisecond,
+		}
+	case dataSourceTypeSQLite:
+		rc = retryConfig{
+			MaxAttempts: dataSource.SQLite.MaxRetries,
+			MinBackoff:  time.Duration(dataSource.SQLite.MinRetryBackoffMS) * time.Millisecond,
+			MaxBackoff:  time.Duration(dataSource.SQLite.MaxRetryBackoffMS) * time.Millisecond,
+		}
+	}
+
+	*clientPtr = NewDBClient(model.NewDB(db), dbConfig.driverName, dbName, rc)
 	return nil
 }
 

--- a/backend/internal/system/database/provider/dbprovider_test.go
+++ b/backend/internal/system/database/provider/dbprovider_test.go
@@ -71,7 +71,7 @@ func (suite *DBProviderTestSuite) TestGetUserDBTransactioner_Success() {
 
 	// Manually construct the provider with an initialized client
 	provider := &dbProvider{
-		userClient: NewDBClient(model.NewDB(db), "postgres", "user"),
+		userClient: NewDBClient(model.NewDB(db), "postgres", "user", retryConfig{}),
 	}
 
 	// Test getting the transactioner
@@ -90,7 +90,7 @@ func (suite *DBProviderTestSuite) TestGetRuntimeDBTransactioner_Success() {
 
 	// Manually construct the provider with an initialized client
 	provider := &dbProvider{
-		runtimeClient: NewDBClient(model.NewDB(db), "postgres", "runtime"),
+		runtimeClient: NewDBClient(model.NewDB(db), "postgres", "runtime", retryConfig{}),
 	}
 
 	// Test getting the transactioner

--- a/backend/internal/system/database/provider/redisprovider.go
+++ b/backend/internal/system/database/provider/redisprovider.go
@@ -21,6 +21,7 @@ package provider
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 
@@ -68,10 +69,16 @@ func initRedisProvider() {
 
 		r := cfg.Redis
 		client := redis.NewClient(&redis.Options{
-			Addr:     r.Address,
-			Username: r.Username,
-			Password: r.Password,
-			DB:       r.DB,
+			Addr:            r.Address,
+			Username:        r.Username,
+			Password:        r.Password,
+			DB:              r.DB,
+			MaxRetries:      r.MaxRetries,
+			MinRetryBackoff: time.Duration(r.MinRetryBackoffMS) * time.Millisecond,
+			MaxRetryBackoff: time.Duration(r.MaxRetryBackoffMS) * time.Millisecond,
+			DialTimeout:     time.Duration(r.DialTimeoutMS) * time.Millisecond,
+			ReadTimeout:     time.Duration(r.ReadTimeoutMS) * time.Millisecond,
+			WriteTimeout:    time.Duration(r.WriteTimeoutMS) * time.Millisecond,
 		})
 
 		if err := client.Ping(context.Background()).Err(); err != nil {

--- a/backend/internal/system/database/provider/retry.go
+++ b/backend/internal/system/database/provider/retry.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/lib/pq"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	dbRetryMaxAttempts = 3
+	dbRetryMinBackoff  = 50 * time.Millisecond
+	dbRetryMaxBackoff  = 2 * time.Second
+	dbRetryRandFloat64 = rand.Float64
+)
+
+type retryConfig struct {
+	MaxAttempts int
+	MinBackoff  time.Duration
+	MaxBackoff  time.Duration
+	RandFloat64 func() float64
+}
+
+type dbRetryMetrics struct {
+	once             sync.Once
+	retryAttempts    metric.Int64Counter
+	retryBackoff     metric.Float64Histogram
+	operationLatency metric.Float64Histogram
+}
+
+var retryMetrics dbRetryMetrics
+
+func initDBRetryMetrics() {
+	retryMetrics.once.Do(func() {
+		meter := otel.Meter("github.com/asgardeo/thunder/database/retry")
+		retryMetrics.retryAttempts, _ = meter.Int64Counter(
+			"thunder_db_retry_attempts_total",
+			metric.WithDescription("Total DB retry attempts for transient errors"),
+		)
+		retryMetrics.retryBackoff, _ = meter.Float64Histogram(
+			"thunder_db_retry_backoff_seconds",
+			metric.WithDescription("Backoff delay used before DB retry attempts"),
+		)
+		retryMetrics.operationLatency, _ = meter.Float64Histogram(
+			"thunder_db_operation_seconds",
+			metric.WithDescription("Latency of DB operations executed through retry wrapper"),
+		)
+	})
+}
+
+func withRetryDB(
+	ctx context.Context,
+	dbType, dbName, queryID string,
+	retryConfig retryConfig,
+	fn func(context.Context) error,
+) error {
+	config := normalizeRetryConfig(retryConfig)
+	if config.MaxAttempts <= 0 {
+		return fn(ctx)
+	}
+
+	initDBRetryMetrics()
+	start := time.Now()
+	var lastErr error
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		err := fn(ctx)
+		if err == nil {
+			recordDBOperationLatency(ctx, dbType, dbName, queryID, "success", time.Since(start))
+			return nil
+		}
+
+		lastErr = err
+
+		if errors.Is(err, context.Canceled) {
+			recordDBOperationLatency(ctx, dbType, dbName, queryID, "cancelled", time.Since(start))
+			return err
+		}
+
+		if !isRetryableDBError(err) {
+			recordDBOperationLatency(ctx, dbType, dbName, queryID, "failed", time.Since(start))
+			return err
+		}
+
+		if attempt == config.MaxAttempts {
+			break
+		}
+
+		delay := calculateRetryDelay(attempt, config)
+		recordDBRetryAttempt(ctx, dbType, dbName, queryID, attempt, delay)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			recordDBOperationLatency(ctx, dbType, dbName, queryID, "cancelled", time.Since(start))
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	recordDBOperationLatency(ctx, dbType, dbName, queryID, "failed", time.Since(start))
+	return fmt.Errorf("database retry attempts exhausted: %w", lastErr)
+}
+
+func normalizeRetryConfig(config retryConfig) retryConfig {
+	if config.MaxAttempts == 0 {
+		config.MaxAttempts = dbRetryMaxAttempts
+	}
+	if config.MinBackoff <= 0 {
+		config.MinBackoff = dbRetryMinBackoff
+	}
+	if config.MaxBackoff <= 0 {
+		config.MaxBackoff = dbRetryMaxBackoff
+	}
+	if config.MaxBackoff < config.MinBackoff {
+		config.MaxBackoff = config.MinBackoff
+	}
+	if config.RandFloat64 == nil {
+		config.RandFloat64 = dbRetryRandFloat64
+	}
+
+	return config
+}
+
+func calculateRetryDelay(attempt int, config retryConfig) time.Duration {
+	if attempt <= 0 {
+		return config.MinBackoff
+	}
+
+	exponentialFactor := math.Pow(2, float64(attempt-1))
+	base := time.Duration(float64(config.MinBackoff) * exponentialFactor)
+	if base > config.MaxBackoff {
+		base = config.MaxBackoff
+	}
+
+	jitter := time.Duration(config.RandFloat64() * float64(base))
+	delay := base + jitter
+	if delay > config.MaxBackoff {
+		return config.MaxBackoff
+	}
+
+	return delay
+}
+
+func isRetryableDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, sql.ErrNoRows) ||
+		errors.Is(err, sql.ErrTxDone) {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, sql.ErrConnDone) {
+		return true
+	}
+
+	if errors.Is(err, driver.ErrBadConn) {
+		return true
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		code := string(pqErr.Code)
+		if code == "40P01" ||
+			strings.HasPrefix(code, "53") ||
+			code == "57P01" ||
+			code == "57P02" ||
+			code == "57P03" {
+			return true
+		}
+	}
+
+	if isTransientNetworkError(err) {
+		return true
+	}
+
+	return false
+}
+
+func isTransientNetworkError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if hasSyscallErrno(err,
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		syscall.EPIPE,
+		syscall.ETIMEDOUT,
+		syscall.ECONNABORTED,
+		syscall.EHOSTUNREACH,
+		syscall.ENETUNREACH,
+	) {
+		return true
+	}
+
+	return false
+}
+
+func hasSyscallErrno(err error, allowed ...syscall.Errno) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if hasSyscallErrno(opErr.Err, allowed...) {
+			return true
+		}
+	}
+
+	var sysErr *os.SyscallError
+	if errors.As(err, &sysErr) {
+		if hasSyscallErrno(sysErr.Err, allowed...) {
+			return true
+		}
+	}
+
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		for _, candidate := range allowed {
+			if errno == candidate {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func recordDBRetryAttempt(
+	ctx context.Context,
+	dbType, dbName, queryID string,
+	attempt int,
+	delay time.Duration,
+) {
+	attrs := metric.WithAttributes(
+		attribute.String("db.type", dbType),
+		attribute.String("db.name", dbName),
+		attribute.String("db.query_id", queryID),
+		attribute.Int("db.retry_attempt", attempt),
+	)
+	if retryMetrics.retryAttempts != nil {
+		retryMetrics.retryAttempts.Add(ctx, 1, attrs)
+	}
+	if retryMetrics.retryBackoff != nil {
+		retryMetrics.retryBackoff.Record(ctx, delay.Seconds(), attrs)
+	}
+}
+
+func recordDBOperationLatency(
+	ctx context.Context,
+	dbType, dbName, queryID, status string,
+	duration time.Duration,
+) {
+	if retryMetrics.operationLatency == nil {
+		return
+	}
+	retryMetrics.operationLatency.Record(
+		ctx,
+		duration.Seconds(),
+		metric.WithAttributes(
+			attribute.String("db.type", dbType),
+			attribute.String("db.name", dbName),
+			attribute.String("db.query_id", queryID),
+			attribute.String("db.status", status),
+		),
+	)
+}

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -85,6 +85,9 @@ Stores identity provider configurations, applications, and authentication flows.
 | `database.config.postgres.max_open_conns` | `500` | Maximum number of open connections |
 | `database.config.postgres.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.config.postgres.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.config.postgres.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.config.postgres.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.config.postgres.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 **`database.config.sqlite.*`** — only read when `database.config.type: sqlite`:
 
@@ -95,6 +98,9 @@ Stores identity provider configurations, applications, and authentication flows.
 | `database.config.sqlite.max_open_conns` | `500` | Maximum number of open connections |
 | `database.config.sqlite.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.config.sqlite.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.config.sqlite.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.config.sqlite.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.config.sqlite.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 ### Runtime Database
 
@@ -117,6 +123,9 @@ Stores runtime data like sessions, tokens, and temporary data. The runtime datab
 | `database.runtime.postgres.max_open_conns` | `500` | Maximum number of open connections |
 | `database.runtime.postgres.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.runtime.postgres.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.runtime.postgres.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.runtime.postgres.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.runtime.postgres.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 **`database.runtime.sqlite.*`** — only read when `database.runtime.type: sqlite`:
 
@@ -127,6 +136,9 @@ Stores runtime data like sessions, tokens, and temporary data. The runtime datab
 | `database.runtime.sqlite.max_open_conns` | `500` | Maximum number of open connections |
 | `database.runtime.sqlite.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.runtime.sqlite.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.runtime.sqlite.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.runtime.sqlite.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.runtime.sqlite.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 **`database.runtime.redis.*`** — only read when `database.runtime.type: redis`:
 
@@ -137,6 +149,12 @@ Stores runtime data like sessions, tokens, and temporary data. The runtime datab
 | `database.runtime.redis.password` | `""` | Redis password or ACL user password |
 | `database.runtime.redis.db` | `0` | Redis logical database index (0–15) |
 | `database.runtime.redis.key_prefix` | `""` | Prefix applied to all Redis keys written by Thunder, for example `thunder:` |
+| `database.runtime.redis.max_retries` | `5` | Maximum retry attempts for transient Redis network and timeout issues |
+| `database.runtime.redis.min_retry_backoff_ms` | `10` | Minimum delay before Redis retries in milliseconds |
+| `database.runtime.redis.max_retry_backoff_ms` | `100` | Maximum delay before Redis retries in milliseconds |
+| `database.runtime.redis.dial_timeout_ms` | `5000` | Redis connection (dial) timeout in milliseconds |
+| `database.runtime.redis.read_timeout_ms` | `3000` | Redis read timeout in milliseconds |
+| `database.runtime.redis.write_timeout_ms` | `3000` | Redis write timeout in milliseconds |
 
 #### Redis Connection Requirements
 
@@ -146,6 +164,15 @@ Stores runtime data like sessions, tokens, and temporary data. The runtime datab
 - Thunder does not enforce TLS at the client configuration level. To encrypt traffic, place a TLS-terminating proxy in front of Redis and point `database.runtime.redis.address` at the proxy endpoint.
 - If your Redis deployment uses Access Control Lists (ACLs), create a dedicated user and grant the following commands: `GET`, `SET`, `DEL`, `EXPIRE`, `EVAL`, `EVALSHA`. Set `database.runtime.redis.username` and `database.runtime.redis.password` accordingly.
 - Thunder calls `PING` at startup to verify connectivity. The process terminates if the Redis server is unreachable.
+
+#### Database Retry Behavior
+
+Thunder applies exponential backoff with jitter for transient failures on non-transactional SQL read operations (`Query` path). Retry behavior is configurable per database via `max_retries`, `min_retry_backoff_ms`, and `max_retry_backoff_ms` under the relevant `postgres` or `sqlite` sub-key.
+
+- Retryable classes include transient connectivity errors (`ErrBadConn`, `ErrConnDone`, connection reset/refused), timeouts, deadlocks (`40P01`), and PostgreSQL resource/availability states (`53xxx`, `57P01`, `57P02`, `57P03`, too-many-connections).
+- Non-retryable conditions include no-row outcomes (`ErrNoRows`), syntax/validation issues, and other permanent SQL conditions.
+- Write operations executed via `Execute` are not retried automatically to avoid accidental duplicate writes. If your write path is explicitly idempotent, add idempotency at the business layer (for example with deterministic IDs or upsert semantics).
+- Retry metrics are emitted through OpenTelemetry metric instruments (`thunder_db_retry_attempts_total`, `thunder_db_retry_backoff_seconds`, `thunder_db_operation_seconds`), which can be exported to Prometheus via your OpenTelemetry collector pipeline.
 
 ### User Database
 
@@ -168,6 +195,9 @@ Stores user profiles and credentials.
 | `database.user.postgres.max_open_conns` | `500` | Maximum number of open connections |
 | `database.user.postgres.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.user.postgres.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.user.postgres.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.user.postgres.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.user.postgres.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 **`database.user.sqlite.*`** — only read when `database.user.type: sqlite`:
 
@@ -178,6 +208,9 @@ Stores user profiles and credentials.
 | `database.user.sqlite.max_open_conns` | `500` | Maximum number of open connections |
 | `database.user.sqlite.max_idle_conns` | `100` | Maximum number of idle connections |
 | `database.user.sqlite.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.user.sqlite.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.user.sqlite.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.user.sqlite.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 ## Cache Configuration
 
@@ -197,6 +230,12 @@ Thunder includes both in-memory and Redis-backed caching to improve performance.
 | `cache.redis.password` | `""` | Redis password |
 | `cache.redis.db` | `0` | Redis database index |
 | `cache.redis.key_prefix` | `thunder` | Prefix added to all Redis cache keys |
+| `cache.redis.max_retries` | `5` | Maximum retry attempts for transient Redis network and timeout issues |
+| `cache.redis.min_retry_backoff_ms` | `10` | Minimum delay before Redis retries in milliseconds |
+| `cache.redis.max_retry_backoff_ms` | `100` | Maximum delay before Redis retries in milliseconds |
+| `cache.redis.dial_timeout_ms` | `5000` | Redis connection (dial) timeout in milliseconds |
+| `cache.redis.read_timeout_ms` | `3000` | Redis read timeout in milliseconds |
+| `cache.redis.write_timeout_ms` | `3000` | Redis write timeout in milliseconds |
 
 ### Cache Property Overrides
 
@@ -251,6 +290,12 @@ cache:
     password: ""
     db: 0
     key_prefix: "thunder"
+    max_retries: 5
+    min_retry_backoff_ms: 10
+    max_retry_backoff_ms: 100
+    dial_timeout_ms: 5000
+    read_timeout_ms: 3000
+    write_timeout_ms: 3000
 ```
 
 :::note

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -85,6 +85,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.config.sqlite.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.config.sqlite.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.config.sqlite.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.config.sqlite.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.config.sqlite.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.config.sqlite.max_retry_backoff_ms }}
     {{- else }}
     postgres:
       hostname: {{ .Values.configuration.database.config.postgres.hostname | quote }}
@@ -96,6 +99,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.config.postgres.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.config.postgres.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.config.postgres.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.config.postgres.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.config.postgres.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.config.postgres.max_retry_backoff_ms }}
     {{- end }}
   runtime:
     type: {{ .Values.configuration.database.runtime.type | quote }}
@@ -106,6 +112,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.runtime.sqlite.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.runtime.sqlite.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.runtime.sqlite.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.runtime.sqlite.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.runtime.sqlite.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.runtime.sqlite.max_retry_backoff_ms }}
     {{- else if eq .Values.configuration.database.runtime.type "redis" }}
     redis:
       address: {{ .Values.configuration.database.runtime.redis.address | quote }}
@@ -124,6 +133,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.runtime.postgres.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.runtime.postgres.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.runtime.postgres.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.runtime.postgres.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.runtime.postgres.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.runtime.postgres.max_retry_backoff_ms }}
     {{- end }}
   user:
     type: {{ .Values.configuration.database.user.type | quote }}
@@ -134,6 +146,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.user.sqlite.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.user.sqlite.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.user.sqlite.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.user.sqlite.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.user.sqlite.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.user.sqlite.max_retry_backoff_ms }}
     {{- else }}
     postgres:
       hostname: {{ .Values.configuration.database.user.postgres.hostname | quote }}
@@ -145,6 +160,9 @@ database:
       max_open_conns: {{ .Values.configuration.database.user.postgres.max_open_conns }}
       max_idle_conns: {{ .Values.configuration.database.user.postgres.max_idle_conns }}
       conn_max_lifetime: {{ .Values.configuration.database.user.postgres.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.user.postgres.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.user.postgres.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.user.postgres.max_retry_backoff_ms }}
     {{- end }}
 
 cache:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -251,12 +251,18 @@ configuration:
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
       sqlite:
         path: "repository/database/configdb.db"
         options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
     # Runtime database configuration
     runtime:
       # WARNING: Use sqlite only if you are running a single pod.
@@ -274,12 +280,18 @@ configuration:
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
       sqlite:
         path: "repository/database/runtimedb.db"
         options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
       redis:
         address: ""      # Redis server address, e.g. "localhost:6379"
         username: ""
@@ -305,12 +317,18 @@ configuration:
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
       sqlite:
         path: "repository/database/userdb.db"
         options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
         max_open_conns: 500
         max_idle_conns: 100
         conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
 
   # Cache configuration
   cache:


### PR DESCRIPTION
### Purpose
Add redis and DB retry on failure support

### Approach
This pull request introduces robust retry logic for SQL database operations, adds configurable Redis client timeouts and retry parameters, and updates the documentation to reflect these new settings and behaviors. The main focus is to improve resilience against transient errors for both database and Redis connections, while ensuring that write operations remain safe from unintended duplication.

**Database retry logic and metrics:**

* Introduced a new `withRetryDB` function in `provider/retry.go` to wrap non-transactional SQL read operations (`Query`) with exponential backoff and jitter retry logic for transient errors, along with OpenTelemetry metrics for retries and operation latency. Write operations (`Execute`) are not retried to avoid duplicate writes.
* Updated `DBClient.QueryContext` in `dbclient.go` to use `withRetryDB` for non-transactional queries, and ensured `ExecuteContext` uses the correct SQL driver method without retries. [[1]](diffhunk://#diff-d7a0ff3acb2fdd0b6c021509a88ca722cc97023049f42ce95c47f3057bc8164cL90-R94) [[2]](diffhunk://#diff-d7a0ff3acb2fdd0b6c021509a88ca722cc97023049f42ce95c47f3057bc8164cL153-R157)

**Configurable Redis client parameters:**

* Added new fields for retry and timeout configuration to `RedisDataSource` and `RedisConfig` structs, including `max_retries`, `min_retry_backoff_ms`, `max_retry_backoff_ms`, `dial_timeout_ms`, `read_timeout_ms`, and `write_timeout_ms`. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR126-R131) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR169-R174)
* Updated Redis client initialization in both `cache/manager.go` and `database/provider/redisprovider.go` to use these new configuration fields, with sensible defaults if not specified. [[1]](diffhunk://#diff-bb2e0ce39a8737488ed07912b52c02b05042254bbe2ad390d254e17075f78527R61-R76) [[2]](diffhunk://#diff-bb2e0ce39a8737488ed07912b52c02b05042254bbe2ad390d254e17075f78527R102-R118) [[3]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR24) [[4]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR59-R74) [[5]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR92-R102)

**Documentation updates:**

* Documented the new Redis configuration options and provided example YAML configuration in the getting started guide. [[1]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R140-R145) [[2]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R215-R220) [[3]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R275-R280)
* Added a section to the documentation explaining the new database retry behavior, including which errors are considered retryable, and how metrics are emitted.

**Testing improvements:**

* Added new tests to `dbclient_test.go` to verify retry logic for queries, ensure writes are not retried, and validate error classification for retryability. [[1]](diffhunk://#diff-977bc1df650db0560766cfbaf71e4207eef8aa8c7a280bbc1ebe384061bc32beR325-R379) [[2]](diffhunk://#diff-977bc1df650db0560766cfbaf71e4207eef8aa8c7a280bbc1ebe384061bc32beR455-R479)

These changes collectively improve the resilience and observability of both SQL and Redis integrations in Thunder, while providing operators with greater control over connection and retry behaviors.

**References:** [[1]](diffhunk://#diff-3e7a05179913ce34a62b9db937f676160a298d672bd4c87482c4035a0d8e5fd6R1-R209) [[2]](diffhunk://#diff-d7a0ff3acb2fdd0b6c021509a88ca722cc97023049f42ce95c47f3057bc8164cL90-R94) [[3]](diffhunk://#diff-d7a0ff3acb2fdd0b6c021509a88ca722cc97023049f42ce95c47f3057bc8164cL153-R157) [[4]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR126-R131) [[5]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR169-R174) [[6]](diffhunk://#diff-bb2e0ce39a8737488ed07912b52c02b05042254bbe2ad390d254e17075f78527R61-R76) [[7]](diffhunk://#diff-bb2e0ce39a8737488ed07912b52c02b05042254bbe2ad390d254e17075f78527R102-R118) [[8]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR24) [[9]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR59-R74) [[10]](diffhunk://#diff-7b8f00b278263d5a99d5fed7f5b29bda8e74dbd0cca011a43ab2104546749f7bR92-R102) [[11]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R140-R145) [[12]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R156-R164) [[13]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R215-R220) [[14]](diffhunk://#diff-d63e2f9a04a2fca149cfa1a6386b2b3945a0afec265dbe83215d6ed5462679b7R275-R280) [[15]](diffhunk://#diff-977bc1df650db0560766cfbaf71e4207eef8aa8c7a280bbc1ebe384061bc32beR325-R379) [[16]](diffhunk://#diff-977bc1df650db0560766cfbaf71e4207eef8aa8c7a280bbc1ebe384061bc32beR455-R479)

### Related Issues
- https://github.com/asgardeo/thunder/issues/2366

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry/backoff and timeout parameters for Redis and DB connections; non-transactional DB reads now auto-retry with exponential backoff and jitter (writes are not retried).
  * Exposed OpenTelemetry metrics for DB retry attempts, backoff, and operation latency.

* **Documentation**
  * Updated configuration guide and examples with new retry, backoff, and timeout settings and observability notes.

* **Tests**
  * Added tests covering retry behavior and retry/no-retry distinctions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->