### PR TITLE
Support mandatory per step challenge token for flow execution

### DIFF
--- a/api/flow-execution.yaml
+++ b/api/flow-execution.yaml
@@ -41,6 +41,7 @@ paths:
                 summary: Subsequent request
                 value:
                   executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                  challengeToken: "a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
                   actionId: "basic_auth"
                   inputs: {
                     "username": "thor",
@@ -63,6 +64,7 @@ paths:
                     executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                     flowStatus: "PROMPT_ONLY"
                     stepId: "3071b6c6-0119-465c-b00b-3a0e6f88a730"
+                    challengeToken: "a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
                     type: "VIEW"
                     data:
                       inputs: [
@@ -161,6 +163,10 @@ components:
           type: string
           description: Identifier of an existing flow execution
           example: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+        challengeToken:
+          type: string
+          description: Per-step challenge token received from the previous flow response
+          example: "a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
         actionId:
           type: string
           description: Identifier of the action to execute in the flow
@@ -193,6 +199,10 @@ components:
           type: string
           description: Identifier of the current flow step
           example: "3071b6c6-0119-465c-b00b-3a0e6f88a730"
+        challengeToken:
+          type: string
+          description: Per-step challenge token to be included in the next request
+          example: "a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
         type:
           type: string
           description: Type of flow step response

--- a/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
@@ -227,6 +227,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetCondition_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetExecutionPolicy() *ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetExecutionPolicy() *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *ExecutionPolicy) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *ExecutionPolicy) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetExecutor provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetExecutor() ExecutorInterface {
 	ret := _mock.Called()

--- a/backend/internal/flow/core/ExecutorInterface_mock_test.go
+++ b/backend/internal/flow/core/ExecutorInterface_mock_test.go
@@ -144,6 +144,59 @@ func (_c *ExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run func() [
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type ExecutorInterfaceMock
+func (_mock *ExecutorInterfaceMock) GetExecutionPolicy(mode string) *ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// ExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type ExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *ExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &ExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *ExecutionPolicy) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *ExecutionPolicy) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetName provides a mock function for the type ExecutorInterfaceMock
 func (_mock *ExecutorInterfaceMock) GetName() string {
 	ret := _mock.Called()

--- a/backend/internal/flow/core/NodeInterface_mock_test.go
+++ b/backend/internal/flow/core/NodeInterface_mock_test.go
@@ -227,6 +227,52 @@ func (_c *NodeInterfaceMock_GetCondition_Call) RunAndReturn(run func() *NodeCond
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) GetExecutionPolicy() *ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// NodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type NodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *NodeInterfaceMock_Expecter) GetExecutionPolicy() *NodeInterfaceMock_GetExecutionPolicy_Call {
+	return &NodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *ExecutionPolicy) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *ExecutionPolicy) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/internal/flow/core/PromptNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/PromptNodeInterface_mock_test.go
@@ -227,6 +227,52 @@ func (_c *PromptNodeInterfaceMock_GetCondition_Call) RunAndReturn(run func() *No
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetExecutionPolicy() *ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type PromptNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetExecutionPolicy() *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &PromptNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *ExecutionPolicy) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *ExecutionPolicy) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
@@ -227,6 +227,52 @@ func (_c *RepresentationNodeInterfaceMock_GetCondition_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) GetExecutionPolicy() *ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// RepresentationNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type RepresentationNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *RepresentationNodeInterfaceMock_Expecter) GetExecutionPolicy() *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &RepresentationNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *ExecutionPolicy) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *ExecutionPolicy) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -38,6 +38,7 @@ type ExecutorInterface interface {
 	ValidatePrerequisites(ctx *NodeContext, execResp *common.ExecutorResponse) bool
 	GetUserIDFromContext(ctx *NodeContext) string
 	GetRequiredInputs(ctx *NodeContext) []common.Input
+	GetExecutionPolicy(mode string) *ExecutionPolicy
 }
 
 // executor represents the basic implementation of an executor.
@@ -177,6 +178,12 @@ func (e *executor) GetRequiredInputs(ctx *NodeContext) []common.Input {
 	}
 
 	return e.GetDefaultInputs()
+}
+
+// GetExecutionPolicy returns the execution policy for the given mode. By default, it returns nil,
+// indicating no special execution policy. Executors that need per-mode policies should override this method.
+func (e *executor) GetExecutionPolicy(mode string) *ExecutionPolicy {
+	return nil
 }
 
 // appendMissingInputs appends the missing required inputs to the executor response.

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -444,6 +444,10 @@ func (f *fakeExecutorBackedNode) ShouldExecute(ctx *NodeContext) bool {
 	return true
 }
 
+func (f *fakeExecutorBackedNode) GetExecutionPolicy() *ExecutionPolicy {
+	return nil
+}
+
 func (f *fakeExecutorBackedNode) GetExecutorName() string {
 	return "fake-exec"
 }

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -59,3 +59,8 @@ type NodeCondition struct {
 	Value  string
 	OnSkip string
 }
+
+// ExecutionPolicy defines behavioral policies for node execution.
+type ExecutionPolicy struct {
+	SkipChallengeValidation bool
+}

--- a/backend/internal/flow/core/node.go
+++ b/backend/internal/flow/core/node.go
@@ -44,6 +44,7 @@ type NodeInterface interface {
 	RemovePreviousNode(previousNodeID string)
 	GetCondition() *NodeCondition
 	SetCondition(condition *NodeCondition)
+	GetExecutionPolicy() *ExecutionPolicy
 }
 
 // node implements the NodeInterface
@@ -215,4 +216,10 @@ func (n *node) GetCondition() *NodeCondition {
 // SetCondition sets the execution condition for the node
 func (n *node) SetCondition(condition *NodeCondition) {
 	n.condition = condition
+}
+
+// GetExecutionPolicy returns the execution policy for the node. By default, it returns nil, indicating
+// no special execution policy. Nodes that need special execution behavior should override this method.
+func (n *node) GetExecutionPolicy() *ExecutionPolicy {
+	return nil
 }

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -242,6 +242,15 @@ func (n *taskExecutionNode) buildNodeResponse(execResp *common.ExecutorResponse)
 	return nodeResp
 }
 
+// GetExecutionPolicy returns the execution policy for the current node by delegating to the
+// configured executor with the node's mode. Returns nil if no executor is set.
+func (n *taskExecutionNode) GetExecutionPolicy() *ExecutionPolicy {
+	if n.executor == nil {
+		return nil
+	}
+	return n.executor.GetExecutionPolicy(n.mode)
+}
+
 // GetExecutorName returns the executor name for the task execution node
 func (n *taskExecutionNode) GetExecutorName() string {
 	return n.executorName

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -894,3 +894,105 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 	s.Equal("testuser", ctx.UserInputs["username"],
 		"UserInputs should not be cleared without failure reason")
 }
+
+func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_NoExecutorReturnsNil() {
+	node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
+
+	policy := node.GetExecutionPolicy()
+	s.Nil(policy)
+}
+
+func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_DelegatedToExecutor() {
+	node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExecutor := NewExecutorInterfaceMock(s.T())
+	expectedPolicy := &ExecutionPolicy{SkipChallengeValidation: true}
+
+	mockExecutor.On("GetName").Return("test-executor")
+	mockExecutor.On("GetExecutionPolicy", "verify").Return(expectedPolicy)
+
+	execNode.SetMode("verify")
+	execNode.SetExecutor(mockExecutor)
+
+	policy := node.GetExecutionPolicy()
+	s.NotNil(policy)
+	s.True(policy.SkipChallengeValidation)
+}
+
+func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_ExecutorReturnsNil() {
+	node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExecutor := NewExecutorInterfaceMock(s.T())
+
+	mockExecutor.On("GetName").Return("test-executor")
+	mockExecutor.On("GetExecutionPolicy", "process").Return(nil)
+
+	execNode.SetMode("process")
+	execNode.SetExecutor(mockExecutor)
+
+	policy := node.GetExecutionPolicy()
+	s.Nil(policy)
+}
+
+func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_DifferentModes() {
+	testCases := []struct {
+		mode     string
+		expected *ExecutionPolicy
+	}{
+		{
+			mode:     "generate",
+			expected: nil,
+		},
+		{
+			mode:     "verify",
+			expected: &ExecutionPolicy{SkipChallengeValidation: true},
+		},
+		{
+			mode:     "validate",
+			expected: &ExecutionPolicy{SkipChallengeValidation: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.mode, func() {
+			node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
+			execNode, _ := node.(ExecutorBackedNodeInterface)
+
+			mockExecutor := NewExecutorInterfaceMock(s.T())
+			mockExecutor.On("GetName").Return("test-executor")
+			mockExecutor.On("GetExecutionPolicy", tc.mode).Return(tc.expected)
+
+			execNode.SetMode(tc.mode)
+			execNode.SetExecutor(mockExecutor)
+
+			policy := node.GetExecutionPolicy()
+
+			if tc.expected == nil {
+				s.Nil(policy)
+			} else {
+				s.NotNil(policy)
+				s.Equal(tc.expected.SkipChallengeValidation, policy.SkipChallengeValidation)
+			}
+		})
+	}
+}
+
+func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_WithEmptyMode() {
+	node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExecutor := NewExecutorInterfaceMock(s.T())
+	expectedPolicy := &ExecutionPolicy{SkipChallengeValidation: false}
+
+	mockExecutor.On("GetName").Return("test-executor")
+	mockExecutor.On("GetExecutionPolicy", "").Return(expectedPolicy)
+
+	execNode.SetExecutor(mockExecutor)
+	// SetMode is not called, so mode will be empty string
+
+	policy := node.GetExecutionPolicy()
+	s.NotNil(policy)
+	s.False(policy.SkipChallengeValidation)
+}

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -58,6 +58,17 @@ func newInviteExecutor(flowFactory core.FlowFactoryInterface) *inviteExecutor {
 	}
 }
 
+// GetExecutionPolicy returns the execution policy for the given mode.
+// The verify mode skips challenge token validation because the invite token itself serves as the challenge.
+func (e *inviteExecutor) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	if mode == ExecutorModeVerify {
+		return &core.ExecutionPolicy{
+			SkipChallengeValidation: true,
+		}
+	}
+	return nil
+}
+
 // Execute delegates to the appropriate mode handler based on the executor mode.
 func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	switch ctx.ExecutorMode {

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -229,6 +229,27 @@ func (suite *InviteExecutorTestSuite) TestExecute_InvalidMode() {
 	assert.Contains(suite.T(), err.Error(), "invalid executor mode for InviteExecutor")
 }
 
+func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_GenerateMode_ReturnsNil() {
+	policy := suite.executor.GetExecutionPolicy(ExecutorModeGenerate)
+	assert.Nil(suite.T(), policy)
+}
+
+func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_VerifyMode_SkipsChallengeValidation() {
+	policy := suite.executor.GetExecutionPolicy(ExecutorModeVerify)
+	assert.NotNil(suite.T(), policy)
+	assert.True(suite.T(), policy.SkipChallengeValidation)
+}
+
+func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_InvalidMode_ReturnsNil() {
+	policy := suite.executor.GetExecutionPolicy("invalid-mode")
+	assert.Nil(suite.T(), policy)
+}
+
+func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_EmptyMode_ReturnsNil() {
+	policy := suite.executor.GetExecutionPolicy("")
+	assert.Nil(suite.T(), policy)
+}
+
 func TestInviteExecutorSuite(t *testing.T) {
 	suite.Run(t, new(InviteExecutorTestSuite))
 }

--- a/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
@@ -278,6 +278,59 @@ func (_c *oAuthExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type oAuthExecutorInterfaceMock
+func (_mock *oAuthExecutorInterfaceMock) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *core.ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// oAuthExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type oAuthExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *oAuthExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &oAuthExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *core.ExecutionPolicy) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdpID provides a mock function for the type oAuthExecutorInterfaceMock
 func (_mock *oAuthExecutorInterfaceMock) GetIdpID(ctx *core.NodeContext) (string, error) {
 	ret := _mock.Called(ctx)

--- a/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
@@ -278,6 +278,59 @@ func (_c *oidcAuthExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type oidcAuthExecutorInterfaceMock
+func (_mock *oidcAuthExecutorInterfaceMock) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *core.ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *core.ExecutionPolicy) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIDTokenClaims provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) GetIDTokenClaims(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error) {
 	ret := _mock.Called(execResp, idToken)

--- a/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
@@ -39,8 +39,8 @@ func (_m *FlowExecServiceInterfaceMock) EXPECT() *FlowExecServiceInterfaceMock_E
 }
 
 // Execute provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs)
+func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string) (*FlowStep, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -48,18 +48,18 @@ func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID st
 
 	var r0 *FlowStep
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) (*FlowStep, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string, string) (*FlowStep, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) *FlowStep); ok {
-		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string, string) *FlowStep); ok {
+		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*FlowStep)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -81,11 +81,12 @@ type FlowExecServiceInterfaceMock_Execute_Call struct {
 //   - verbose bool
 //   - action string
 //   - inputs map[string]string
-func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
-	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs)}
+//   - challengeToken string
+func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}, challengeToken interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
+	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)}
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -115,6 +116,10 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Co
 		if args[6] != nil {
 			arg6 = args[6].(map[string]string)
 		}
+		var arg7 string
+		if args[7] != nil {
+			arg7 = args[7].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -123,6 +128,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Co
 			arg4,
 			arg5,
 			arg6,
+			arg7,
 		)
 	})
 	return _c
@@ -133,7 +139,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Return(flowStep *FlowStep, 
 	return _c
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string) (*FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/flow/executor"
+	"github.com/asgardeo/thunder/internal/system/crypto/token"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/observability"
@@ -43,6 +44,7 @@ type flowEngineInterface interface {
 type flowEngine struct {
 	executorRegistry executor.ExecutorRegistryInterface
 	observabilitySvc observability.ObservabilityServiceInterface
+	logger           *log.Logger
 }
 
 // newFlowEngine creates a new flow engine with the given dependencies.
@@ -53,12 +55,13 @@ func newFlowEngine(
 	return &flowEngine{
 		executorRegistry: executorRegistry,
 		observabilitySvc: observabilitySvc,
+		logger:           log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
 	}
 }
 
 // Execute executes a step in the flow
 func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine"))
+	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	flowStep := FlowStep{
 		ExecutionID: ctx.ExecutionID,
@@ -80,6 +83,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	}
 
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
+	challengeTokenValidated := false
 	for currentNode != nil {
 		logger.Debug("Executing node", log.String("nodeID", currentNode.GetID()),
 			log.String("nodeType", string(currentNode.GetType())))
@@ -134,6 +138,17 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			return flowStep, svcErr
 		}
 
+		// Validate the incoming challenge token once per request against the first execution node.
+		// Node executor has to be set before validation as task execution nodes have to check validation
+		// policy against the executor
+		if !challengeTokenValidated {
+			challengeTokenValidated = true
+			if svcErr := fe.validateChallengeToken(ctx, currentNode); svcErr != nil {
+				publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+				return flowStep, svcErr
+			}
+		}
+
 		executionStartTime := time.Now().UnixMilli()
 
 		// Publish node execution started event
@@ -171,7 +186,15 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			// Check if flow failed or just incomplete
 			if flowStep.Status == common.FlowStatusError {
 				publishFlowFailedEvent(ctx, nil, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+				return flowStep, nil
 			}
+
+			// Flow is incomplete — rotate challenge token so the next step is bound to a fresh token
+			if svcErr := fe.rotateChallengeToken(ctx, &flowStep); svcErr != nil {
+				publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+				return flowStep, svcErr
+			}
+
 			// Don't publish completed event here - flow is incomplete (waiting for user input)
 			return flowStep, nil
 		}
@@ -542,7 +565,7 @@ func (fe *flowEngine) handleDisplayOnlyPromptResponse(ctx *EngineContext,
 func (fe *flowEngine) handleCompletedResponse(ctx *EngineContext,
 	nodeResp *common.NodeResponse, logger *log.Logger) (
 	core.NodeInterface, *serviceerror.ServiceError) {
-	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
+	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
 		logger.Error("Error moving to the next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -587,7 +610,7 @@ func (fe *flowEngine) handleForwardResponse(ctx *EngineContext,
 		log.String("nextNodeID", nodeResp.NextNodeID),
 		log.String("failureReason", nodeResp.FailureReason))
 
-	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
+	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
 		logger.Error("Error resolving to next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -615,7 +638,7 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 	nodeResp := &common.NodeResponse{NextNodeID: condition.OnSkip}
 
 	// Resolve to the next node
-	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
+	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
 		logger.Error("Error moving to the next node after skipping", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -625,10 +648,10 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 }
 
 // resolveToNextNode resolves the next node to execute based on nodeResp.NextNodeID.
-func (fe *flowEngine) resolveToNextNode(graph core.GraphInterface, nodeResp *common.NodeResponse) (
+func (fe *flowEngine) resolveToNextNode(engineCtx *EngineContext, nodeResp *common.NodeResponse) (
 	core.NodeInterface, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine"))
-
+	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
+	graph := engineCtx.Graph
 	if nodeResp == nil || nodeResp.NextNodeID == "" {
 		logger.Debug("No next node ID in response. Returning nil.")
 		return nil, nil
@@ -727,6 +750,57 @@ func (fe *flowEngine) resolveStepDetailsForPrompt(ctx *EngineContext, nodeResp *
 
 	flowStep.Status = common.FlowStatusIncomplete
 	flowStep.Type = common.StepTypeView
+	return nil
+}
+
+// validateChallengeToken validates the incoming challenge token against the stored hash.
+// If the hash is not present in the context, i.e. this is the first execution or the previous step
+// did not set a token, validation is skipped. Also if the current node's execution policy allows
+// skipping, validation is skipped.
+func (fe *flowEngine) validateChallengeToken(
+	ctx *EngineContext, currentNode core.NodeInterface) *serviceerror.ServiceError {
+	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	if ctx.ChallengeTokenHash == "" {
+		logger.Debug("Challenge token hash is empty in the context; skipping validation")
+		return nil
+	}
+	if currentNode != nil {
+		policy := currentNode.GetExecutionPolicy()
+		if policy != nil && policy.SkipChallengeValidation {
+			logger.Debug("Current node's execution policy set to skip challenge token validation; skipping")
+			return nil
+		}
+	} else {
+		logger.Debug("Current node is nil while validating challenge token; enforcing validation")
+	}
+
+	if ctx.ChallengeTokenIn == "" {
+		logger.Debug("Challenge token is empty in the request")
+		return &ErrorInvalidChallengeToken
+	}
+	if !token.ValidateTokenHash(ctx.ChallengeTokenIn, ctx.ChallengeTokenHash) {
+		logger.Debug("Invalid challenge token provided in the request")
+		return &ErrorInvalidChallengeToken
+	}
+
+	return nil
+}
+
+// rotateChallengeToken generates a fresh challenge token, stores its hash in the engine context and
+// returns the new token in the flow step. This ensures that the next step is bound to a fresh token
+// and prevents replay attacks with old tokens.
+func (fe *flowEngine) rotateChallengeToken(ctx *EngineContext, flowStep *FlowStep) *serviceerror.ServiceError {
+	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	newToken, err := token.GenerateSecureToken()
+	if err != nil {
+		logger.Error("Failed to generate new challenge token", log.Error(err))
+		return &serviceerror.InternalServerError
+	}
+
+	ctx.ChallengeTokenHash = token.HashToken(newToken)
+	flowStep.ChallengeToken = newToken
 	return nil
 }
 

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -26,6 +26,8 @@ import (
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/crypto/token"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/observability/observabilitymock"
@@ -1597,4 +1599,166 @@ func (s *EngineTestSuite) TestHandleDisplayOnlyPromptResponse_MergesAdditionalDa
 	s.Nil(nextNode)
 	// Verify merged data
 	s.Equal(common.FlowStatusComplete, flowStep.Status)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_EmptyTokenHashSkipsValidation() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   "some-token",
+		ChallengeTokenHash: "",
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.Nil(svcErr)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_SkipValidationWhenPolicyAllows() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetExecutionPolicy").Return(&core.ExecutionPolicy{
+		SkipChallengeValidation: true,
+	})
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   "wrong-token",
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.Nil(svcErr)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_ReturnsErrorWhenTokenEmpty() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetExecutionPolicy").Return(nil)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   "", // Empty token
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.NotNil(svcErr)
+	s.Equal("FES-1009", svcErr.Code)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_ReturnsErrorWhenTokenInvalid() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetExecutionPolicy").Return(nil)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   "invalid-token",
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.NotNil(svcErr)
+	s.Equal("FES-1009", svcErr.Code)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_SucceedsWhenTokenValid() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetExecutionPolicy").Return(nil)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   tokenStr,
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.Nil(svcErr)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_SkipValidationWhenNodeNil() {
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   "wrong-token",
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, nil)
+	s.NotNil(svcErr)
+	s.Equal("FES-1009", svcErr.Code)
+}
+
+func (s *EngineTestSuite) TestValidateChallengeToken_SkipValidationWhenPolicyNil() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetExecutionPolicy").Return(nil)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	// Generate a token and hash it
+	tokenStr, err := token.GenerateSecureToken()
+	s.NoError(err)
+	tokenHash := token.HashToken(tokenStr)
+
+	ctx := &EngineContext{
+		ExecutionID:        "test-exec-id",
+		ChallengeTokenIn:   tokenStr,
+		ChallengeTokenHash: tokenHash,
+	}
+
+	svcErr := fe.validateChallengeToken(ctx, mockNode)
+	s.Nil(svcErr)
 }

--- a/backend/internal/flow/flowexec/error_constants.go
+++ b/backend/internal/flow/flowexec/error_constants.go
@@ -87,3 +87,11 @@ var ErrorInvalidFlowInitContext = serviceerror.ServiceError{
 	Error:            "Invalid request",
 	ErrorDescription: "Invalid flow initialization context provided",
 }
+
+// ErrorInvalidChallengeToken defines the error response for invalid or missing challenge tokens.
+var ErrorInvalidChallengeToken = serviceerror.ServiceError{
+	Code:             "FES-1009",
+	Type:             serviceerror.ClientErrorType,
+	Error:            "Invalid challenge token",
+	ErrorDescription: "The challenge token is missing or invalid",
+}

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -55,9 +55,10 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 	verbose := flowR.Verbose
 	action := sysutils.SanitizeString(flowR.Action)
 	inputs := sysutils.SanitizeStringMap(flowR.Inputs)
+	challengeToken := sysutils.SanitizeString(flowR.ChallengeToken)
 
 	flowStep, flowErr := h.flowExecService.Execute(
-		r.Context(), appID, executionID, flowTypeStr, verbose, action, inputs)
+		r.Context(), appID, executionID, flowTypeStr, verbose, action, inputs, challengeToken)
 
 	if flowErr != nil {
 		handleFlowError(w, flowErr)
@@ -65,13 +66,14 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 	}
 
 	flowResp := FlowResponse{
-		ExecutionID:   flowStep.ExecutionID,
-		StepID:        flowStep.StepID,
-		FlowStatus:    string(flowStep.Status),
-		Type:          string(flowStep.Type),
-		Data:          flowStep.Data,
-		Assertion:     flowStep.Assertion,
-		FailureReason: flowStep.FailureReason,
+		ExecutionID:    flowStep.ExecutionID,
+		StepID:         flowStep.StepID,
+		FlowStatus:     string(flowStep.Status),
+		Type:           string(flowStep.Type),
+		Data:           flowStep.Data,
+		Assertion:      flowStep.Assertion,
+		FailureReason:  flowStep.FailureReason,
+		ChallengeToken: flowStep.ChallengeToken,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, flowResp)

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -59,17 +59,21 @@ type EngineContext struct {
 	AuthUser          managerpkg.AuthUser
 	Assertion         string
 	ExecutionHistory  map[string]*common.NodeExecutionRecord
+
+	ChallengeTokenIn   string
+	ChallengeTokenHash string
 }
 
 // FlowStep represents the outcome of a individual flow step
 type FlowStep struct {
-	ExecutionID   string
-	StepID        string
-	Type          common.FlowStepType
-	Status        common.FlowStatus
-	Data          FlowData
-	Assertion     string
-	FailureReason string
+	ExecutionID    string
+	StepID         string
+	Type           common.FlowStepType
+	Status         common.FlowStatus
+	ChallengeToken string
+	Data           FlowData
+	Assertion      string
+	FailureReason  string
 }
 
 // FlowData holds the data returned by a flow execution step
@@ -83,23 +87,25 @@ type FlowData struct {
 
 // FlowResponse represents the flow execution API response body
 type FlowResponse struct {
-	ExecutionID   string   `json:"executionId"`
-	StepID        string   `json:"stepId,omitempty"`
-	FlowStatus    string   `json:"flowStatus"`
-	Type          string   `json:"type,omitempty"`
-	Data          FlowData `json:"data,omitempty"`
-	Assertion     string   `json:"assertion,omitempty"`
-	FailureReason string   `json:"failureReason,omitempty"`
+	ExecutionID    string   `json:"executionId"`
+	StepID         string   `json:"stepId,omitempty"`
+	FlowStatus     string   `json:"flowStatus"`
+	Type           string   `json:"type,omitempty"`
+	ChallengeToken string   `json:"challengeToken,omitempty"`
+	Data           FlowData `json:"data,omitempty"`
+	Assertion      string   `json:"assertion,omitempty"`
+	FailureReason  string   `json:"failureReason,omitempty"`
 }
 
 // FlowRequest represents the flow execution API request body
 type FlowRequest struct {
-	ApplicationID string            `json:"applicationId"`
-	FlowType      string            `json:"flowType"`
-	Verbose       bool              `json:"verbose,omitempty"`
-	ExecutionID   string            `json:"executionId"`
-	Action        string            `json:"action"`
-	Inputs        map[string]string `json:"inputs"`
+	ApplicationID  string            `json:"applicationId"`
+	FlowType       string            `json:"flowType"`
+	Verbose        bool              `json:"verbose,omitempty"`
+	ExecutionID    string            `json:"executionId"`
+	ChallengeToken string            `json:"challengeToken,omitempty"`
+	Action         string            `json:"action"`
+	Inputs         map[string]string `json:"inputs"`
 }
 
 // FlowInitContext represents the context for initiating a new flow with runtime data
@@ -158,6 +164,7 @@ type flowContextContent struct {
 	Token               *string `json:"token,omitempty"`
 	AvailableAttributes *string `json:"availableAttributes,omitempty"`
 	AuthUser            *string `json:"authUser,omitempty"`
+	ChallengeTokenHash  *string `json:"challengeTokenHash,omitempty"`
 }
 
 // encrypt marshals and encrypts the content, returning the encrypted string.
@@ -287,20 +294,27 @@ func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContex
 		}
 	}
 
+	// Get challenge token hash from JSON content
+	challengeTokenHash := ""
+	if content.ChallengeTokenHash != nil {
+		challengeTokenHash = *content.ChallengeTokenHash
+	}
+
 	return EngineContext{
-		ExecutionID:       f.ExecutionID,
-		TraceID:           "", // TraceID is transient and set from request context
-		FlowType:          graph.GetType(),
-		AppID:             content.AppID,
-		Verbose:           content.Verbose,
-		UserInputs:        userInputs,
-		RuntimeData:       runtimeData,
-		CurrentNode:       currentNode,
-		CurrentAction:     currentAction,
-		Graph:             graph,
-		AuthenticatedUser: authenticatedUser,
-		AuthUser:          authUser,
-		ExecutionHistory:  executionHistory,
+		ExecutionID:        f.ExecutionID,
+		TraceID:            "", // TraceID is transient and set from request context
+		FlowType:           graph.GetType(),
+		AppID:              content.AppID,
+		Verbose:            content.Verbose,
+		UserInputs:         userInputs,
+		RuntimeData:        runtimeData,
+		CurrentNode:        currentNode,
+		CurrentAction:      currentAction,
+		Graph:              graph,
+		AuthenticatedUser:  authenticatedUser,
+		AuthUser:           authUser,
+		ExecutionHistory:   executionHistory,
+		ChallengeTokenHash: challengeTokenHash,
 	}, nil
 }
 
@@ -398,6 +412,12 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 	}
 	graphID := ctx.Graph.GetID()
 
+	// Get challenge token hash
+	var challengeTokenHash *string
+	if ctx.ChallengeTokenHash != "" {
+		challengeTokenHash = &ctx.ChallengeTokenHash
+	}
+
 	content := flowContextContent{
 		AppID:               ctx.AppID,
 		Verbose:             ctx.Verbose,
@@ -415,6 +435,7 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		Token:               token,
 		AvailableAttributes: availableAttributes,
 		AuthUser:            authUserStr,
+		ChallengeTokenHash:  challengeTokenHash,
 	}
 
 	encryptedContext, err := content.encrypt()

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -41,7 +41,7 @@ import (
 // entry point for flow execution
 type FlowExecServiceInterface interface {
 	Execute(ctx context.Context, appID, executionID, flowType string, verbose bool,
-		action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)
+		action string, inputs map[string]string, challengeToken string) (*FlowStep, *serviceerror.ServiceError)
 	InitiateFlow(ctx context.Context, initContext *FlowInitContext) (string, *serviceerror.ServiceError)
 }
 
@@ -78,18 +78,19 @@ func newFlowExecService(flowMgtService flowmgt.FlowMgtServiceInterface,
 
 // Execute executes a flow with the given data
 func (s *flowExecService) Execute(ctx context.Context,
-	appID, executionID, flowType string, verbose bool, action string, inputs map[string]string) (
+	appID, executionID, flowType string, verbose bool,
+	action string, inputs map[string]string, challengeToken string) (
 	*FlowStep, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowExecService"))
 
 	// Get trace ID from context
 	traceID := sysContext.GetTraceID(ctx)
 
-	var context *EngineContext
+	var engineCtx *EngineContext
 	var loadErr *serviceerror.ServiceError
 
 	if isNewFlow(executionID) {
-		context, loadErr = s.loadNewContext(ctx, appID, flowType, verbose, action, inputs, logger)
+		engineCtx, loadErr = s.loadNewContext(ctx, appID, flowType, verbose, action, inputs, logger)
 		if loadErr != nil {
 			logger.Error("Failed to load new flow context",
 				log.String("appID", appID),
@@ -117,25 +118,27 @@ func (s *flowExecService) Execute(ctx context.Context,
 			return nil, loadErr
 		}
 	} else {
-		context, loadErr = s.loadPrevContext(ctx, executionID, action, inputs, logger)
+		engineCtx, loadErr = s.loadPrevContext(ctx, executionID, action, inputs, logger)
 		if loadErr != nil {
 			logger.Error("Failed to load previous flow context",
 				log.String(log.LoggerKeyExecutionID, executionID),
 				log.String("error", loadErr.Error))
 			return nil, loadErr
 		}
+		// Set the incoming challenge token on the context so the engine can validate it
+		engineCtx.ChallengeTokenIn = challengeToken
 	}
 
 	// Set trace ID to engine context (request context is already set during context loading)
-	context.TraceID = traceID
+	engineCtx.TraceID = traceID
 
-	flowStep, flowErr := s.flowEngine.Execute(context)
+	flowStep, flowErr := s.flowEngine.Execute(engineCtx)
 
 	if flowErr != nil {
-		if !isNewFlow(executionID) {
-			if removeErr := s.removeContext(ctx, context.ExecutionID, logger); removeErr != nil {
+		if !isNewFlow(executionID) && flowErr.Code != ErrorInvalidChallengeToken.Code {
+			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
 				logger.Error("Failed to remove flow context after engine failure",
-					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(removeErr))
+					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		}
@@ -144,23 +147,23 @@ func (s *flowExecService) Execute(ctx context.Context,
 
 	if isComplete(flowStep) {
 		if !isNewFlow(executionID) {
-			if removeErr := s.removeContext(ctx, context.ExecutionID, logger); removeErr != nil {
+			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
 				logger.Error("Failed to remove flow context after completion",
-					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(removeErr))
+					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		}
 	} else {
 		if isNewFlow(executionID) {
-			if storeErr := s.storeContext(ctx, context, logger); storeErr != nil {
+			if storeErr := s.storeContext(ctx, engineCtx, logger); storeErr != nil {
 				logger.Error("Failed to store initial flow context",
-					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(storeErr))
+					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(storeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		} else {
-			if updateErr := s.updateContext(ctx, context, &flowStep, logger); updateErr != nil {
-				logger.Error("Failed to update flow context", log.String(log.LoggerKeyExecutionID, context.ExecutionID),
-					log.Error(updateErr))
+			if updateErr := s.updateContext(ctx, engineCtx, &flowStep, logger); updateErr != nil {
+				logger.Error("Failed to update flow context",
+					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(updateErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		}

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -496,7 +496,7 @@ func TestExecute_ContextDecryptionFailure(t *testing.T) {
 	}
 
 	_, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
-		string(common.FlowTypeAuthentication), false, "submit", map[string]string{})
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
 
 	assert.NotNil(t, svcErr)
 	assert.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
@@ -544,7 +544,10 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
-	mockEngine.EXPECT().Execute(mock.Anything).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
+	challengeToken := "test-challenge-token"
+	mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
+		return ctx != nil && ctx.ChallengeTokenIn == challengeToken
+	})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
 	mockStore.EXPECT().UpdateFlowContext(
 		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
 		mock.AnythingOfType("EngineContext")).Return(nil)
@@ -558,9 +561,320 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 	}
 
 	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
-		string(common.FlowTypeAuthentication), false, "submit", map[string]string{})
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, challengeToken)
 
 	assert.Nil(t, svcErr)
 	assert.NotNil(t, flowStep)
 	assert.Equal(t, common.FlowStatusIncomplete, flowStep.Status)
+}
+
+func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	engineCtx := EngineContext{
+		ExecutionID: "existing-execution-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+	dbModel, err := FromEngineContext(engineCtx)
+	assert.NoError(t, err)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+	mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
+		return ctx != nil && ctx.ChallengeTokenIn == ""
+	})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
+	mockStore.EXPECT().UpdateFlowContext(
+		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+		mock.AnythingOfType("EngineContext")).Return(nil)
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+	}
+
+	// Execute with empty challenge token
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	assert.Nil(t, svcErr)
+	assert.NotNil(t, flowStep)
+	assert.Equal(t, common.FlowStatusIncomplete, flowStep.Status)
+}
+
+func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	tests := []struct {
+		name            string
+		challengeToken  string
+		expectInContext string
+	}{
+		{
+			name:            "with short token",
+			challengeToken:  "abc123",
+			expectInContext: "abc123",
+		},
+		{
+			name: "with long token",
+			challengeToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0." +
+				"dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+			expectInContext: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0." +
+				"dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+		},
+		{
+			name:            "with empty token",
+			challengeToken:  "",
+			expectInContext: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engineCtx := EngineContext{
+				ExecutionID: "existing-execution-id",
+				AppID:       "test-app-id",
+				FlowType:    common.FlowTypeAuthentication,
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{},
+				},
+				UserInputs:       map[string]string{},
+				RuntimeData:      map[string]string{},
+				ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+				Graph:            testGraph,
+			}
+			dbModel, err := FromEngineContext(engineCtx)
+			assert.NoError(t, err)
+
+			mockStore := newFlowStoreInterfaceMock(t)
+			mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+			mockEngine := newFlowEngineInterfaceMock(t)
+			mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+			mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+			mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+			mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+				&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+			expectedToken := tt.expectInContext
+			mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
+				return ctx != nil && ctx.ChallengeTokenIn == expectedToken
+			})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
+			mockStore.EXPECT().UpdateFlowContext(
+				mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+				mock.AnythingOfType("EngineContext")).Return(nil)
+
+			service := &flowExecService{
+				flowStore:      mockStore,
+				flowMgtService: mockFlowMgtSvc,
+				flowEngine:     mockEngine,
+				appService:     mockAppService,
+				transactioner:  &stubTransactioner{},
+			}
+
+			flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+				string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, tt.challengeToken)
+
+			assert.Nil(t, svcErr)
+			assert.NotNil(t, flowStep)
+			assert.Equal(t, common.FlowStatusIncomplete, flowStep.Status)
+		})
+	}
+}
+
+func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T) {
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	engineCtx := EngineContext{
+		ExecutionID: "existing-execution-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+	dbModel, err := FromEngineContext(engineCtx)
+	assert.NoError(t, err)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+	// Engine returns invalid challenge token error
+	mockEngine.EXPECT().Execute(mock.Anything).Return(FlowStep{}, &ErrorInvalidChallengeToken)
+	// DeleteFlowContext must NOT be called — flow must be preserved for retry
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "wrong-token")
+
+	assert.NotNil(t, svcErr)
+	assert.Equal(t, ErrorInvalidChallengeToken.Code, svcErr.Code)
+	assert.Nil(t, flowStep)
+}
+
+func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	engineCtx := EngineContext{
+		ExecutionID: "existing-execution-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+	dbModel, err := FromEngineContext(engineCtx)
+	assert.NoError(t, err)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+	otherErr := &serviceerror.ServiceError{Code: "FES-9999", Error: "some other engine error"}
+	mockEngine.EXPECT().Execute(mock.Anything).Return(FlowStep{}, otherErr)
+	// DeleteFlowContext MUST be called — non-challenge-token errors remove the context
+	mockStore.EXPECT().DeleteFlowContext(
+		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+		"existing-execution-id").Return(nil)
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "valid-token")
+
+	assert.NotNil(t, svcErr)
+	assert.Equal(t, otherErr.Code, svcErr.Code)
+	assert.Nil(t, flowStep)
+}
+
+func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
+	testConfig := &config.Config{}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app").Return(
+		&appmodel.Application{ID: "test-app", AuthFlowID: "auth-graph-1"}, nil).Times(2)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
+	mockEngine.EXPECT().Execute(mock.Anything).Return(FlowStep{}, &ErrorInvalidChallengeToken)
+	// DeleteFlowContext must NOT be called — new flows have no persisted context to clean up
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+	}
+
+	// Pass empty executionID to indicate a new flow
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	assert.NotNil(t, svcErr)
+	assert.Equal(t, ErrorInvalidChallengeToken.Code, svcErr.Code)
+	assert.Nil(t, flowStep)
 }

--- a/backend/internal/system/crypto/token/token.go
+++ b/backend/internal/system/crypto/token/token.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package token provides utilities for generating and validating secure tokens.
+package token
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/crypto/hash"
+)
+
+// GenerateSecureToken generates a cryptographically random 32-byte token, hex-encoded (64 chars).
+func GenerateSecureToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate secure token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// HashToken returns the SHA-256 hex digest of the given token.
+// The token itself carries 256 bits of entropy, so no salt is needed.
+func HashToken(rawToken string) string {
+	h, _ := hash.Hash([]byte(rawToken), hash.GenericSHA256)
+	return hex.EncodeToString(h)
+}
+
+// ValidateTokenHash checks whether rawToken hashes to storedHash using constant-time comparison.
+func ValidateTokenHash(rawToken, storedHash string) bool {
+	expected := HashToken(rawToken)
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(storedHash)) == 1
+}

--- a/backend/internal/system/crypto/token/token_test.go
+++ b/backend/internal/system/crypto/token/token_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package token
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TokenTestSuite struct {
+	suite.Suite
+}
+
+func TestTokenTestSuite(t *testing.T) {
+	suite.Run(t, new(TokenTestSuite))
+}
+
+func (suite *TokenTestSuite) TestGenerateSecureToken() {
+	tok1, err := GenerateSecureToken()
+	suite.NoError(err)
+	suite.Len(tok1, 64, "token should be 64 hex chars (32 bytes)")
+
+	tok2, err := GenerateSecureToken()
+	suite.NoError(err)
+	suite.NotEqual(tok1, tok2, "two tokens should not be equal")
+}
+
+func (suite *TokenTestSuite) TestHashToken() {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{"ShortInput", "abc123"},
+		{"LongInput", "this-is-a-longer-token-string-for-testing"},
+		{"EmptyInput", ""},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			hash1 := HashToken(tc.input)
+			hash2 := HashToken(tc.input)
+			suite.Equal(hash1, hash2, "same input should produce same hash")
+			suite.Len(hash1, 64, "SHA-256 hex digest should be 64 chars")
+		})
+	}
+
+	suite.NotEqual(HashToken("abc"), HashToken("def"), "different inputs should produce different hashes")
+}
+
+func (suite *TokenTestSuite) TestValidateTokenHash() {
+	tok, err := GenerateSecureToken()
+	suite.Require().NoError(err)
+
+	h := HashToken(tok)
+
+	testCases := []struct {
+		name       string
+		rawToken   string
+		storedHash string
+		expectOk   bool
+	}{
+		{"ValidToken", tok, h, true},
+		{"WrongToken", "wrong", h, false},
+		{"WrongHash", tok, "not-a-valid-hash", false},
+		{"EmptyToken", "", h, false},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			suite.Equal(tc.expectOk, ValidateTokenHash(tc.rawToken, tc.storedHash))
+		})
+	}
+}

--- a/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
@@ -228,6 +228,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetCondition_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetExecutionPolicy() *core.ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *core.ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetExecutionPolicy() *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *core.ExecutionPolicy) *ExecutorBackedNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetExecutor provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetExecutor() core.ExecutorInterface {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/coremock/ExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/ExecutorInterface_mock.go
@@ -145,6 +145,59 @@ func (_c *ExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run func() [
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type ExecutorInterfaceMock
+func (_mock *ExecutorInterfaceMock) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *core.ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// ExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type ExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *ExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &ExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *ExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *core.ExecutionPolicy) *ExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetName provides a mock function for the type ExecutorInterfaceMock
 func (_mock *ExecutorInterfaceMock) GetName() string {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
@@ -228,6 +228,52 @@ func (_c *NodeInterfaceMock_GetCondition_Call) RunAndReturn(run func() *core.Nod
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) GetExecutionPolicy() *core.ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *core.ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// NodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type NodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *NodeInterfaceMock_Expecter) GetExecutionPolicy() *NodeInterfaceMock_GetExecutionPolicy_Call {
+	return &NodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *core.ExecutionPolicy) *NodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
@@ -228,6 +228,52 @@ func (_c *PromptNodeInterfaceMock_GetCondition_Call) RunAndReturn(run func() *co
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetExecutionPolicy() *core.ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *core.ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type PromptNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetExecutionPolicy() *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &PromptNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *core.ExecutionPolicy) *PromptNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
@@ -228,6 +228,52 @@ func (_c *RepresentationNodeInterfaceMock_GetCondition_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) GetExecutionPolicy() *core.ExecutionPolicy {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func() *core.ExecutionPolicy); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// RepresentationNodeInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type RepresentationNodeInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+func (_e *RepresentationNodeInterfaceMock_Expecter) GetExecutionPolicy() *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	return &RepresentationNodeInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy")}
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func() *core.ExecutionPolicy) *RepresentationNodeInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetID provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetID() string {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
@@ -279,6 +279,59 @@ func (_c *oAuthExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type oAuthExecutorInterfaceMock
+func (_mock *oAuthExecutorInterfaceMock) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *core.ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// oAuthExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type oAuthExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *oAuthExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &oAuthExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *core.ExecutionPolicy) *oAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdpID provides a mock function for the type oAuthExecutorInterfaceMock
 func (_mock *oAuthExecutorInterfaceMock) GetIdpID(ctx *core.NodeContext) (string, error) {
 	ret := _mock.Called(ctx)

--- a/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
@@ -279,6 +279,59 @@ func (_c *oidcAuthExecutorInterfaceMock_GetDefaultInputs_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetExecutionPolicy provides a mock function for the type oidcAuthExecutorInterfaceMock
+func (_mock *oidcAuthExecutorInterfaceMock) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
+	ret := _mock.Called(mode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExecutionPolicy")
+	}
+
+	var r0 *core.ExecutionPolicy
+	if returnFunc, ok := ret.Get(0).(func(string) *core.ExecutionPolicy); ok {
+		r0 = returnFunc(mode)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ExecutionPolicy)
+		}
+	}
+	return r0
+}
+
+// oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutionPolicy'
+type oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call struct {
+	*mock.Call
+}
+
+// GetExecutionPolicy is a helper method to define mock.On call
+//   - mode string
+func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetExecutionPolicy(mode interface{}) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	return &oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call{Call: _e.mock.On("GetExecutionPolicy", mode)}
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Run(run func(mode string)) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) Return(executionPolicy *core.ExecutionPolicy) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(executionPolicy)
+	return _c
+}
+
+func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(run func(mode string) *core.ExecutionPolicy) *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIDTokenClaims provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) GetIDTokenClaims(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error) {
 	ret := _mock.Called(execResp, idToken)

--- a/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *FlowExecServiceInterfaceMock) EXPECT() *FlowExecServiceInterfaceMock_E
 }
 
 // Execute provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs)
+func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string) (*flowexec.FlowStep, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -49,18 +49,18 @@ func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID st
 
 	var r0 *flowexec.FlowStep
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string, string) (*flowexec.FlowStep, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) *flowexec.FlowStep); ok {
-		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string, string) *flowexec.FlowStep); ok {
+		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*flowexec.FlowStep)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -82,11 +82,12 @@ type FlowExecServiceInterfaceMock_Execute_Call struct {
 //   - verbose bool
 //   - action string
 //   - inputs map[string]string
-func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
-	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs)}
+//   - challengeToken string
+func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}, challengeToken interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
+	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs, challengeToken)}
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -116,6 +117,10 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Co
 		if args[6] != nil {
 			arg6 = args[6].(map[string]string)
 		}
+		var arg7 string
+		if args[7] != nil {
+			arg7 = args[7].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -124,6 +129,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Co
 			arg4,
 			arg5,
 			arg6,
+			arg7,
 		)
 	})
 	return _c
@@ -134,7 +140,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Return(flowStep *flowexec.F
 	return _c
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string, challengeToken string) (*flowexec.FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -1794,6 +1794,7 @@ paths:
                 summary: Subsequent request
                 value:
                   executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                  challengeToken: a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2
                   actionId: basic_auth
                   inputs:
                     username: thor
@@ -1815,6 +1816,7 @@ paths:
                     executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                     flowStatus: PROMPT_ONLY
                     stepId: 3071b6c6-0119-465c-b00b-3a0e6f88a730
+                    challengeToken: a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2
                     type: VIEW
                     data:
                       inputs:
@@ -10206,6 +10208,10 @@ components:
           type: string
           description: Identifier of an existing flow execution
           example: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+        challengeToken:
+          type: string
+          description: Per-step challenge token received from the previous flow response
+          example: a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2
         actionId:
           type: string
           description: Identifier of the action to execute in the flow
@@ -10236,6 +10242,10 @@ components:
           type: string
           description: Identifier of the current flow step
           example: 3071b6c6-0119-465c-b00b-3a0e6f88a730
+        challengeToken:
+          type: string
+          description: Per-step challenge token to be included in the next request
+          example: a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2
         type:
           type: string
           description: Type of flow step response

--- a/docs/static/api/next/postman/collections/modules/flow-execution.postman.json
+++ b/docs/static/api/next/postman/collections/modules/flow-execution.postman.json
@@ -1,7 +1,7 @@
 {
   "item": [
     {
-      "id": "3aded318-bd07-47bc-98df-21b3140c687b",
+      "id": "a74a5b2f-7627-4feb-afb2-4e69d6f5fa90",
       "name": "Execute a flow step",
       "description": {
         "content": "",
@@ -9,7 +9,7 @@
       },
       "item": [
         {
-          "id": "691ef329-9b82-4db4-b0aa-6418e4b07f96",
+          "id": "18e4d9ac-db32-46c3-a476-7f27239abca3",
           "name": "Execute a flow step",
           "request": {
             "name": "Execute a flow step",
@@ -71,7 +71,7 @@
           },
           "response": [
             {
-              "id": "edd6c88e-13c5-413e-88d3-c11f6b52f318",
+              "id": "95a3314d-e83d-44a4-82fb-1276380b7341",
               "name": "Flow step executed successfully",
               "originalRequest": {
                 "url": {
@@ -129,12 +129,12 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"flowId\": \"<string>\",\n  \"flowStatus\": \"<string>\",\n  \"stepId\": \"<string>\",\n  \"type\": \"<string>\",\n  \"data\": {\n    \"inputs\": [\n      {\n        \"ref\": \"<string>\",\n        \"identifier\": \"<string>\",\n        \"type\": \"<string>\",\n        \"required\": \"<boolean>\"\n      },\n      {\n        \"ref\": \"<string>\",\n        \"identifier\": \"<string>\",\n        \"type\": \"<string>\",\n        \"required\": \"<boolean>\"\n      }\n    ],\n    \"redirectURL\": \"<string>\",\n    \"additionalData\": {\n      \"dolorc\": \"<string>\",\n      \"tempor9\": \"<string>\",\n      \"Ut_6_\": \"<string>\",\n      \"consequat_a34\": \"<string>\",\n      \"eaa1\": \"<string>\"\n    },\n    \"actions\": [\n      {\n        \"ref\": \"<string>\",\n        \"nextNode\": \"<string>\",\n        \"type\": \"<string>\"\n      },\n      {\n        \"ref\": \"<string>\",\n        \"nextNode\": \"<string>\",\n        \"type\": \"<string>\"\n      }\n    ],\n    \"meta\": \"<object>\"\n  }\n}",
+              "body": "{\n  \"executionId\": \"<string>\",\n  \"flowStatus\": \"<string>\",\n  \"stepId\": \"<string>\",\n  \"type\": \"<string>\",\n  \"challengeToken\": \"<string>\",\n  \"data\": {\n    \"inputs\": [\n      {\n        \"ref\": \"<string>\",\n        \"identifier\": \"<string>\",\n        \"type\": \"<string>\",\n        \"required\": \"<boolean>\"\n      },\n      {\n        \"ref\": \"<string>\",\n        \"identifier\": \"<string>\",\n        \"type\": \"<string>\",\n        \"required\": \"<boolean>\"\n      }\n    ],\n    \"redirectURL\": \"<string>\",\n    \"additionalData\": {\n      \"ullamco_a\": \"<string>\"\n    },\n    \"actions\": [\n      {\n        \"ref\": \"<string>\",\n        \"nextNode\": \"<string>\",\n        \"type\": \"<string>\"\n      },\n      {\n        \"ref\": \"<string>\",\n        \"nextNode\": \"<string>\",\n        \"type\": \"<string>\"\n      }\n    ],\n    \"meta\": \"<object>\"\n  }\n}",
               "cookie": [],
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "432ec7cc-3f06-43c4-87dd-03914dfaff38",
+              "id": "86277951-12b5-46cd-a14b-225c2ab9dba5",
               "name": "Bad Request: The request body is malformed or contains invalid data",
               "originalRequest": {
                 "url": {
@@ -197,7 +197,7 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "067e4bd7-d746-478f-8d6d-327a0fa46a83",
+              "id": "b483fd5f-681e-4ed2-905f-6f95995a0fce",
               "name": "Internal Server Error: An unexpected error occurred while processing the request",
               "originalRequest": {
                 "url": {
@@ -296,7 +296,7 @@
     }
   ],
   "info": {
-    "_postman_id": "cdb3e0d6-0b0f-4331-a5e4-e0d9ca89f8eb",
+    "_postman_id": "ba5b7962-537c-4291-9b5f-266e2cc5cc40",
     "name": "Flow Execution API for App Native Authentication",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.22.4
-      version: 0.22.4
+      specifier: 0.22.5
+      version: 0.22.5
     '@asgardeo/react-router':
       specifier: 2.0.0
       version: 2.0.0
@@ -261,10 +261,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.22.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.22.5(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.1.21
         version: 0.1.21
@@ -490,10 +490,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.22.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.22.5(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -605,7 +605,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@monaco-editor/react':
         specifier: 'catalog:'
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -696,7 +696,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -888,7 +888,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1134,7 +1134,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.22.4(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.5(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1514,14 +1514,14 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.6.6':
-    resolution: {integrity: sha512-qcfux+I5a0kb6WzedmseuIe+PYsi19hf1f9iCWxW7BpVhvinxw25e9vMMSNw+YhYGh88dwQE0vL0xT5zIivKzA==}
+  '@asgardeo/browser@0.6.7':
+    resolution: {integrity: sha512-8StsoB/ZkikigRi9tkp1hD9JyL6J5+FonzgE8yifizzl1k4qPe1isYJ4mRx526s0tp/qNFeknseBsnQsBTdqDg==}
 
   '@asgardeo/i18n@0.4.5':
     resolution: {integrity: sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==}
 
-  '@asgardeo/javascript@0.18.0':
-    resolution: {integrity: sha512-TA0lNEil3xlQVQo2Iet1aW1awjVrfqCqmfy3CSpbjWZ1QhuO8DTmlQQYui3oib94vzILBudglRj5dY/xGfiilw==}
+  '@asgardeo/javascript@0.18.1':
+    resolution: {integrity: sha512-i2jKgwiTIZzulTBye9KKUZprGSeSmoXcY4as6tuogXRH75AVhx7rMVrxRcEduoHSX6C30GEYmTl8StPGbL0QXg==}
 
   '@asgardeo/react-router@2.0.0':
     resolution: {integrity: sha512-RvHol3VgjV466y7RhpmPosER89Yz1prREvjWjhu95X9e4l761+3n8bRSQR5lpP1tasAVKtVH6RzWvWoPST7+Zg==}
@@ -1530,8 +1530,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.22.4':
-    resolution: {integrity: sha512-3L4kWd0OpOgIfVFBaC8S7Q3JBpKq3SxdpmVTDGXeLGK1XS8nan49W+iW43UeYtb6XHurh0xfN8e2lXn3aW5/pw==}
+  '@asgardeo/react@0.22.5':
+    resolution: {integrity: sha512-1jqFr00cJOgqLo0h17G/60iErTUb67oYuHVXsUHVJ1UqZqBOq9gfaMbfKtDLwRsFj5zKAmWm/NPwaCnxJbHP7A==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -3652,25 +3652,21 @@ packages:
     resolution: {integrity: sha512-P7EGH74jsFGY/gd881EeHdz6MXSrjkLHDrwes4cs3ETpaa3ZnCSQrG84imFnOeRQucqB3P2QZc1eL44ATc6nVw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.6.2':
     resolution: {integrity: sha512-qwq2hFBsoR2tJSlflA3mKyrgzo5eNK2CTxcN3gPmBfxVA4jEIa+30pjpbQrK1C+lshhQrItZiPGlvcpL7rOESQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.6.2':
     resolution: {integrity: sha512-Ru92V5qOivrvhJqIXbJUaHTv2zS19OGf30+FFdD+gnyCz6EzWtVcozYHAsjVfIQRWtwM0kEql77SpdV7dEnIVQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.6.2':
     resolution: {integrity: sha512-/AIa8MNZZZh6EnPjWEq6EXsYl9B8JwD2QFcPGFRavXfpiYtK8Uk0q3NVSVcmg5L8WEW9ve5sxAY27lswym8cJw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.6.2':
     resolution: {integrity: sha512-0y9FHSbUj1bhD7obbQXFgnCYHNGuqajMks+oVhqsd0p48U8kjqLPG0aZchztDNzqPk52UHqIBBSiLeMofIcIzw==}
@@ -3806,49 +3802,41 @@ packages:
     resolution: {integrity: sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.1':
     resolution: {integrity: sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.1':
     resolution: {integrity: sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.1':
     resolution: {integrity: sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.1':
     resolution: {integrity: sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.1':
     resolution: {integrity: sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.1':
     resolution: {integrity: sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.1':
     resolution: {integrity: sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.1':
     resolution: {integrity: sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==}
@@ -3907,42 +3895,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -4162,98 +4144,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-LE1gjAwQRrbCOorJJ7LFr10s5vqYf5a00V5Ea9wXcT2+56n5YosJkcp8eQ12FxRBv2YX8dsdQJb+ZTtYJwb6XQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-tdy8ThO/fPp40B81v0YK3QC+KODOmzJzSUOO37DinQxzlTJ026gqUSOM8tzlVixRbQJltgVDCTYF8HNPRErQTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-lS082ROBWdmOyVY/0YB3JmsiClaWoxvC+dA8/rbhyB9VLkvVEaihLEOr4CYmrMse151C4+S6hCw6oa1iewox7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-Hi73aYY0cBkr1/SvNQqH8Cd+rSV6S9RB5izCv0ySBcRnd/Wfn5plguUoGYwBnhHgFbh6cPw9m2dUVBR6BG1gxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
@@ -4624,42 +4592,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.21':
     resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.21':
     resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.21':
     resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.21':
     resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.21':
     resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.21':
     resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
@@ -5093,49 +5055,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -8204,28 +8158,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -10172,56 +10122,48 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.98.0:
     resolution: {integrity: sha512-03baQZCxVyEp8v1NWBRlzGYrmVT/LK7ZrHlF1piscGiGxwfdxoLXVuxsylx3qn/dD/4i/rh7Bzk7reK1br9jvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.98.0:
     resolution: {integrity: sha512-LeqNxQA8y4opjhe68CcFvMzCSrBuJqYVFbwElEj9bagHXQHTp9xVPJRn6VcrC+0VLEDq13HVXMv7RslIuU0zmA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-arm@1.98.0:
     resolution: {integrity: sha512-OBkjTDPYR4hSaueOGIM6FDpl9nt/VZwbSRpbNu9/eEJcxE8G/vynRugW8KRZmCFjPy8j/jkGBvvS+k9iOqKV3g==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.98.0:
     resolution: {integrity: sha512-7w6hSuOHKt8FZsmjRb3iGSxEzM87fO9+M8nt5JIQYMhHTj5C+JY/vcske0v715HCVj5e1xyTnbGXf8FcASeAIw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-x64@1.98.0:
     resolution: {integrity: sha512-QikNyDEJOVqPmxyCFkci8ZdCwEssdItfjQFJB+D+Uy5HFqcS5Lv3d3GxWNX/h1dSb23RPyQdQc267ok5SbEyJw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-riscv64@1.98.0:
     resolution: {integrity: sha512-E7fNytc/v4xFBQKzgzBddV/jretA4ULAPO6XmtBiQu4zZBdBozuSxsQLe2+XXeb0X4S2GIl72V7IPABdqke/vA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-x64@1.98.0:
     resolution: {integrity: sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.98.0:
     resolution: {integrity: sha512-C4MMzcAo3oEDQnW7L8SBgB9F2Fq5qHPnaYTZRMOH3Mp/7kM4OooBInXpCiiFjLnjY95hzP4KyctVx0uYR6MYlQ==}
@@ -11639,9 +11581,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.6.6':
+  '@asgardeo/browser@0.6.7':
     dependencies:
-      '@asgardeo/javascript': 0.18.0
+      '@asgardeo/javascript': 0.18.1
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -11657,22 +11599,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@asgardeo/javascript@0.18.0':
+  '@asgardeo/javascript@0.18.1':
     dependencies:
       '@asgardeo/i18n': 0.4.5
       jose: 5.10.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.22.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.22.5(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@asgardeo/react': 0.22.4(@types/react@19.2.7)(react@19.2.3)
+      '@asgardeo/react': 0.22.5(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.22.4(@types/react@19.2.7)(react@19.2.3)':
+  '@asgardeo/react@0.22.5(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
-      '@asgardeo/browser': 0.6.6
+      '@asgardeo/browser': 0.6.7
       '@asgardeo/i18n': 0.4.5
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - ../docs
 
 catalog:
-  '@asgardeo/react': 0.22.4
+  '@asgardeo/react': 0.22.5
   '@asgardeo/react-router': 2.0.0
   '@hookform/resolvers': 5.2.2
   '@monaco-editor/react': 4.7.0

--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -192,12 +192,6 @@ These variables are used to manage tokens and authentication state. These will b
 | `accessToken` | Access token for management API calls |
 | `refreshToken` | Refresh token for token renewal |
 | `expiresAt` | Token expiration timestamp |
-| `codeVerifier` | PKCE code verifier |
-| `codeChallenge` | PKCE code challenge |
-| `authId` | Authentication session ID |
-| `executionId` | Flow execution ID |
-| `assertion` | Authentication assertion |
-| `authCode` | Authorization code |
 
 ## Collection Variables (Auto-populated)
 
@@ -213,6 +207,7 @@ These variables are automatically populated during the demo execution:
 | `github_session_token` | GitHub authentication session token |
 | `asgardeo_session_token` | Asgardeo authentication session token |
 | `exec_flow_id` | Flow execution ID for flow-native APIs |
+| `exec_challenge_token` | Challenge token for flow execution |
 | `auth_std_auth_id` | OAuth standard flow auth ID |
 | `auth_std_flow_id` | OAuth standard flow flow exec ID |
 | `auth_std_assertion` | OAuth standard flow assertion |

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -1,22 +1,21 @@
 {
   "info": {
-    "_postman_id": "4daf4513-cbd8-4634-a0b6-5610c8d4d2ce",
+    "_postman_id": "060460cd-d810-40ad-8074-425375b35f25",
     "name": "Demo - Authentication",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "18934058"
+    "_exporter_id": "15629984"
   },
   "item": [
     {
       "name": "01 - Set Token",
       "item": [
         {
-          "name": "01 - Initiate Authorization",
+          "name": "01 - Get Management Token",
           "event": [
             {
               "listen": "prerequest",
               "script": {
                 "exec": [
-                  "// Generate PKCE code verifier (43-128 chars, URL-safe)",
                   "function base64UrlEncode(buffer) {",
                   "    return btoa(String.fromCharCode(...new Uint8Array(buffer)))",
                   "        .replace(/\\+/g, '-')",
@@ -24,303 +23,108 @@
                   "        .replace(/=/g, '');",
                   "}",
                   "",
-                  "// Generate random code verifier",
+                  "const baseUrl = `${pm.environment.get('scheme')}://${pm.environment.get('host')}:${pm.environment.get('port')}`;",
+                  "const clientId = pm.environment.get('MGT_TOKEN_APP_CLIENT_ID');",
+                  "const redirectUri = pm.environment.get('MGT_TOKEN_APP_REDIRECT_URI');",
+                  "const scope = pm.environment.get('MGT_TOKEN_SCOPE');",
+                  "const username = pm.environment.get('ADMIN_USERNAME');",
+                  "const password = pm.environment.get('ADMIN_PASSWORD');",
+                  "",
                   "const array = new Uint8Array(32);",
                   "crypto.getRandomValues(array);",
                   "const codeVerifier = base64UrlEncode(array);",
-                  "pm.environment.set(\"codeVerifier\", codeVerifier);",
+                  "pm.variables.set('codeVerifier', codeVerifier);",
                   "",
-                  "// Generate code challenge (SHA-256 hash of verifier)",
-                  "crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))",
-                  "    .then(hash => {",
-                  "        const codeChallenge = base64UrlEncode(hash);",
-                  "        pm.environment.set(\"codeChallenge\", codeChallenge);",
-                  "        console.log(\"PKCE generated - Verifier length:\", codeVerifier.length);",
-                  "    });",
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Should redirect to login\", function() {",
-                  "    pm.expect(pm.response.code).to.be.oneOf([302, 303, 307]);",
+                  "return new Promise((resolve, reject) => {",
+                  "    crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))",
+                  "        .then(hash => {",
+                  "            const codeChallenge = base64UrlEncode(hash);",
+                  "",
+                  "            // Step 1: Initiate Authorization",
+                  "            const authorizeUrl = `${baseUrl}/oauth2/authorize?client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=${encodeURIComponent(scope)}&state=test-state&code_challenge=${codeChallenge}&code_challenge_method=S256`;",
+                  "            pm.sendRequest({ url: authorizeUrl, method: 'GET', followRedirects: false }, (err, res) => {",
+                  "                if (err) return reject('Authorize failed: ' + err);",
+                  "                const location = res.headers.get('Location');",
+                  "                if (!location) return reject('No Location header from /authorize');",
+                  "                const redirectUrl = new URL(location);",
+                  "                const authId = redirectUrl.searchParams.get('authId');",
+                  "                const executionId = redirectUrl.searchParams.get('executionId');",
+                  "                if (!executionId) return reject('No executionId in redirect: ' + location);",
+                  "                console.log('✓ Step 1: executionId:', executionId);",
+                  "",
+                  "                // Step 2: Init Flow",
+                  "                pm.sendRequest({",
+                  "                    url: `${baseUrl}/flow/execute`,",
+                  "                    method: 'POST',",
+                  "                    header: { 'Content-Type': 'application/json' },",
+                  "                    body: { mode: 'raw', raw: JSON.stringify({ executionId, challengeToken: null }) }",
+                  "                }, (err, res) => {",
+                  "                    if (err) return reject('Init flow failed: ' + err);",
+                  "                    const initResp = res.json();",
+                  "                    console.log('✓ Step 2: Flow initialized, status:', initResp.flowStatus);",
+                  "",
+                  "                    // Step 3: Execute Flow with credentials",
+                  "                    pm.sendRequest({",
+                  "                        url: `${baseUrl}/flow/execute`,",
+                  "                        method: 'POST',",
+                  "                        header: { 'Content-Type': 'application/json' },",
+                  "                        body: {",
+                  "                            mode: 'raw',",
+                  "                            raw: JSON.stringify({ executionId, challengeToken: initResp.challengeToken, inputs: { username, password }, action: 'action_001' })",
+                  "                        }",
+                  "                    }, (err, res) => {",
+                  "                        if (err) return reject('Execute flow failed: ' + err);",
+                  "                        const execResp = res.json();",
+                  "                        if (execResp.flowStatus !== 'COMPLETE' || !execResp.assertion) {",
+                  "                            return reject('Auth failed: ' + (execResp.failureReason || execResp.flowStatus));",
+                  "                        }",
+                  "                        console.log('✓ Step 3: Credentials verified');",
+                  "",
+                  "                        // Step 4: Complete Authorization",
+                  "                        pm.sendRequest({",
+                  "                            url: `${baseUrl}/oauth2/auth/callback`,",
+                  "                            method: 'POST',",
+                  "                            header: { 'Content-Type': 'application/json' },",
+                  "                            body: { mode: 'raw', raw: JSON.stringify({ authId, assertion: execResp.assertion }) }",
+                  "                        }, (err, res) => {",
+                  "                            if (err) return reject('Complete auth failed: ' + err);",
+                  "                            const callbackResp = res.json();",
+                  "                            const redirectUriStr = callbackResp.redirect_uri || callbackResp.redirectUri;",
+                  "                            if (!redirectUriStr) return reject('No redirect_uri in callback response: ' + JSON.stringify(callbackResp));",
+                  "                            const authCode = new URL(redirectUriStr).searchParams.get('code');",
+                  "                            if (!authCode) return reject('No auth code in redirect URI');",
+                  "                            pm.variables.set('authCode', authCode);",
+                  "                            console.log('✓ Step 4: Authorization code obtained');",
+                  "                            resolve();",
+                  "                        });",
+                  "                    });",
+                  "                });",
+                  "            });",
+                  "        })",
+                  "        .catch(reject);",
                   "});",
-                  "const location = pm.response.headers.get(\"Location\");",
-                  "if (location) {",
-                  "    const url = new URL(location);",
-                  "    const authId = url.searchParams.get(\"authId\");",
-                  "    const executionId = url.searchParams.get(\"executionId\");",
-                  "    ",
-                  "    pm.environment.set(\"authId\", authId);",
-                  "    pm.environment.set(\"executionId\", executionId);",
-                  "    ",
-                  "    console.log(\"AuthId:\", authId);",
-                  "    console.log(\"ExecutionId:\", executionId);",
-                  "}",
                   ""
                 ],
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {}
               }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/oauth2/authorize?client_id={{MGT_TOKEN_APP_CLIENT_ID}}&redirect_uri={{MGT_TOKEN_APP_REDIRECT_URI}}&response_type=code&scope={{MGT_TOKEN_SCOPE}}&state=test-state&code_challenge={{codeChallenge}}&code_challenge_method=S256",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "authorize"
-              ],
-              "query": [
-                {
-                  "key": "client_id",
-                  "value": "{{MGT_TOKEN_APP_CLIENT_ID}}"
-                },
-                {
-                  "key": "redirect_uri",
-                  "value": "{{MGT_TOKEN_APP_REDIRECT_URI}}"
-                },
-                {
-                  "key": "response_type",
-                  "value": "code"
-                },
-                {
-                  "key": "scope",
-                  "value": "{{MGT_TOKEN_SCOPE}}"
-                },
-                {
-                  "key": "state",
-                  "value": "test-state"
-                },
-                {
-                  "key": "code_challenge",
-                  "value": "{{codeChallenge}}"
-                },
-                {
-                  "key": "code_challenge_method",
-                  "value": "S256"
-                }
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "02 - Init Flow",
-          "event": [
+            },
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test(\"Flow step returned\", function() {",
-                  "    pm.expect(pm.response.code).to.equal(200);",
-                  "});",
-                  "const resp = pm.response.json();",
-                  "console.log(\"Flow status:\", resp.flowStatus);",
-                  "console.log(\"Flow type:\", resp.type);",
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"executionId\": \"{{executionId}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/flow/execute",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flow",
-                "execute"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "03 - Execute Flow",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Authentication successful\", function() {",
-                  "    pm.expect(pm.response.code).to.equal(200);",
-                  "});",
-                  "const resp = pm.response.json();",
-                  "if (resp.flowStatus === \"COMPLETE\" && resp.assertion) {",
-                  "    pm.environment.set(\"assertion\", resp.assertion);",
-                  "    console.log(\"✓ Authentication complete, assertion obtained\");",
-                  "} else {",
-                  "    console.log(\"✗ Authentication failed:\", resp.failureReason || resp.flowStatus);",
-                  "}",
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
-              }
-            },
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"executionId\": \"{{executionId}}\",\n    \"inputs\": {\n        \"username\": \"{{ADMIN_USERNAME}}\",\n        \"password\": \"{{ADMIN_PASSWORD}}\"\n    },\n    \"action\": \"action_001\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/flow/execute",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flow",
-                "execute"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "04 - Complete Authorization",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Authorization completed\", function() {",
-                  "    pm.expect(pm.response.code).to.equal(200);",
-                  "});",
-                  "const resp = pm.response.json();",
-                  "if (resp.redirectUri) {",
-                  "    const url = new URL(resp.redirect_uri);",
-                  "    const code = url.searchParams.get(\"code\");",
-                  "    pm.environment.set(\"authCode\", code);",
-                  "    console.log(\"✓ Authorization code obtained\");",
-                  "}",
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
-              }
-            },
-            {
-              "listen": "prerequest",
-              "script": {
-                "packages": {},
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"authId\": \"{{authId}}\",\n    \"assertion\": \"{{assertion}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/oauth2/auth/callback",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "auth",
-                "callback"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "05 - Exchange Code for Token",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Token obtained\", function() {",
+                  "pm.test('Token obtained', function() {",
                   "    pm.expect(pm.response.code).to.equal(200);",
                   "});",
                   "const token = pm.response.json();",
                   "if (token.access_token) {",
-                  "    pm.environment.set(\"accessToken\", token.access_token);",
-                  "    pm.environment.set(\"expiresAt\", String(Date.now() + (token.expires_in * 1000)));",
-                  "    ",
+                  "    pm.environment.set('accessToken', token.access_token);",
+                  "    pm.environment.set('expiresAt', String(Date.now() + (token.expires_in * 1000)));",
                   "    if (token.refresh_token) {",
-                  "        pm.environment.set(\"refreshToken\", token.refresh_token);",
+                  "        pm.environment.set('refreshToken', token.refresh_token);",
                   "    }",
-                  "    ",
-                  "    console.log(\"✓ Access token stored\");",
-                  "    console.log(\"✓ Expires in:\", token.expires_in, \"seconds\");",
+                  "    console.log('✓ Access token stored, expires in:', token.expires_in, 'seconds');",
                   "}",
                   ""
                 ],
@@ -339,44 +143,34 @@
                 {
                   "key": "grant_type",
                   "value": "authorization_code",
-                  "type": "text",
-                  "uuid": "77f67144-1112-4773-b322-171030e13d31"
+                  "type": "text"
                 },
                 {
                   "key": "code",
                   "value": "{{authCode}}",
-                  "type": "text",
-                  "uuid": "d0096182-585d-4066-927f-52b1791b330c"
+                  "type": "text"
                 },
                 {
                   "key": "redirect_uri",
                   "value": "{{MGT_TOKEN_APP_REDIRECT_URI}}",
-                  "type": "text",
-                  "uuid": "72d50dd8-c9d5-4b1e-88c6-f9522b85a79e"
+                  "type": "text"
                 },
                 {
                   "key": "client_id",
                   "value": "{{MGT_TOKEN_APP_CLIENT_ID}}",
-                  "type": "text",
-                  "uuid": "677ae63e-a94d-482a-aa1c-216b111db30b"
+                  "type": "text"
                 },
                 {
                   "key": "code_verifier",
                   "value": "{{codeVerifier}}",
-                  "type": "text",
-                  "uuid": "25e13a0f-8751-4d85-9100-14c7dca21bdd"
+                  "type": "text"
                 }
               ]
             },
             "url": {
               "raw": "{{baseUrl}}/oauth2/token",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "token"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth2", "token"]
             }
           },
           "response": []
@@ -392,9 +186,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         },
         {
@@ -403,9 +195,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         }
       ]
@@ -477,12 +267,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/organization-units",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "organization-units"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["organization-units"]
             }
           },
           "response": []
@@ -535,12 +321,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/user-schemas",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "user-schemas"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["user-schemas"]
             }
           },
           "response": []
@@ -602,14 +384,9 @@
             "url": {
               "raw": "https://localhost:8090/notification-senders/message",
               "protocol": "https",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "8090",
-              "path": [
-                "notification-senders",
-                "message"
-              ]
+              "path": ["notification-senders", "message"]
             }
           },
           "response": []
@@ -670,12 +447,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/identity-providers",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "identity-providers"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["identity-providers"]
             }
           },
           "response": []
@@ -736,12 +509,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/identity-providers",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "identity-providers"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["identity-providers"]
             }
           },
           "response": []
@@ -802,12 +571,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/identity-providers",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "identity-providers"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["identity-providers"]
             }
           },
           "response": []
@@ -837,12 +602,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/users",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "users"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["users"]
             }
           },
           "response": []
@@ -872,12 +633,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/users",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "users"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["users"]
             }
           },
           "response": []
@@ -907,12 +664,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/users",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "users"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["users"]
             }
           },
           "response": []
@@ -942,12 +695,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/users",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "users"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["users"]
             }
           },
           "response": []
@@ -1008,12 +757,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/applications",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "applications"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["applications"]
             }
           },
           "response": []
@@ -1074,12 +819,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flows",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flows"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flows"]
             }
           },
           "response": []
@@ -1140,12 +881,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flows",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flows"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flows"]
             }
           },
           "response": []
@@ -1206,12 +943,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flows",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flows"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flows"]
             }
           },
           "response": []
@@ -1272,12 +1005,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flows",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flows"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flows"]
             }
           },
           "response": []
@@ -1329,7 +1058,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Demo Basic Registration Flow\",\n    \"handle\": \"demo-basic-flow\",\n    \"flowType\": \"REGISTRATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"user_type_resolver\"\n        },\n        {\n            \"id\": \"user_type_resolver\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"UserTypeResolver\"\n            },\n            \"onSuccess\": \"prompt_basic\"\n        },\n        {\n            \"id\": \"prompt_basic\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_001\",\n                        \"label\": \"{{ t(signup:heading) }}\",\n                        \"variant\": \"HEADING_1\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_001\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_001\",\n                                \"ref\": \"username\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"{{ t(elements:fields.username.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.username.placeholder) }}\"\n                            },\n                            {\n                                \"id\": \"input_002\",\n                                \"ref\": \"password\",\n                                \"type\": \"PASSWORD_INPUT\",\n                                \"label\": \"{{ t(elements:fields.password.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.password.placeholder) }}\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_001\",\n                                \"label\": \"{{ t(elements:buttons.continue.text) }}\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"username\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"password\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"prompt_additional_info\"\n        },\n        {\n            \"id\": \"prompt_additional_info\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_002\",\n                        \"label\": \"Additional Information\",\n                        \"variant\": \"HEADING_2\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_002\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_003\",\n                                \"ref\": \"given_name\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"First Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your first name\"\n                            },\n                            {\n                                \"id\": \"input_004\",\n                                \"ref\": \"family_name\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Last Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your last name\"\n                            },\n                            {\n                                \"id\": \"input_005\",\n                                \"ref\": \"email\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Email Address\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your email address\"\n                            },\n                            {\n                                \"id\": \"input_006\",\n                                \"ref\": \"mobileNumber\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Mobile Number\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your mobile number\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_002\",\n                                \"label\": \"Complete Registration\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_003\",\n                            \"identifier\": \"given_name\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_004\",\n                            \"identifier\": \"family_name\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_005\",\n                            \"identifier\": \"email\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_006\",\n                            \"identifier\": \"mobileNumber\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_002\",\n                        \"nextNode\": \"provisioning\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"provisioning\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"ProvisioningExecutor\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "raw": "{\n    \"name\": \"Demo Basic Registration Flow\",\n    \"handle\": \"demo-basic-flow-2\",\n    \"flowType\": \"REGISTRATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"user_type_resolver\"\n        },\n        {\n            \"id\": \"user_type_resolver\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"UserTypeResolver\"\n            },\n            \"onSuccess\": \"prompt_basic\"\n        },\n        {\n            \"id\": \"prompt_basic\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_001\",\n                        \"label\": \"{{ t(signup:heading) }}\",\n                        \"variant\": \"HEADING_1\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_001\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_001\",\n                                \"ref\": \"username\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"{{ t(elements:fields.username.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.username.placeholder) }}\"\n                            },\n                            {\n                                \"id\": \"input_002\",\n                                \"ref\": \"password\",\n                                \"type\": \"PASSWORD_INPUT\",\n                                \"label\": \"{{ t(elements:fields.password.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.password.placeholder) }}\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_001\",\n                                \"label\": \"{{ t(elements:buttons.continue.text) }}\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"username\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"password\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"prompt_additional_info\"\n        },\n        {\n            \"id\": \"prompt_additional_info\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_002\",\n                        \"label\": \"Additional Information\",\n                        \"variant\": \"HEADING_2\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_002\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_003\",\n                                \"ref\": \"given_name\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"First Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your first name\"\n                            },\n                            {\n                                \"id\": \"input_004\",\n                                \"ref\": \"family_name\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Last Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your last name\"\n                            },\n                            {\n                                \"id\": \"input_005\",\n                                \"ref\": \"email\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Email Address\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your email address\"\n                            },\n                            {\n                                \"id\": \"input_006\",\n                                \"ref\": \"mobileNumber\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Mobile Number\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your mobile number\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_002\",\n                                \"label\": \"Complete Registration\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_003\",\n                            \"identifier\": \"given_name\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_004\",\n                            \"identifier\": \"family_name\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_005\",\n                            \"identifier\": \"email\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_006\",\n                            \"identifier\": \"mobileNumber\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_002\",\n                        \"nextNode\": \"provisioning\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"provisioning\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"ProvisioningExecutor\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1338,12 +1067,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flows",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flows"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flows"]
             }
           },
           "response": []
@@ -1402,14 +1127,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/credentials/authenticate",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "credentials",
-                    "authenticate"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "credentials", "authenticate"]
                 }
               },
               "response": []
@@ -1439,14 +1158,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/credentials/authenticate",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "credentials",
-                    "authenticate"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "credentials", "authenticate"]
                 }
               },
               "response": []
@@ -1502,15 +1215,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/otp/sms/send",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "otp",
-                    "sms",
-                    "send"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "otp", "sms", "send"]
                 }
               },
               "response": []
@@ -1540,15 +1246,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/otp/sms/verify",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "otp",
-                    "sms",
-                    "verify"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "otp", "sms", "verify"]
                 }
               },
               "response": []
@@ -1578,15 +1277,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/otp/sms/verify",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "otp",
-                    "sms",
-                    "verify"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "otp", "sms", "verify"]
                 }
               },
               "response": []
@@ -1642,15 +1334,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/google/start",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "google",
-                    "start"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "google", "start"]
                 }
               },
               "response": []
@@ -1680,15 +1365,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/google/finish",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "google",
-                    "finish"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "google", "finish"]
                 }
               },
               "response": []
@@ -1744,15 +1422,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/github/start",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "github",
-                    "start"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "github", "start"]
                 }
               },
               "response": []
@@ -1782,15 +1453,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/github/finish",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "github",
-                    "finish"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "github", "finish"]
                 }
               },
               "response": []
@@ -1846,15 +1510,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/standard/start",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "standard",
-                    "start"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "standard", "start"]
                 }
               },
               "response": []
@@ -1884,15 +1541,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/auth/oauth/standard/finish",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "auth",
-                    "oauth",
-                    "standard",
-                    "finish"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["auth", "oauth", "standard", "finish"]
                 }
               },
               "response": []
@@ -1910,9 +1560,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         },
         {
@@ -1921,9 +1569,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         }
       ]
@@ -1951,7 +1597,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -1960,13 +1606,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -1981,13 +1622,24 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                },
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2017,13 +1669,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2034,9 +1681,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2057,7 +1702,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2066,13 +1711,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2088,9 +1728,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -2099,9 +1737,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -2126,7 +1762,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2135,13 +1771,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -2156,11 +1787,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2192,13 +1825,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2209,9 +1837,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2232,7 +1858,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2241,13 +1867,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2263,9 +1884,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -2274,9 +1893,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -2301,7 +1918,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{smsAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{smsAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2310,13 +1927,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -2331,11 +1943,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2367,13 +1981,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2385,8 +1994,25 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the challenge token from the response",
+                      "const challengeToken = jsonResponse.challengeToken;",
+                      "",
+                      "// Store as collection variables",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                },
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2407,7 +2033,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2416,13 +2042,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2433,9 +2054,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2456,7 +2075,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"443375\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"otp\": \"<OTP>\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2465,13 +2084,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2487,9 +2101,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -2498,9 +2110,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -2525,7 +2135,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{mfaAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{mfaAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2534,13 +2144,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -2555,11 +2160,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2591,13 +2198,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2609,8 +2211,25 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the challenge token from the response",
+                      "const challengeToken = jsonResponse.challengeToken;",
+                      "",
+                      "// Store as collection variables",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                },
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2631,7 +2250,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2640,13 +2259,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2657,9 +2271,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2680,7 +2292,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"921262\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"otp\": \"<OTP>\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2689,13 +2301,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2711,9 +2318,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -2722,9 +2327,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -2749,7 +2352,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{multiOptionAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{multiOptionAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2758,13 +2361,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -2779,11 +2377,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2815,13 +2415,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2832,9 +2427,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -2855,7 +2448,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n        // \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2864,13 +2457,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2885,11 +2473,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2921,13 +2511,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2939,6 +2524,14 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the challenge token from the response",
+                      "const challengeToken = jsonResponse.challengeToken;",
+                      "",
+                      "// Store as collection variables",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2961,7 +2554,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"action\": \"action_002\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"action\": \"action_002\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2970,13 +2563,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -2987,9 +2575,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -3010,7 +2596,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n    }\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n    }\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3019,13 +2605,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -3041,9 +2622,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -3052,9 +2631,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -3070,9 +2647,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         },
         {
@@ -3081,9 +2656,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         }
       ]
@@ -3111,7 +2684,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"registrationFlowId\": \"{{basicRegistrationFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"registrationFlowId\": \"{{basicRegistrationFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3120,13 +2693,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "applications",
-                    "{{loginApplicationId}}"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["applications", "{{loginApplicationId}}"]
                 }
               },
               "response": []
@@ -3141,11 +2709,13 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the executionId from the response",
+                      "// Extract the executionId and challenge token from the response",
                       "const executionId = jsonResponse.executionId;",
+                      "const challengeToken = jsonResponse.challengeToken;",
                       "",
-                      "// Store it as a collection variable",
+                      "// Store as collection variables",
                       "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -3177,13 +2747,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -3195,6 +2760,14 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the challenge token from the response",
+                      "const challengeToken = jsonResponse.challengeToken;",
+                      "",
+                      "// Store as collection variables",
+                      "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -3217,7 +2790,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"kurt\",\n        \"password\": \"kurt@123\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"kurt\",\n        \"password\": \"kurt@123\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3226,13 +2799,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -3243,9 +2811,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "exec": [
-                      ""
-                    ],
+                    "exec": [""],
                     "type": "text/javascript",
                     "packages": {},
                     "requests": {}
@@ -3266,7 +2832,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"given_name\": \"Kurt\",\n        \"family_name\": \"Weller\",\n        \"email\": \"kurt@fbi.com\",\n        \"mobileNumber\": \"+94712345688\"\n    },\n    \"action\": \"action_002\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"given_name\": \"Kurt\",\n        \"family_name\": \"Weller\",\n        \"email\": \"kurt@fbi.com\",\n        \"mobileNumber\": \"+94712345688\"\n    },\n    \"action\": \"action_002\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3275,13 +2841,8 @@
                 },
                 "url": {
                   "raw": "{{baseUrl}}/flow/execute",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "flow",
-                    "execute"
-                  ]
+                  "host": ["{{baseUrl}}"],
+                  "path": ["flow", "execute"]
                 }
               },
               "response": []
@@ -3297,9 +2858,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             },
             {
@@ -3308,9 +2867,7 @@
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {},
-                "exec": [
-                  ""
-                ]
+                "exec": [""]
               }
             }
           ]
@@ -3326,9 +2883,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         },
         {
@@ -3337,9 +2892,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         }
       ]
@@ -3364,7 +2917,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+              "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"ouId\": \"{{demoOuId}}\",\n    \"authFlowId\": \"{{basicAuthFlowGraphId}}\",\n    \"isRegistrationFlowEnabled\": true,\n    \"allowedUserTypes\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validityPeriod\": 3600,\n        \"userAttributes\": [\n            \"email\",\n            \"username\",\n            \"given_name\",\n            \"family_name\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inboundAuthConfig\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"clientId\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirectUris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grantTypes\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"responseTypes\": [\n                    \"code\"\n                ],\n                \"tokenEndpointAuthMethod\": \"none\",\n                \"pkceRequired\": true,\n                \"publicClient\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"accessToken\": {\n                        \"validityPeriod\": 7200,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ]\n                    },\n                    \"idToken\": {\n                        \"validityPeriod\": 3600,\n                        \"userAttributes\": [\n                            \"email\",\n                            \"username\",\n                            \"given_name\",\n                            \"family_name\",\n                            \"groups\"\n                        ],\n                        \"scopeClaims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3373,13 +2926,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "applications",
-                "{{loginApplicationId}}"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["applications", "{{loginApplicationId}}"]
             }
           },
           "response": []
@@ -3419,13 +2967,8 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/oauth2/authorize?client_id={{LOGIN_APPLICATION_CLIENT_ID}}&redirect_uri={{LOGIN_APPLICATION_REDIRECT_URI}}&response_type=code&state=test-state&code_challenge=wxmTR5SueS1wRSqFa5LMXJ7BgjZ-dubItVtJjblSVKg&code_challenge_method=S256",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "authorize"
-              ],
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth2", "authorize"],
               "query": [
                 {
                   "key": "client_id",
@@ -3463,6 +3006,14 @@
               "listen": "test",
               "script": {
                 "exec": [
+                  "// Parse the JSON response",
+                  "const jsonResponse = pm.response.json();",
+                  "",
+                  "// Extract the challenge token from the response",
+                  "const challengeToken = jsonResponse.challengeToken;",
+                  "",
+                  "// Store as collection variables",
+                  "pm.collectionVariables.set(\"exec_challenge_token\", challengeToken);",
                   ""
                 ],
                 "type": "text/javascript",
@@ -3473,8 +3024,10 @@
             {
               "listen": "prerequest",
               "script": {
+                "exec": [""],
+                "type": "text/javascript",
                 "packages": {},
-                "type": "text/javascript"
+                "requests": {}
               }
             }
           ],
@@ -3498,13 +3051,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flow/execute",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flow",
-                "execute"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flow", "execute"]
             }
           },
           "response": []
@@ -3536,9 +3084,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {}
@@ -3556,7 +3102,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"executionId\": \"{{auth_std_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}",
+              "raw": "{\n    \"executionId\": \"{{auth_std_flow_id}}\",\n    \"challengeToken\": \"{{exec_challenge_token}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3565,13 +3111,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/flow/execute",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "flow",
-                "execute"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["flow", "execute"]
             }
           },
           "response": []
@@ -3620,14 +3161,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/oauth2/auth/callback",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "auth",
-                "callback"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth2", "auth", "callback"]
             }
           },
           "response": []
@@ -3638,9 +3173,7 @@
             {
               "listen": "test",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript",
                 "packages": {},
                 "requests": {}
@@ -3694,13 +3227,8 @@
             },
             "url": {
               "raw": "{{baseUrl}}/oauth2/token",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "oauth2",
-                "token"
-              ]
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth2", "token"]
             }
           },
           "response": []
@@ -3716,9 +3244,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         },
         {
@@ -3727,9 +3253,7 @@
             "type": "text/javascript",
             "packages": {},
             "requests": {},
-            "exec": [
-              ""
-            ]
+            "exec": [""]
           }
         }
       ]
@@ -3812,9 +3336,7 @@
         "type": "text/javascript",
         "packages": {},
         "requests": {},
-        "exec": [
-          ""
-        ]
+        "exec": [""]
       }
     }
   ],
@@ -3857,9 +3379,11 @@
     },
     {
       "key": "auth_std_auth_code",
-      "value": "",
-      "type": "string"
+      "value": ""
+    },
+    {
+      "key": "exec_challenge_token",
+      "value": ""
     }
   ]
 }
-

--- a/samples/api/postman/authentication/environment.json
+++ b/samples/api/postman/authentication/environment.json
@@ -1,328 +1,292 @@
 {
-	"id": "ec72ce9d-77b9-403c-9737-c85fc831741c",
-	"name": "Thunder",
-	"values": [
-		{
-			"key": "scheme",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "host",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "port",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "baseUrl",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "accessToken",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "refreshToken",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "expiresAt",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "codeVerifier",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "codeChallenge",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "authId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "executionId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "assertion",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "authCode",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "MGT_TOKEN_APP_CLIENT_ID",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "MGT_TOKEN_APP_REDIRECT_URI",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "MGT_TOKEN_SCOPE",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "ADMIN_USERNAME",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "ADMIN_PASSWORD",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "demoOuId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoOuHandle",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoSchemaId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoSchemaName",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoLoginUser1Username",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoLoginUser1Password",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "demoLoginUser1Email",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoLoginUser1Mobile",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "MESSAGE_NOTIFICATION_SENDER_URL",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "messageNotificationSenderId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "GOOGLE_CLIENT_ID",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "GOOGLE_CLIENT_SECRET",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "FED_IDP_REDIRECT_URI",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "googleIDPId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "GITHUB_CLIENT_ID",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "GITHUB_CLIENT_SECRET",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "githubIDPId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "ASGARDEO_CLIENT_ID",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "ASGARDEO_CLIENT_SECRET",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "ASGARDEO_BASE_URI",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "asgardeoIDPId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoGoogleUserSub",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "demoGoogleUserEmail",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoGithubUserSub",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "demoGithubUserEmail",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "demoAsgardeoUserSub",
-			"value": "",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "demoAsgardeoUserEmail",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "LOGIN_APPLICATION_CLIENT_ID",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "LOGIN_APPLICATION_REDIRECT_URI",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "loginApplicationId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "basicAuthFlowGraphId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "smsAuthFlowGraphId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "mfaAuthFlowGraphId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "multiOptionAuthFlowGraphId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "basicRegistrationFlowGraphId",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		}
-	],
-	"color": 62,
-	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2026-01-26T05:39:44.821Z",
-	"_postman_exported_using": "Postman/11.81.4"
+  "id": "ec72ce9d-77b9-403c-9737-c85fc831741c",
+  "name": "Thunder",
+  "values": [
+    {
+      "key": "scheme",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "host",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "port",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "baseUrl",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "accessToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "refreshToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "expiresAt",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "MGT_TOKEN_APP_CLIENT_ID",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "MGT_TOKEN_APP_REDIRECT_URI",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "MGT_TOKEN_SCOPE",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "ADMIN_USERNAME",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "ADMIN_PASSWORD",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "demoOuId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoOuHandle",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoSchemaId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoSchemaName",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoLoginUser1Username",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoLoginUser1Password",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "demoLoginUser1Email",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoLoginUser1Mobile",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "MESSAGE_NOTIFICATION_SENDER_URL",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "messageNotificationSenderId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "GOOGLE_CLIENT_ID",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "GOOGLE_CLIENT_SECRET",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "FED_IDP_REDIRECT_URI",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "googleIDPId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "GITHUB_CLIENT_ID",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "GITHUB_CLIENT_SECRET",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "githubIDPId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "ASGARDEO_CLIENT_ID",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "ASGARDEO_CLIENT_SECRET",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "ASGARDEO_BASE_URI",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "asgardeoIDPId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoGoogleUserSub",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "demoGoogleUserEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoGithubUserSub",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "demoGithubUserEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "demoAsgardeoUserSub",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "demoAsgardeoUserEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "LOGIN_APPLICATION_CLIENT_ID",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "LOGIN_APPLICATION_REDIRECT_URI",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "loginApplicationId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "basicAuthFlowGraphId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "smsAuthFlowGraphId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "mfaAuthFlowGraphId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "multiOptionAuthFlowGraphId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "basicRegistrationFlowGraphId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "color": 62,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-01-26T05:39:44.821Z",
+  "_postman_exported_using": "Postman/11.81.4"
 }

--- a/samples/apps/react-sdk-sample/package-lock.json
+++ b/samples/apps/react-sdk-sample/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-sdk-sample",
       "version": "0.34.0",
       "dependencies": {
-        "@asgardeo/react": "0.21.3",
+        "@asgardeo/react": "0.22.5",
         "@wso2/oxygen-ui": "0.0.1-alpha.10",
         "jwt-decode": "4.0.0",
         "react": "19.2.3",
@@ -31,12 +31,12 @@
       }
     },
     "node_modules/@asgardeo/browser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@asgardeo/browser/-/browser-0.6.3.tgz",
-      "integrity": "sha512-H8e9wWSJdQVhRcBsxOKO5Z3hcARARt/ADSPwFZG+RczwUUmo43DxewvV7OuMaoJ+YtTfSxDl6t8pZwhS5P3KBg==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@asgardeo/browser/-/browser-0.6.7.tgz",
+      "integrity": "sha512-8StsoB/ZkikigRi9tkp1hD9JyL6J5+FonzgE8yifizzl1k4qPe1isYJ4mRx526s0tp/qNFeknseBsnQsBTdqDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asgardeo/javascript": "0.16.1",
+        "@asgardeo/javascript": "0.18.1",
         "base64url": "3.0.1",
         "buffer": "6.0.3",
         "core-js": "3.42.0",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@asgardeo/javascript": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.16.1.tgz",
-      "integrity": "sha512-0lqYQZqsgIXWXTk1Tre0BPEspHodIbSbK8BdXBuu+nzYYnWaDMt5ecMPzpFs2bHQ5K/guk6YUJk9ZvKdoEey2w==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.18.1.tgz",
+      "integrity": "sha512-i2jKgwiTIZzulTBye9KKUZprGSeSmoXcY4as6tuogXRH75AVhx7rMVrxRcEduoHSX6C30GEYmTl8StPGbL0QXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asgardeo/i18n": "0.4.5",
@@ -79,12 +79,12 @@
       }
     },
     "node_modules/@asgardeo/react": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@asgardeo/react/-/react-0.21.3.tgz",
-      "integrity": "sha512-zOID43dHpwJ08/3VpHbyriytzzcjg0t6fV/E2kluIwhBMsYcKd3EkAriOb0vh6LcURT5SpdxVJol6qc2igv23g==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@asgardeo/react/-/react-0.22.5.tgz",
+      "integrity": "sha512-1jqFr00cJOgqLo0h17G/60iErTUb67oYuHVXsUHVJ1UqZqBOq9gfaMbfKtDLwRsFj5zKAmWm/NPwaCnxJbHP7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asgardeo/browser": "0.6.3",
+        "@asgardeo/browser": "0.6.7",
         "@asgardeo/i18n": "0.4.5",
         "@emotion/css": "11.13.5",
         "@floating-ui/react": "0.27.12",
@@ -2438,6 +2438,24 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -5058,24 +5076,6 @@
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array/node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/samples/apps/react-sdk-sample/package.json
+++ b/samples/apps/react-sdk-sample/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@asgardeo/react": "0.21.3",
+    "@asgardeo/react": "0.22.5",
     "@wso2/oxygen-ui": "0.0.1-alpha.10",
     "jwt-decode": "4.0.0",
     "react": "19.2.3",

--- a/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
@@ -73,6 +73,7 @@ interface ActionPrompt {
 interface AuthResponse {
     flowStatus?: string;
     assertion?: string;
+    challengeToken?: string;
     failureReason?: string;
     type?: string;
     data?: {
@@ -102,6 +103,7 @@ const LoginPage = () => {
 
     const START_INIT_KEY = 'startInit';
     const EXECUTION_ID_KEY = 'executionId';
+    const CHALLENGE_TOKEN_KEY = 'challengeToken';
 
     const isComponentReMount = useRef(false);
     const { setToken, clearToken } = useAuth();
@@ -115,6 +117,7 @@ const LoginPage = () => {
     const [loading, setLoading] = useState<boolean>(true);
     const [retryCount, setRetryCount] = useState<number>(0);
     const [executionId, setExecutionId] = useState<string>(sessionStorage.getItem(EXECUTION_ID_KEY) || '');
+    const [challengeToken, setChallengeToken] = useState<string>(sessionStorage.getItem(CHALLENGE_TOKEN_KEY) || '');
     const [startInit] = useState<boolean>(JSON.parse(sessionStorage.getItem(START_INIT_KEY) || 'true'));
 
     // Unified form data state
@@ -251,12 +254,18 @@ const LoginPage = () => {
         event.preventDefault(); // Prevent focus loss
     };
 
-    const handleSocialLoginClick = useCallback((redirectURL: string) => {
+    const handleSocialLoginClick = useCallback((redirectURL: string, newChallengeToken?: string) => {
         setLoading(true);
         sessionStorage.setItem(EXECUTION_ID_KEY, executionId);
+        const tokenToSave = newChallengeToken !== undefined ? newChallengeToken : challengeToken;
+        if (tokenToSave) {
+            sessionStorage.setItem(CHALLENGE_TOKEN_KEY, tokenToSave);
+        } else {
+            sessionStorage.removeItem(CHALLENGE_TOKEN_KEY);
+        }
         sessionStorage.setItem(START_INIT_KEY, "false");
         window.location.href = redirectURL;
-    }, [executionId]);
+    }, [executionId, challengeToken]);
 
     // Process authentication response
     const processAuthResponse = useCallback((data: AuthResponse, selectedAction?: string) => {
@@ -264,6 +273,7 @@ const LoginPage = () => {
         const isMobileLogin = selectedAction && selectedAction.includes('mobile');
 
         setExecutionId(data.executionId || '');
+        setChallengeToken(data.challengeToken || '');
         if (data.flowStatus && data.flowStatus == 'ERROR') {
             if (isMobileLogin && data?.failureReason && data.failureReason.includes("User not found")) {
                 console.log("User not found, prompting registration");
@@ -343,7 +353,7 @@ const LoginPage = () => {
                 // This handles intermediate steps like "send_sms" that don't need user input
                 const singleAction = data.data.actions[0];
                 setLoading(true);
-                submitAuthDecision(executionId, singleAction.ref)
+                submitAuthDecision(executionId, singleAction.ref, undefined, data.challengeToken)
                     .then((result) => {
                         processAuthResponse(result.data, singleAction.ref);
                     })
@@ -361,8 +371,10 @@ const LoginPage = () => {
             const idpName = data.data?.additionalData?.idpName || 'Social Login';
 
             if (isCameFromDecision) {
-                // If this is a decision screen, handle the social login click
-                handleSocialLoginClick(url || '');
+                // If this is a decision screen, handle the social login click.
+                // Pass the new challenge token directly — the React state update for
+                // challengeToken hasn't flushed yet, so the closed-over value is stale.
+                handleSocialLoginClick(url || '', data.challengeToken || '');
                 return;
             }
             
@@ -380,8 +392,8 @@ const LoginPage = () => {
     const handleAuthOptionSelection = (actionId: string) => {
         setLoading(true);
         setSelectedAction(actionId);
-        
-        submitAuthDecision(executionId, actionId)
+
+        submitAuthDecision(executionId, actionId, undefined, challengeToken)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -450,7 +462,7 @@ const LoginPage = () => {
                     } else if (data.data?.actions && data.data.actions.length === 1) {
                         // Single action without inputs - auto-execute it
                         const singleAction = data.data.actions[0];
-                        submitAuthDecision(data.executionId, singleAction.ref)
+                        submitAuthDecision(data.executionId, singleAction.ref, undefined, data.challengeToken)
                             .then((result) => {
                                 processAuthResponse(result.data, singleAction.ref);
                             })
@@ -466,7 +478,7 @@ const LoginPage = () => {
                     // Handle redirection for social logins
                     const url = data.data?.redirectURL;
                     const idpName = data.data?.additionalData?.idpName || 'Social Login';
-                    
+
                     if (url) {
                         // Store the redirect URL instead of redirecting immediately
                         setRedirectURL(url);
@@ -475,6 +487,7 @@ const LoginPage = () => {
                 }
 
                 setExecutionId(data.executionId);
+                setChallengeToken(data.challengeToken || '');
                 setLoading(false);
             }).catch((error) => {
                 const errorType = isSignupMode ? "registration" : "auth";
@@ -546,7 +559,7 @@ const LoginPage = () => {
                     } else if (data.data?.actions && data.data.actions.length === 1) {
                         // Single action without inputs - auto-execute it
                         const singleAction = data.data.actions[0];
-                        submitAuthDecision(data.executionId, singleAction.ref)
+                        submitAuthDecision(data.executionId, singleAction.ref, undefined, data.challengeToken)
                             .then((result) => {
                                 processAuthResponse(result.data, singleAction.ref);
                             })
@@ -562,7 +575,7 @@ const LoginPage = () => {
                     // Handle redirection for social logins
                     const url = data.data?.redirectURL;
                     const idpName = data.data?.additionalData?.idpName || 'Social Login';
-                    
+
                     if (url) {
                         // Store the redirect URL instead of redirecting immediately
                         setRedirectURL(url);
@@ -571,6 +584,7 @@ const LoginPage = () => {
                 }
 
                 setExecutionId(data.executionId);
+                setChallengeToken(data.challengeToken || '');
                 setLoading(false);
             }).catch((error) => {
                 console.error(`Error during user registration:`, error);
@@ -600,7 +614,7 @@ const LoginPage = () => {
             const formAction = event.currentTarget.getAttribute('data-action-id');
             if (formAction) {
                 setSelectedAction(formAction);
-                submitAuthDecision(executionId, formAction, completeFormData)
+                submitAuthDecision(executionId, formAction, completeFormData, challengeToken)
                     .then((result) => {
                         processAuthResponse(result.data, formAction);
                     })
@@ -612,7 +626,7 @@ const LoginPage = () => {
         } else {
             // This is a direct input submission - include action if available
             const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-            submitNativeAuth(executionId, completeFormData, actionRef)
+            submitNativeAuth(executionId, completeFormData, actionRef, challengeToken)
                 .then((result) => {
                     if (isMobileInput) {
                         processAuthResponse(result.data, "mobile");
@@ -651,7 +665,7 @@ const LoginPage = () => {
         };
 
         const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-        submitNativeAuth(executionId, passkeyInputs, actionRef)
+        submitNativeAuth(executionId, passkeyInputs, actionRef, challengeToken)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -687,7 +701,7 @@ const LoginPage = () => {
 
         // Include action ref if available (consistent with other direct submissions)
         const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-        submitNativeAuth(executionId, passkeyInputs, actionRef)
+        submitNativeAuth(executionId, passkeyInputs, actionRef, challengeToken)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -757,7 +771,7 @@ const LoginPage = () => {
                 // Clear query parameters to avoid re-submission
                 window.history.replaceState({}, document.title, window.location.pathname);
 
-                submitNativeAuth(executionId, { type: NativeAuthSubmitType.SOCIAL, code: code })
+                submitNativeAuth(executionId, { type: NativeAuthSubmitType.SOCIAL, code: code }, undefined, challengeToken)
                     .then((result) => {
                         processAuthResponse(result.data);
                     }).catch((error) => {

--- a/samples/apps/react-vanilla-sample/src/services/authService.ts
+++ b/samples/apps/react-vanilla-sample/src/services/authService.ts
@@ -370,9 +370,10 @@ export const initiateNativeAuthFlowWithData = async (flowType: 'LOGIN' | 'REGIST
  * @param {string} executionId - The flow ID received from the initiateNativeAuth response.
  * @param {string} actionId - The ID of the selected authentication action.
  * @param {object} inputs - Optional input data to submit with the decision.
+ * @param {string} challengeToken - Optional challenge token for the current step, if required by the server.
  * @returns {Promise<object>} - A promise that resolves to the response data from the server.
  */
-export const submitAuthDecision = async (executionId: string, actionId: string, inputs?: Record<string, unknown>) => {
+export const submitAuthDecision = async (executionId: string, actionId: string, inputs?: Record<string, unknown>, challengeToken?: string) => {
     const headers = {
         'Content-Type': 'application/json'
     };
@@ -381,6 +382,10 @@ export const submitAuthDecision = async (executionId: string, actionId: string, 
         executionId: executionId,
         action: actionId
     };
+
+    if (challengeToken) {
+        data.challengeToken = challengeToken;
+    }
 
     // Include inputs if provided
     if (inputs && Object.keys(inputs).length > 0) {
@@ -410,12 +415,14 @@ export const submitAuthDecision = async (executionId: string, actionId: string, 
  * @param {string} executionId - The flow ID received from the initiateNativeAuth response.
  * @param {object} payload - The payload containing the form data or other required information.
  * @param {string} action - Optional action ref to include in the request.
+ * @param {string} challengeToken - Optional challenge token for the current step, if required by the server.
  * @returns {Promise<object>} - A promise that resolves to the response data from the server.
  */
 export const submitNativeAuth = async (
     executionId: string,
     payload: Record<string, unknown> | NativeAuthSubmitPayload,
-    action?: string
+    action?: string,
+    challengeToken?: string
 ) => {
     const headers = {
         'Content-Type': 'application/json'
@@ -428,6 +435,10 @@ export const submitNativeAuth = async (
     // Include action if provided
     if (action) {
         data.action = action;
+    }
+
+    if (challengeToken) {
+        data.challengeToken = challengeToken;
     }
 
     if ('type' in payload) {

--- a/tests/e2e/utils/thunder-setup/mfa-setup.ts
+++ b/tests/e2e/utils/thunder-setup/mfa-setup.ts
@@ -194,11 +194,13 @@ export class ThunderMFASetup {
 
     const flowData = await flowResponse.json();
     const executionId = flowData.executionId;
+    const challengeToken = flowData.challengeToken;
 
     // Step 2: Submit credentials
     const authResponse = await this.request.post(`${this.config.thunderUrl}/flow/execute`, {
       data: {
         executionId: executionId,
+        challengeToken: challengeToken,
         inputs: {
           username: this.config.adminUsername,
           password: this.config.adminPassword,

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -501,7 +501,8 @@ func (ts *AssuranceTestSuite) TestAssurance_SMSOTPOnly() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err)
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
 
@@ -515,7 +516,8 @@ func (ts *AssuranceTestSuite) TestAssurance_SMSOTPOnly() {
 
 	// Step 3: Submit OTP
 	otpInputs := map[string]string{"otp": lastMessage.OTP}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002",
+		otpFlowStep.ChallengeToken)
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)
@@ -555,7 +557,8 @@ func (ts *AssuranceTestSuite) TestAssurance_CredentialsPlusSMSOTP() {
 		"password": userAttrs["password"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err)
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
 
@@ -569,7 +572,8 @@ func (ts *AssuranceTestSuite) TestAssurance_CredentialsPlusSMSOTP() {
 
 	// Step 3: Submit OTP
 	otpInputs := map[string]string{"otp": lastMessage.OTP}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002",
+		otpFlowStep.ChallengeToken)
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)
@@ -606,7 +610,8 @@ func (ts *AssuranceTestSuite) TestAssurance_BasicAuthOnly() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)

--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -352,7 +352,8 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 				ts.validateRequiredInputs(flowStep.Data.Inputs, []string{"username", "password"})
 
 				// Step 2: Provide credentials - should authenticate and proceed to attribute collection
-				credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "")
+				credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "",
+					flowStep.ChallengeToken)
 				ts.Require().NoError(err, "Failed to complete basic authentication")
 
 				if len(testCase.expectedMissingAttrs) == 0 {
@@ -371,7 +372,8 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 
 					// Step 3: Provide missing attributes
 					if len(testCase.providedAttrs) > 0 {
-						finalStep, err := common.CompleteFlow(credentialStep.ExecutionID, testCase.providedAttrs, "")
+						finalStep, err := common.CompleteFlow(credentialStep.ExecutionID, testCase.providedAttrs, "",
+							credentialStep.ChallengeToken)
 						ts.Require().NoError(err, "Failed to complete attribute collection")
 						ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected flow status to be COMPLETE")
 						ts.Require().NotEmpty(finalStep.Assertion, "Expected assertion after attribute collection")
@@ -389,7 +391,8 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 					ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
 
 					// Provide credentials
-					credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "")
+					credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "",
+						flowStep.ChallengeToken)
 					ts.Require().NoError(err, "Failed to complete second authentication")
 					ts.Require().Equal("COMPLETE", credentialStep.FlowStatus,
 						"Expected flow to complete on second login")
@@ -416,7 +419,7 @@ func (ts *AttributeCollectFlowTestSuite) TestSingleRequestLogin_WithAllInputs() 
 		"email":        "john.doe2@example.com",
 		"mobileNumber": "+1987654345",
 	}
-	finalStep, err := common.CompleteFlow(flowStep.ExecutionID, allInputs, "")
+	finalStep, err := common.CompleteFlow(flowStep.ExecutionID, allInputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication with all inputs")
 	ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected flow status to be COMPLETE")
 	ts.Require().NotEmpty(finalStep.Assertion, "Expected assertion after completing flow with all inputs")
@@ -431,7 +434,7 @@ func (ts *AttributeCollectFlowTestSuite) TestInvalidCredentials() {
 	flowStep, err := common.InitiateAuthenticationFlow(attrCollectTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
 
-	errorResp, err := common.CompleteFlow(flowStep.ExecutionID, invalidCredentials, "")
+	errorResp, err := common.CompleteFlow(flowStep.ExecutionID, invalidCredentials, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Expected error response for invalid credentials")
 	ts.Require().NotEmpty(errorResp.FailureReason, "Expected failure reason for invalid credentials")
 	ts.Require().Contains(errorResp.FailureReason, "User not found",

--- a/tests/integration/flow/authentication/authz_test.go
+++ b/tests/integration/flow/authentication/authz_test.go
@@ -360,7 +360,8 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithDirectRoleAssignment
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
@@ -404,7 +405,8 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithNoRole() {
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
@@ -440,7 +442,8 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithPartialPermissions()
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")

--- a/tests/integration/flow/authentication/basic_auth_test.go
+++ b/tests/integration/flow/authentication/basic_auth_test.go
@@ -334,7 +334,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccess() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow: %v", err)
 	}
@@ -420,7 +421,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 		"username": userAttrs["username"].(string),
 	}
 
-	intermediateFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	intermediateFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with missing credentials: %v", err)
 	}
@@ -441,7 +443,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		intermediateFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow: %v", err)
 	}
@@ -484,7 +487,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidCredentials() {
 		"password": "wrong_password",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid credentials: %v", err)
 	}
@@ -521,7 +525,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowRetryAfterInvalidCredentials(
 		"password": "wrong_password",
 	}
 
-	retryFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidInputs, "action_001")
+	retryFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidInputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid credentials: %v", err)
 	}
@@ -536,7 +541,8 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowRetryAfterInvalidCredentials(
 		"password": "testpassword",
 	}
 
-	successFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, validInputs, "action_001")
+	successFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, validInputs, "action_001",
+		retryFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow after retry: %v", err)
 	}
@@ -581,7 +587,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidFlowID() {
 		"password": "somepassword",
 	}
 
-	errorResp, err := common.CompleteAuthFlowWithError("invalid-flow-id", inputs)
+	errorResp, err := common.CompleteAuthFlowWithError("invalid-flow-id", inputs, flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow: %v", err)
 	}

--- a/tests/integration/flow/authentication/challenge_token_test.go
+++ b/tests/integration/flow/authentication/challenge_token_test.go
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/flow/common"
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	ctTokenTestOU = testutils.OrganizationUnit{
+		Handle:      "ct_token_test_ou",
+		Name:        "Test OU for Challenge Token Flow",
+		Description: "Organization unit created for challenge token flow testing",
+		Parent:      nil,
+	}
+
+	ctTokenTestFlow = testutils.Flow{
+		Name:     "Challenge Token Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_ct_token_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
+					},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+				},
+				"onSuccess":    "auth_assert",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	ctTokenUserSchema = testutils.UserSchema{
+		Name: "ct_token_test_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+		},
+	}
+
+	ctTokenTestUser = testutils.User{
+		Type: ctTokenUserSchema.Name,
+		Attributes: json.RawMessage(`{
+			"username": "ct_token_testuser",
+			"password": "testpassword"
+		}`),
+	}
+)
+
+var (
+	ctTokenTestAppID    string
+	ctTokenUserSchemaID string
+)
+
+type ChallengeTokenTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+	ouID   string
+}
+
+func TestChallengeTokenTestSuite(t *testing.T) {
+	suite.Run(t, new(ChallengeTokenTestSuite))
+}
+
+func (ts *ChallengeTokenTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(ctTokenTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	ctTokenUserSchema.OUID = ts.ouID
+	schemaID, err := testutils.CreateUserType(ctTokenUserSchema)
+	ts.Require().NoError(err, "Failed to create test user schema")
+	ctTokenUserSchemaID = schemaID
+
+	flowID, err := testutils.CreateFlow(ctTokenTestFlow)
+	ts.Require().NoError(err, "Failed to create challenge token test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	app := testutils.Application{
+		Name:                      "Challenge Token Test App",
+		Description:               "Application for testing challenge token flows",
+		IsRegistrationFlowEnabled: false,
+		ClientID:                  "ct_token_test_client",
+		ClientSecret:              "ct_token_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{ctTokenUserSchema.Name},
+		AuthFlowID:                flowID,
+		OUID:                      ts.ouID,
+	}
+	appID, err := testutils.CreateApplication(app)
+	ts.Require().NoError(err, "Failed to create test application")
+	ctTokenTestAppID = appID
+
+	user := ctTokenTestUser
+	user.OUID = ts.ouID
+	userIDs, err := testutils.CreateMultipleUsers(user)
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.config.CreatedUserIDs = userIDs
+}
+
+func (ts *ChallengeTokenTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("Failed to cleanup users: %v", err)
+	}
+	if ctTokenTestAppID != "" {
+		if err := testutils.DeleteApplication(ctTokenTestAppID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow %s: %v", flowID, err)
+		}
+	}
+	if ctTokenUserSchemaID != "" {
+		if err := testutils.DeleteUserType(ctTokenUserSchemaID); err != nil {
+			ts.T().Logf("Failed to delete test user schema: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit: %v", err)
+		}
+	}
+}
+
+func (ts *ChallengeTokenTestSuite) TestNewFlowReturnsChallengeToken() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected INCOMPLETE flow status")
+	ts.Require().NotEmpty(flowStep.ChallengeToken, "Challenge token must be returned for incomplete flow")
+}
+
+func (ts *ChallengeTokenTestSuite) TestValidTokenAllowsContinuation() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.ChallengeToken, "Challenge token must be returned")
+
+	inputs := map[string]string{
+		"username": "ct_token_testuser",
+		"password": "testpassword",
+	}
+	completeStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Flow should complete with valid challenge token and credentials")
+	ts.Require().Equal("COMPLETE", completeStep.FlowStatus, "Expected COMPLETE flow status")
+	ts.Require().NotEmpty(completeStep.Assertion, "Assertion token should be present")
+}
+
+func (ts *ChallengeTokenTestSuite) TestTokenIsRotatedOnEachStep() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	firstToken := flowStep.ChallengeToken
+	ts.Require().NotEmpty(firstToken, "Challenge token must be returned on initiation")
+
+	// Submit only the username to trigger a retry step (password missing)
+	inputs := map[string]string{
+		"username": "ct_token_testuser",
+	}
+	retryStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001", firstToken)
+
+	ts.Require().NoError(err, "Flow step should succeed with valid challenge token")
+	ts.Require().Equal("INCOMPLETE", retryStep.FlowStatus, "Expected retry step for missing password")
+	ts.Require().NotEmpty(retryStep.ChallengeToken, "Rotated challenge token must be returned")
+	ts.Require().NotEqual(firstToken, retryStep.ChallengeToken, "Challenge token must be rotated on each step")
+}
+
+func (ts *ChallengeTokenTestSuite) TestInvalidTokenRejectsRequest() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.ChallengeToken, "Challenge token must be returned")
+
+	inputs := map[string]string{
+		"username": "ct_token_testuser",
+		"password": "testpassword",
+	}
+	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, inputs, "wrong-challenge-token")
+	ts.Require().NoError(err, "Error response should be returned for invalid challenge token")
+	ts.Require().NotNil(errorResp, "Error response should not be nil")
+	ts.Require().Equal("FES-1009", errorResp.Code, "Expected challenge token error code")
+}
+
+func (ts *ChallengeTokenTestSuite) TestMissingTokenRejectsRequest() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.ChallengeToken, "Challenge token must be returned")
+
+	inputs := map[string]string{
+		"username": "ct_token_testuser",
+		"password": "testpassword",
+	}
+	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, inputs, "")
+	ts.Require().NoError(err, "Error response should be returned for missing challenge token")
+	ts.Require().NotNil(errorResp, "Error response should not be nil")
+	ts.Require().Equal("FES-1009", errorResp.Code, "Expected challenge token error code")
+}
+
+func (ts *ChallengeTokenTestSuite) TestFlowCanBeRetriedAfterInvalidToken() {
+	flowStep, err := common.InitiateAuthenticationFlow(ctTokenTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.ChallengeToken, "Challenge token must be returned on initiation")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID must be returned on initiation")
+
+	inputs := map[string]string{
+		"username": "ct_token_testuser",
+		"password": "testpassword",
+	}
+
+	// Submit with a wrong token
+	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, inputs, "wrong-challenge-token")
+	ts.Require().NoError(err, "Error response should be returned for invalid challenge token")
+	ts.Require().NotNil(errorResp, "Error response should not be nil")
+	ts.Require().Equal("FES-1009", errorResp.Code, "Expected challenge token error code")
+
+	// Retry the same execution with the correct token
+	completeStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Flow should complete when retried with the correct challenge token")
+	ts.Require().Equal("COMPLETE", completeStep.FlowStatus, "Expected COMPLETE flow status on retry")
+	ts.Require().NotEmpty(completeStep.Assertion, "Assertion token should be present after successful retry")
+}

--- a/tests/integration/flow/authentication/conditional_exec_auth_test.go
+++ b/tests/integration/flow/authentication/conditional_exec_auth_test.go
@@ -391,7 +391,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestSkipConditionalNodes() {
 	inputs := map[string]string{
 		"code": authCode,
 	}
-	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication flow")
 
 	// For existing user, flow should complete directly
@@ -438,7 +438,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 	inputs := map[string]string{
 		"code": authCode,
 	}
-	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication flow")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
@@ -449,7 +449,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 		"ouHandle":      conditionalExecNewOUHandle,
 		"ouDescription": "Organization Unit created during conditional exec auth flow test",
 	}
-	flowStep, err = common.CompleteFlow(ExecutionID, ouInputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, ouInputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication flow after OU details")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status to be COMPLETE")
 	ts.Require().NotEmpty(flowStep.Assertion, "Assertion token should be present")

--- a/tests/integration/flow/authentication/github_auth_test.go
+++ b/tests/integration/flow/authentication/github_auth_test.go
@@ -386,7 +386,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete GitHub authentication flow: %v", err)
 	}
@@ -422,7 +422,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteWithInvalidCode() {
 		"code": "invalid-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(ExecutionID, inputs, "")
+	_, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -440,7 +440,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteWithMissingCode() {
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")

--- a/tests/integration/flow/authentication/google_auth_test.go
+++ b/tests/integration/flow/authentication/google_auth_test.go
@@ -401,7 +401,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete Google authentication flow: %v", err)
 	}
@@ -437,7 +437,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteWithInvalidCode() {
 		"code": "invalid-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(ExecutionID, inputs, "")
+	_, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -455,7 +455,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteWithMissingCode() {
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")
@@ -497,7 +497,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowMultipleUsersSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete Google authentication flow: %v", err)
 	}

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -350,7 +350,7 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithoutInputs_Should
 	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_google which has no inputs - should redirect to Google
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_google")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_google", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow with action_google")
 
 	// Should redirect to Google OAuth
@@ -365,7 +365,7 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputs_ShouldPro
 	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_basic which requires username and password
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow with action_basic")
 
 	ts.Equal("INCOMPLETE", flowStep.FlowStatus)
@@ -386,7 +386,7 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputsProvided_S
 	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_basic
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to select action_basic")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -395,7 +395,7 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputsProvided_S
 		"username": "multiactionuser",
 		"password": "testpassword",
 	}
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow with inputs")
 
 	ts.Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete after providing required inputs")
@@ -409,7 +409,7 @@ func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
 	ExecutionID := flowStep.ExecutionID
 
 	// Select action_google
-	flowStep, err = common.CompleteFlow(ExecutionID, nil, "action_google")
+	flowStep, err = common.CompleteFlow(ExecutionID, nil, "action_google", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to select action_google")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 	ts.Require().Equal("REDIRECTION", flowStep.Type)
@@ -424,7 +424,7 @@ func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
 
 	// Complete flow with authorization code
 	inputs := map[string]string{"code": authCode}
-	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow with auth code")
 
 	ts.Equal("COMPLETE", flowStep.FlowStatus)

--- a/tests/integration/flow/authentication/prompt_actions_test.go
+++ b/tests/integration/flow/authentication/prompt_actions_test.go
@@ -425,7 +425,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 		"Expected actions basic_auth and prompt_mobile should be present")
 
 	// Step 2: Choose basic auth
-	basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
+	basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -451,7 +452,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 	// Clear any previous messages before SMS flow
 	ts.mockServer.ClearMessages()
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "",
+		basicAuthStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with credentials: %v", err)
 	}
@@ -482,7 +484,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -528,7 +531,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 		}
 
 		// Step 2: Choose basic auth
-		_, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
+		basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth",
+			flowStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 		}
@@ -543,7 +547,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"password": userAttrs["password"].(string),
 		}
 
-		mobilePromptStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
+		mobilePromptStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "",
+			basicAuthStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with credentials: %v", err)
 		}
@@ -569,7 +574,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"mobileNumber": "+1987654321",
 		}
 
-		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "")
+		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "",
+			mobilePromptStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 		}
@@ -600,7 +606,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"otp": lastMessage.OTP,
 		}
 
-		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
+		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp",
+			otpFlowStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 		}
@@ -645,7 +652,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 		}
 
 		// Step 2: Choose basic auth
-		basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
+		basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth",
+			flowStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 		}
@@ -676,7 +684,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"password": userAttrs["password"].(string),
 		}
 
-		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
+		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "",
+			basicAuthStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 		}
@@ -707,7 +716,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"otp": lastMessage.OTP,
 		}
 
-		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
+		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp",
+			otpFlowStep.ChallengeToken)
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 		}
@@ -752,7 +762,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 	}
 
 	// Step 2: Choose sms OTP auth
-	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile")
+	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -782,7 +793,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "action_mobile")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "action_mobile",
+		smsAuthStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -813,7 +825,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -858,7 +871,8 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {
 	}
 
 	// Step 2: Choose sms OTP auth
-	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile")
+	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -872,7 +886,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {
 	}
 
 	// This should result in failure or error
-	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, mobileInputs)
+	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, mobileInputs, flowStep.ChallengeToken)
 	if err != nil {
 		// If the API returned an error response, that's expected
 		ts.T().Logf("Expected error occurred: %v", err)

--- a/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
+++ b/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
@@ -273,7 +273,7 @@ func (ts *SensitiveInputCleanupTestSuite) TestPasswordClearedAfterAuthExecution(
 	// After basic_auth completes, password should be cleared from context.
 	// The second prompt node (prompt_password_again) should detect the missing password
 	// and return INCOMPLETE, asking for it again.
-	step2, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	step2, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow step 2")
 
 	ts.Require().Equal("INCOMPLETE", step2.FlowStatus,
@@ -292,7 +292,7 @@ func (ts *SensitiveInputCleanupTestSuite) TestPasswordClearedAfterAuthExecution(
 		"password": userAttrs["password"].(string),
 	}
 
-	step3, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
+	step3, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002", step2.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow step 3")
 
 	ts.Require().Equal("COMPLETE", step3.FlowStatus, "Expected flow to complete after re-submitting password")

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -466,7 +466,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -493,7 +494,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -562,7 +564,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 		"username": userAttrs["username"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with username: %v", err)
 	}
@@ -594,7 +597,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -637,7 +641,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 	ts.mockServer.ClearMessages()
 
 	// Continue flow to trigger OTP sending
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -652,7 +657,8 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 		"otp": "000000", // Invalid OTP
 	}
 
-	completeFlowStep, err := common.CompleteFlow(otpFlowStep.ExecutionID, invalidOTPInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(otpFlowStep.ExecutionID, invalidOTPInputs, "action_002",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid OTP: %v", err)
 	}
@@ -700,7 +706,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}

--- a/tests/integration/flow/authentication/verbose_meta_test.go
+++ b/tests/integration/flow/authentication/verbose_meta_test.go
@@ -333,7 +333,8 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeEnabled() {
 		"password": "testpassword123",
 	}
 	action := "action_001"
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action,
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -365,7 +366,8 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeDisabled() {
 		"password": "testpassword123",
 	}
 	action := "action_001"
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action,
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -413,7 +415,8 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeWithGraphWithoutMeta() {
 		"username": "verboseuser",
 		"password": "testpassword123",
 	}
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -438,7 +441,8 @@ func (ts *VerboseMetaTestSuite) TestVerbosePersistsAcrossRequests() {
 	action := "action_001"
 
 	// Note: We're not sending verbose flag here, it should be retrieved from stored context
-	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action,
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 

--- a/tests/integration/flow/common/model.go
+++ b/tests/integration/flow/common/model.go
@@ -31,12 +31,13 @@ type TestSuiteConfig struct {
 }
 
 type FlowStep struct {
-	ExecutionID   string   `json:"executionId"`
-	FlowStatus    string   `json:"flowStatus"`
-	Type          string   `json:"type,omitempty"`
-	Data          FlowData `json:"data,omitempty"`
-	Assertion     string   `json:"assertion,omitempty"`
-	FailureReason string   `json:"failureReason,omitempty"`
+	ExecutionID    string   `json:"executionId"`
+	FlowStatus     string   `json:"flowStatus"`
+	Type           string   `json:"type,omitempty"`
+	Data           FlowData `json:"data,omitempty"`
+	Assertion      string   `json:"assertion,omitempty"`
+	FailureReason  string   `json:"failureReason,omitempty"`
+	ChallengeToken string   `json:"challengeToken,omitempty"`
 }
 
 type FlowData struct {

--- a/tests/integration/flow/common/utils.go
+++ b/tests/integration/flow/common/utils.go
@@ -139,11 +139,12 @@ func InitiateAuthFlowWithError(appID string, inputs map[string]string) (*ErrorRe
 	return &errorResponse, nil
 }
 
-// CompleteFlow completes the flow with given inputs and action
-func CompleteFlow(executionId string, inputs map[string]string, action string) (
+// CompleteFlow completes the flow with given inputs, action and challenge token
+func CompleteFlow(executionId string, inputs map[string]string, action string, challengeToken string) (
 	*FlowStep, error) {
 	flowReqBody := map[string]interface{}{
-		"executionId": executionId,
+		"executionId":    executionId,
+		"challengeToken": challengeToken,
 	}
 	if len(inputs) > 0 {
 		flowReqBody["inputs"] = inputs
@@ -188,10 +189,12 @@ func CompleteFlow(executionId string, inputs map[string]string, action string) (
 }
 
 // CompleteAuthFlowWithError completes the authentication flow and expects an error response
-func CompleteAuthFlowWithError(executionId string, inputs map[string]string) (*ErrorResponse, error) {
+func CompleteAuthFlowWithError(executionId string, inputs map[string]string, challengeToken string) (
+	*ErrorResponse, error) {
 	flowReqBody := map[string]interface{}{
-		"executionId": executionId,
-		"inputs":      inputs,
+		"executionId":    executionId,
+		"challengeToken": challengeToken,
+		"inputs":         inputs,
 	}
 
 	reqBody, err := json.Marshal(flowReqBody)

--- a/tests/integration/flow/registration/basic_registration_test.go
+++ b/tests/integration/flow/registration/basic_registration_test.go
@@ -174,7 +174,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"password": "testpassword123",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -193,7 +194,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+		completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
 	}
@@ -260,7 +262,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowDuplicateUser
 		"password": "newpassword123",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -285,7 +288,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 	inputs := map[string]string{
 		"username": username,
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -301,7 +304,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 	inputs = map[string]string{
 		"password": "testpassword123",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_credentials")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_credentials",
+		completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with username input: %v", err)
 	}
@@ -320,7 +324,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+		completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
 	}
@@ -438,7 +443,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithoutToken
 		"username": username,
 		"password": "testpassword123",
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow")
 
 	inputs = map[string]string{
@@ -446,7 +452,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithoutToken
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+		completeFlowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")
@@ -505,7 +512,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 		"username": username,
 		"password": "testpassword123",
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials",
+		flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow")
 
 	inputs = map[string]string{
@@ -513,7 +521,8 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+		completeFlowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")

--- a/tests/integration/flow/registration/github_registration_test.go
+++ b/tests/integration/flow/registration/github_registration_test.go
@@ -533,7 +533,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteSuc
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete GitHub registration flow: %v", err)
 	}
@@ -589,7 +589,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteWit
 		"code": "invalid-reg-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(flowID, inputs, "")
+	_, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -607,7 +607,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteWit
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")
@@ -642,7 +642,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first GitHub registration flow: %v", err)
 	}
@@ -671,7 +671,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second GitHub registration flow: %v", err)
 	}

--- a/tests/integration/flow/registration/google_registration_test.go
+++ b/tests/integration/flow/registration/google_registration_test.go
@@ -519,7 +519,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteSuc
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete Google registration flow: %v", err)
 	}
@@ -575,7 +575,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteWit
 		"code": "invalid-reg-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(flowID, inputs, "")
+	_, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -593,7 +593,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteWit
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")
@@ -628,7 +628,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first Google registration flow: %v", err)
 	}
@@ -657,7 +657,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second Google registration flow: %v", err)
 	}
@@ -685,7 +685,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first Google registration flow: %v", err)
 	}
@@ -726,7 +726,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second Google registration flow: %v", err)
 	}

--- a/tests/integration/flow/registration/google_registration_with_role_group_test.go
+++ b/tests/integration/flow/registration/google_registration_with_role_group_test.go
@@ -449,7 +449,7 @@ func (ts *GoogleRegistrationGroupRoleTestSuite) TestGoogleRegistrationWithGroupA
 
 	// Step 3: Complete the flow
 	inputs := map[string]string{"code": authCode}
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow")
 
 	// Verify flow completion

--- a/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
+++ b/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
@@ -528,7 +528,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 
 	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"code": authCode,
-	}, "")
+	}, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete runtime data flow with authorization code")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 	ts.Require().Equal("VIEW", flowStep.Type)
@@ -536,7 +536,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 
 	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"mobileNumber": mobileNumber,
-	}, "action_mobile")
+	}, "action_mobile", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to continue runtime data flow with mobile number")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 	ts.Require().Equal("VIEW", flowStep.Type)
@@ -549,7 +549,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 
 	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"otp": otpMessage.OTP,
-	}, "action_otp")
+	}, "action_otp", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete runtime data flow with OTP")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete after HTTP request executor")
 	ts.Require().NotEmpty(flowStep.Assertion, "Assertion should be present after flow completion")

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -749,7 +749,8 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"mobileNumber": mobileNumber,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+				flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -765,7 +766,8 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"otp": lastMessage.OTP,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002",
+				flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -776,7 +778,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"ouDescription": tc.ouDescription,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -788,7 +790,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"email":        mobileNumber + "@example.com",
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
 			ts.Require().NotEmpty(flowStep.Assertion)
@@ -879,7 +881,8 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 			// Wait for OTP to be sent
 			time.Sleep(1 * time.Second)
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+				flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -891,7 +894,8 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				"otp": lastMessage.OTP,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002",
+				flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -907,7 +911,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				"ouDescription": "Should fail due to duplicate",
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 			ts.Require().NoError(err)
 			ts.Require().Equal("ERROR", flowStep.FlowStatus)
 			ts.Require().Empty(flowStep.Assertion)

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -431,7 +431,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 		"mobileNumber": mobileNumber,
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with mobile number: %v", err)
 	}
@@ -456,7 +457,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with OTP: %v", err)
 	}
@@ -484,7 +486,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 	}
 	fillInputs = append(fillInputs, completeFlowStep.Data.Inputs...)
 	attrInputs := fillRequiredRegistrationAttributes(fillInputs, mobileNumber)
-	completeFlowStep, err = common.CompleteFlow(flowStep.ExecutionID, attrInputs, "")
+	completeFlowStep, err = common.CompleteFlow(flowStep.ExecutionID, attrInputs, "", completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with attributes: %v", err)
 	}
@@ -547,7 +549,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 	ts.mockServer.ClearMessages()
 
 	// Continue flow to trigger OTP sending
-	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with mobile number: %v", err)
 	}
@@ -562,7 +565,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 		"otp": "000000",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidOTPInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidOTPInputs, "action_otp",
+		otpFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with invalid OTP: %v", err)
 	}
@@ -603,7 +607,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"mobileNumber": mobileNumber,
 	}
 
-	otpStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
+	otpStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to provide mobile number: %v", err)
 	}
@@ -625,7 +630,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"otp": lastMessage.OTP,
 	}
 
-	provisionStep, err := common.CompleteFlow(otpStep.ExecutionID, otpInputs, "action_otp")
+	provisionStep, err := common.CompleteFlow(otpStep.ExecutionID, otpInputs, "action_otp",
+		otpStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with OTP: %v", err)
 	}
@@ -641,7 +647,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"mobileNumber": mobileNumber,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(provisionStep.ExecutionID, userInputs, "")
+	completeFlowStep, err := common.CompleteFlow(provisionStep.ExecutionID, userInputs, "",
+		provisionStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration with user attributes: %v", err)
 	}

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -630,14 +630,14 @@ func initiateAuthorizeFlowAndRetrieveAuthzCode(ts *AuthzTestSuite, username stri
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": username,
 		"password": password,
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	ts.NoError(err, "Failed to execute authentication flow")
 	ts.Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete successfully")
 
@@ -821,7 +821,7 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 			}
 
 			// Initiate authentication flow
-			_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+			initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 			if err != nil {
 				ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 			}
@@ -830,7 +830,7 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 			flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 				"username": tc.Username,
 				"password": tc.Password,
-			}, "action_001")
+			}, "action_001", initialStep.ChallengeToken)
 			if err != nil {
 				ts.T().Fatalf("Failed to execute authentication flow: %v", err)
 			}
@@ -938,7 +938,7 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeErrorScenarios() {
 			ts.NoError(err, "Failed to extract auth ID")
 
 			// Initiate authentication flow
-			_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+			initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 			if err != nil {
 				ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 			}
@@ -947,7 +947,7 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeErrorScenarios() {
 			flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 				"username": tc.Username,
 				"password": tc.Password,
-			}, "action_001")
+			}, "action_001", initialStep.ChallengeToken)
 			if err != nil {
 				ts.T().Fatalf("Failed to execute authentication flow: %v", err)
 			}
@@ -1029,14 +1029,14 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithResourceParameter() {
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "resourcetest",
 		"password": "testpass123",
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	ts.NoError(err, "Failed to execute authentication flow")
 	ts.Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status COMPLETE")
 
@@ -1137,14 +1137,14 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithClaimsLocales() {
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "localestest",
 		"password": "testpass123",
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	ts.NoError(err, "Failed to execute authentication flow")
 	ts.Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status COMPLETE")
 
@@ -1229,14 +1229,14 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithNonce() {
 	ts.NoError(err)
 
 	// Initiate auth flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err)
 
 	// Execute credentials
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "noncetest",
 		"password": "testpass123",
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	ts.NoError(err)
 	ts.Equal("COMPLETE", flowStep.FlowStatus)
 
@@ -1320,13 +1320,13 @@ func (ts *AuthzTestSuite) TestNonceIgnoredWithoutOpenIDScope() {
 	ts.NoError(err)
 
 	// Execute authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err)
 
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "nonopeniduser",
 		"password": "testpass123",
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	ts.NoError(err)
 	ts.Equal("COMPLETE", flowStep.FlowStatus)
 

--- a/tests/integration/oauth/claims/claims_parameter_test.go
+++ b/tests/integration/oauth/claims/claims_parameter_test.go
@@ -376,7 +376,7 @@ func (ts *ClaimsParameterTestSuite) getTokenWithClaims(
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(flowID, nil, "")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -386,7 +386,7 @@ func (ts *ClaimsParameterTestSuite) getTokenWithClaims(
 		"username": "claims_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}
@@ -506,7 +506,7 @@ func (ts *ClaimsParameterTestSuite) getTokensWithClaims(
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(flowID, nil, "")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -516,7 +516,7 @@ func (ts *ClaimsParameterTestSuite) getTokensWithClaims(
 		"username": "claims_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}

--- a/tests/integration/oauth/token/refresh_token_test.go
+++ b/tests/integration/oauth/token/refresh_token_test.go
@@ -308,14 +308,14 @@ func (ts *RefreshTokenTestSuite) obtainTokensViaAuthCodeFlow(
 	ts.Require().NoError(err, "Failed to extract auth data")
 
 	// Step 2: Execute authentication flow.
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
 
 	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId,
 		map[string]string{
 			"username": refreshTokenTestUsername,
 			"password": refreshTokenTestPassword,
-		}, "action_001")
+		}, "action_001", initialStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to execute authentication flow")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus,
 		"Authentication flow should complete")

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -383,7 +383,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeToken(scope string) (string, er
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -393,7 +393,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeToken(scope string) (string, er
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}
@@ -453,7 +453,7 @@ func (ts *UserInfoTestSuite) getRefreshToken(scope string) (string, error) {
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, map[string]string{}, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{}, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -463,7 +463,7 @@ func (ts *UserInfoTestSuite) getRefreshToken(scope string) (string, error) {
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}
@@ -957,7 +957,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeTokenWithClient(scope, cID, cSe
 	}
 
 	// 3. Initiate Auth
-	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return "", err
 	}
@@ -967,7 +967,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeTokenWithClient(scope, cID, cSe
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return "", err
 	}

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -239,12 +239,13 @@ type FlowAction struct {
 
 // FlowStep represents a single step in a flow execution
 type FlowStep struct {
-	ExecutionID   string    `json:"executionId"`
-	FlowStatus    string    `json:"flowStatus"`
-	Type          string    `json:"type"`
-	Data          *FlowData `json:"data,omitempty"`
-	Assertion     string    `json:"assertion,omitempty"`
-	FailureReason string    `json:"failureReason,omitempty"`
+	ExecutionID    string    `json:"executionId"`
+	FlowStatus     string    `json:"flowStatus"`
+	Type           string    `json:"type"`
+	Data           *FlowData `json:"data,omitempty"`
+	Assertion      string    `json:"assertion,omitempty"`
+	FailureReason  string    `json:"failureReason,omitempty"`
+	ChallengeToken string    `json:"challengeToken,omitempty"`
 }
 
 // Flow represents a flow definition

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -128,8 +128,9 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 	return resp, nil
 }
 
-// ExecuteAuthenticationFlow executes an authentication flow and returns the flow step
-func ExecuteAuthenticationFlow(executionId string, inputs map[string]string, action string) (*FlowStep, error) {
+// ExecuteAuthenticationFlow executes an authentication flow and returns the flow step.
+func ExecuteAuthenticationFlow(executionId string, inputs map[string]string, action string,
+	challengeToken ...string) (*FlowStep, error) {
 	flowData := map[string]interface{}{
 		"executionId": executionId,
 	}
@@ -139,6 +140,9 @@ func ExecuteAuthenticationFlow(executionId string, inputs map[string]string, act
 	}
 	if action != "" {
 		flowData["action"] = action
+	}
+	if len(challengeToken) > 0 && challengeToken[0] != "" {
+		flowData["challengeToken"] = challengeToken[0]
 	}
 
 	flowJSON, err := json.Marshal(flowData)
@@ -392,7 +396,7 @@ func ValidateOAuth2ErrorRedirect(location string, expectedError string,
 
 // ObtainAccessTokenWithPassword performs the complete OAuth authorization code flow with password
 // authentication and returns a TokenResponse with the access token and expiry information.
-// clientSecret is optional and can be provided for confidential clients 
+// clientSecret is optional and can be provided for confidential clients
 // and use client_secret_post authentication in the token request.
 func ObtainAccessTokenWithPassword(clientID, redirectURI, scope, username, password string,
 	usePKCE bool, optionalParams ...string) (*TokenResponse, error) {
@@ -443,16 +447,16 @@ func ObtainAccessTokenWithPassword(clientID, redirectURI, scope, username, passw
 	}
 
 	// Step 3: Execute initial authentication flow step (to get to the login prompt)
-	_, err = ExecuteAuthenticationFlow(executionId, nil, "")
+	initialStep, err := ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute initial authentication flow: %w", err)
 	}
 
-	// Step 4: Execute authentication flow with credentials
+	// Step 4: Execute authentication flow with credentials, forwarding the challenge token
 	flowStep, err := ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": username,
 		"password": password,
-	}, "action_001")
+	}, "action_001", initialStep.ChallengeToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute authentication flow: %w", err)
 	}


### PR DESCRIPTION
### Purpose
This pull request introduces support for a mandatory per step challenge token that will tighten the flow execution security. This also allows specifying an execution policies for nodes and executors in the flow engine, allowing for more flexible and fine-grained control over node behavior. Current primary usage is to skip the challenge token validation for the invite executor verify mode.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
This PR mandates the usage of a challengeToken for flow execution

#### 💥 Impact
Existing flow/execute REST API requests will fail if they don't send a challengeToken in sub sequent requests

#### 🔄 Migration Guide
- Update any flow/execute API usages to retrieve challengeToken from the flow/execute response and pass it with the immediate next request in the request body
- Update asgardeo/javascript SDK version to `0.22.5` or above which support challengeToken usage

---

### Approach

**Per step Challenge Token:**
- A mandatory challengeToken request and response parameter is introduced for flow execution layer. If a challenge token is returned in the flow/execution response, the next request should send it in the request body.
- A new challenge token is generated for each flow execution response that will require further input.

**Execution Policy Support:**

- Introduced a new `ExecutionPolicy` struct in `model.go` to define behavioral policies for node execution, currently supporting the `SkipChallengeValidation` flag.
- Added the `GetExecutionPolicy` method to the `ExecutorInterface` and `NodeInterface` interfaces, with default implementations returning `nil` (no special policy).
- Implemented `GetExecutionPolicy` in `taskExecutionNode` to delegate to its executor, passing the node's mode.
- Provided a custom `GetExecutionPolicy` in `inviteExecutor` to skip challenge validation in verify mode.

**API and OpenAPI Spec Updates:**

- Updated `api/flow-execution.yaml` to document the `challengeToken` property in both request and response objects, including schema definitions and example values.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2008

### Related PRs
- https://github.com/asgardeo/javascript/pull/466

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added challenge-token support for flows: tokens returned on incomplete steps, must be supplied to continue; tokens are securely generated, rotated on incomplete steps, and invalid/missing tokens return FES-1009.

* **Documentation**
  * API docs, examples, and Postman collections updated to include challengeToken; sample apps and demos updated to persist/forward tokens.

* **Tests**
  * New E2E and integration tests covering issuance, validation, rotation, rejection, and callsite updates to propagate tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->