### PR TITLE
Include OU details in httpRequestExecutor

### DIFF
--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -53,6 +53,17 @@ func ResolvePlaceholder(ctx *NodeContext, value string) string {
 			return match // Keep placeholder if not found
 		}
 
+		// Special handling for ouId - only resolve from runtime data or authenticated user
+		if key == "ouId" {
+			if ctx.AuthenticatedUser.OUID != "" {
+				return ctx.AuthenticatedUser.OUID
+			}
+			if runtimeValue, ok := ctx.RuntimeData["ouId"]; ok && runtimeValue != "" {
+				return runtimeValue
+			}
+			return match // Keep placeholder if not found
+		}
+
 		// Check runtime data first
 		if runtimeValue, ok := ctx.RuntimeData[key]; ok && runtimeValue != "" {
 			return runtimeValue

--- a/backend/internal/flow/core/utils_test.go
+++ b/backend/internal/flow/core/utils_test.go
@@ -158,6 +158,55 @@ func (s *UtilsTestSuite) TestResolvePlaceholderUserIDNotFromUserInputs() {
 	s.Equal("{{ context.userId }}", result, "userId should NOT be resolved from UserInputs")
 }
 
+func (s *UtilsTestSuite) TestResolvePlaceholderOUIDFromAuthenticatedUser() {
+	ctx := &NodeContext{
+		RuntimeData: map[string]string{},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "ou-123",
+		},
+	}
+
+	result := ResolvePlaceholder(ctx, "{{ context.ouId }}")
+	s.Equal("ou-123", result)
+}
+
+func (s *UtilsTestSuite) TestResolvePlaceholderOUIDFromRuntimeData() {
+	ctx := &NodeContext{
+		RuntimeData: map[string]string{"ouId": "runtime-ou-456"},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "",
+		},
+	}
+
+	result := ResolvePlaceholder(ctx, "{{ context.ouId }}")
+	s.Equal("runtime-ou-456", result)
+}
+
+func (s *UtilsTestSuite) TestResolvePlaceholderOUIDAuthenticatedUserTakesPrecedence() {
+	ctx := &NodeContext{
+		RuntimeData: map[string]string{"ouId": "runtime-ou-id"},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "auth-ou-id",
+		},
+	}
+
+	result := ResolvePlaceholder(ctx, "{{ context.ouId }}")
+	s.Equal("auth-ou-id", result, "AuthenticatedUser.OUID should take precedence over RuntimeData")
+}
+
+func (s *UtilsTestSuite) TestResolvePlaceholderOUIDNotFromUserInputs() {
+	ctx := &NodeContext{
+		UserInputs:  map[string]string{"ouId": "input-ou-id"},
+		RuntimeData: map[string]string{},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "",
+		},
+	}
+
+	result := ResolvePlaceholder(ctx, "{{ context.ouId }}")
+	s.Equal("{{ context.ouId }}", result, "ouId should NOT be resolved from UserInputs")
+}
+
 func (s *UtilsTestSuite) TestResolvePlaceholderKeyNotFound() {
 	ctx := &NodeContext{
 		RuntimeData: map[string]string{"existing": "value"},

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/ou"
 	httpservice "github.com/asgardeo/thunder/internal/system/http"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
@@ -75,7 +77,8 @@ type errorHandlingConfig struct {
 // httpRequestExecutor implements the ExecutorInterface for making HTTP requests to external endpoints.
 type httpRequestExecutor struct {
 	core.ExecutorInterface
-	logger *log.Logger
+	ouService ou.OrganizationUnitServiceInterface
+	logger    *log.Logger
 }
 
 var _ core.ExecutorInterface = (*httpRequestExecutor)(nil)
@@ -83,6 +86,7 @@ var _ core.ExecutorInterface = (*httpRequestExecutor)(nil)
 // newHTTPRequestExecutor creates a new instance of HTTPRequestExecutor.
 func newHTTPRequestExecutor(
 	flowFactory core.FlowFactoryInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 ) *httpRequestExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, httpRequestLoggerComponentName),
 		log.String(log.LoggerKeyExecutorName, ExecutorNameHTTPRequest))
@@ -92,6 +96,7 @@ func newHTTPRequestExecutor(
 
 	return &httpRequestExecutor{
 		ExecutorInterface: base,
+		ouService:         ouService,
 		logger:            logger,
 	}
 }
@@ -114,6 +119,7 @@ func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 		return execResp, nil
 	}
 
+	h.enrichOURuntimeData(ctx, config)
 	h.resolvePlaceholders(ctx, config)
 
 	response, err := h.executeRequestWithRetry(ctx, config)
@@ -276,6 +282,51 @@ func (h *httpRequestExecutor) parseErrorHandling(config *httpRequestConfig, prop
 			config.ErrorHandling.RetryDelay = maxHTTPRequestRetryDelay
 		}
 	}
+}
+
+// enrichOURuntimeData fetches OU details and populates ouHandle and ouName into RuntimeData
+// so that placeholders like {{ context.ouHandle }} can be resolved for the current request.
+// It only performs the fetch when an OU placeholder is referenced in the config and the OU ID
+// is available in the context.
+func (h *httpRequestExecutor) enrichOURuntimeData(ctx *core.NodeContext, config *httpRequestConfig) {
+	if h.ouService == nil {
+		return
+	}
+
+	ouPlaceholderPattern := regexp.MustCompile(`{{\s*context\.\s*(ouHandle|ouName|ouDescription)\s*}}`)
+
+	// Build a single searchable string from all resolvable config fields.
+	var sb strings.Builder
+	sb.WriteString(config.URL)
+	for _, v := range config.Headers {
+		sb.WriteString(v)
+	}
+	if bodyJSON, err := json.Marshal(config.Body); err == nil {
+		sb.Write(bodyJSON)
+	}
+	if !ouPlaceholderPattern.MatchString(sb.String()) {
+		return
+	}
+
+	ouID := ctx.AuthenticatedUser.OUID
+	if ouID == "" {
+		ouID = ctx.RuntimeData[ouIDKey]
+	}
+	if ouID == "" {
+		return
+	}
+
+	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+	organizationUnit, svcErr := h.ouService.GetOrganizationUnit(ctx.Context, ouID)
+	if svcErr != nil {
+		logger.Warn("Failed to fetch OU details for placeholder enrichment",
+			log.String(ouIDKey, ouID), log.String("error", svcErr.Error))
+		return
+	}
+
+	ctx.RuntimeData["ouHandle"] = organizationUnit.Handle
+	ctx.RuntimeData["ouName"] = organizationUnit.Name
+	ctx.RuntimeData["ouDescription"] = organizationUnit.Description
 }
 
 // resolvePlaceholders resolves placeholders in the configuration using context data.

--- a/backend/internal/flow/executor/http_request_executor_test.go
+++ b/backend/internal/flow/executor/http_request_executor_test.go
@@ -25,11 +25,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 )
 
 type HTTPRequestExecutorTestSuite struct {
@@ -42,9 +48,20 @@ func TestHTTPRequestExecutorTestSuite(t *testing.T) {
 	suite.Run(t, new(HTTPRequestExecutorTestSuite))
 }
 
+func (suite *HTTPRequestExecutorTestSuite) SetupSuite() {
+	_ = config.InitializeThunderRuntime("test", &config.Config{})
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TearDownSuite() {
+	config.ResetThunderRuntime()
+}
+
 func (suite *HTTPRequestExecutorTestSuite) SetupTest() {
-	flowFactory, _ := core.Initialize()
-	suite.executor = newHTTPRequestExecutor(flowFactory)
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	suite.executor = newHTTPRequestExecutor(mockFlowFactory, nil)
 }
 
 func (suite *HTTPRequestExecutorTestSuite) TearDownTest() {
@@ -689,4 +706,274 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ResponseStatusExtraction(
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
 	assert.Equal(suite.T(), "123", execResp.RuntimeData["resourceId"])
 	assert.Equal(suite.T(), "201", execResp.RuntimeData["statusCode"])
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestEnrichOURuntimeData_OUIDFromAuthenticatedUser() {
+	// When AuthenticatedUser.OUID is set, it should be used to fetch OU details
+	// and ouHandle/ouName should be enriched into RuntimeData before placeholder resolution.
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-auth-123").
+		Return(ou.OrganizationUnit{
+			ID:          "ou-auth-123",
+			Handle:      "acme-corp",
+			Name:        "Acme Corporation",
+			Description: "Acme Corporation description",
+		}, nil)
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	executor := newHTTPRequestExecutor(mockFlowFactory, mockOUService)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "test-flow",
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "ou-auth-123",
+		},
+		RuntimeData: map[string]string{},
+		UserInputs:  map[string]string{},
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api/enrich",
+			"method": "POST",
+			"body": map[string]interface{}{
+				"orgHandle":      "{{ context.ouHandle }}",
+				"orgName":        "{{ context.ouName }}",
+				"orgDescription": "{{ context.ouDescription }}",
+			},
+		},
+	}
+
+	execResp, err := executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), "acme-corp", receivedBody["orgHandle"])
+	assert.Equal(suite.T(), "Acme Corporation", receivedBody["orgName"])
+	assert.Equal(suite.T(), "Acme Corporation description", receivedBody["orgDescription"])
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestEnrichOURuntimeData_FallbackToRuntimeData() {
+	// When AuthenticatedUser.OUID is absent, RuntimeData["ouId"] should be used to fetch OU details.
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-runtime-456").
+		Return(ou.OrganizationUnit{
+			ID:          "ou-runtime-456",
+			Handle:      "beta-org",
+			Name:        "Beta Organization",
+			Description: "Beta Organization description",
+		}, nil)
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	executor := newHTTPRequestExecutor(mockFlowFactory, mockOUService)
+
+	ctx := &core.NodeContext{
+		ExecutionID:       "test-flow",
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			// OUID is empty — falls back to RuntimeData["ouId"]
+		},
+		RuntimeData: map[string]string{
+			"ouId": "ou-runtime-456",
+		},
+		UserInputs: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api/enrich",
+			"method": "POST",
+			"body": map[string]interface{}{
+				"handle":      "{{ context.ouHandle }}",
+				"name":        "{{ context.ouName }}",
+				"description": "{{ context.ouDescription }}",
+			},
+		},
+	}
+
+	execResp, err := executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), "beta-org", receivedBody["handle"])
+	assert.Equal(suite.T(), "Beta Organization", receivedBody["name"])
+	assert.Equal(suite.T(), "Beta Organization description", receivedBody["description"])
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestEnrichOURuntimeData_AuthenticatedUserOUIDPreferredOverRuntimeData() {
+	// When both AuthenticatedUser.OUID and RuntimeData["ouId"] are set,
+	// AuthenticatedUser.OUID should be preferred.
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	// Only the AuthenticatedUser.OUID should trigger a lookup — not the RuntimeData fallback.
+	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-auth-primary").
+		Return(ou.OrganizationUnit{
+			ID:     "ou-auth-primary",
+			Handle: "primary-handle",
+			Name:   "Primary Org",
+		}, nil)
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	executor := newHTTPRequestExecutor(mockFlowFactory, mockOUService)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "test-flow",
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "ou-auth-primary",
+		},
+		RuntimeData: map[string]string{
+			"ouId": "ou-runtime-fallback", // should NOT be used
+		},
+		UserInputs: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api/enrich",
+			"method": "POST",
+			"body": map[string]interface{}{
+				"handle": "{{ context.ouHandle }}",
+			},
+		},
+	}
+
+	execResp, err := executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), "primary-handle", receivedBody["handle"])
+	// The mock expectation for "ou-auth-primary" (not "ou-runtime-fallback") asserts the correct OU was fetched.
+	mockOUService.AssertNotCalled(suite.T(), "GetOrganizationUnit", mock.Anything, "ou-runtime-fallback")
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestEnrichOURuntimeData_OverwritesExistingRuntimeData() {
+	// When ctx.RuntimeData["ouHandle"] is pre-populated, enrichOURuntimeData must overwrite it
+	// with the value fetched from the OU service.
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-overwrite-test").
+		Return(ou.OrganizationUnit{
+			ID:     "ou-overwrite-test",
+			Handle: "fetched-handle",
+			Name:   "Fetched Org",
+		}, nil)
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	executor := newHTTPRequestExecutor(mockFlowFactory, mockOUService)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "test-flow",
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "ou-overwrite-test",
+		},
+		RuntimeData: map[string]string{
+			"ouHandle": "stale-handle", // pre-populated — must be overwritten
+		},
+		UserInputs: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api/enrich",
+			"method": "POST",
+			"body": map[string]interface{}{
+				"handle": "{{ context.ouHandle }}",
+			},
+		},
+	}
+
+	execResp, err := executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	// The fetched value must overwrite the stale preset value.
+	assert.Equal(suite.T(), "fetched-handle", receivedBody["handle"])
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestEnrichOURuntimeData_OULookupFailure_GracefulDegradation() {
+	// When OU lookup fails, execution should continue (graceful degradation):
+	// a warning is logged but the executor completes, leaving placeholders unresolved.
+	var receivedBody map[string]interface{}
+
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedBody)
+		if err != nil {
+			receivedBody = nil
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-not-found").
+		Return(ou.OrganizationUnit{}, &serviceerror.ServiceError{
+			Error:            "ou_not_found",
+			ErrorDescription: "organization unit not found",
+		})
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameHTTPRequest, common.ExecutorTypeUtility,
+		[]common.Input{}, []common.Input{}).
+		Return(newMockExecutor(ExecutorNameHTTPRequest, common.ExecutorTypeUtility, []common.Input{}, []common.Input{}))
+	executor := newHTTPRequestExecutor(mockFlowFactory, mockOUService)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "test-flow",
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			OUID: "ou-not-found",
+		},
+		RuntimeData: map[string]string{},
+		UserInputs:  map[string]string{},
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api/enrich",
+			"method": "POST",
+			"body": map[string]interface{}{
+				"orgHandle": "{{ context.ouHandle }}",
+			},
+		},
+	}
+
+	execResp, err := executor.Execute(ctx)
+
+	// Execution must complete despite the OU lookup failure.
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	// ouHandle placeholder remains unresolved because enrichment failed.
+	assert.Equal(suite.T(), "{{ context.ouHandle }}", receivedBody["orgHandle"])
 }

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -90,7 +90,7 @@ func Initialize(
 		ouService, authRegistry.AuthAssertGenerator, authnProvider, entityProvider,
 		attributeCacheSvc, roleService))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService, entityProvider))
-	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
+	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory, ouService))
 	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService, ouService))
 	reg.RegisterExecutor(ExecutorNameInviteExecutor, newInviteExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameEmailExecutor, newEmailExecutor(flowFactory, emailClient, templateService))


### PR DESCRIPTION
### Purpose
Currently only `ouId` is included in the context, so that it's not possible to have the OU details such as `ouHanlde`, `ouName` injected into HTTPRequestExecutor, when publishing a login event.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

Inject OU details to the runtime data if expected parameters in the `httepRequestExecutor` event has OU information inside `httepRequestExecutor`.  

#### Registration flow
```
{
    "name": "Basic Registration with OU Flow",
    "handle": "basic-registration-with-ou-flow",
    "flowType": "REGISTRATION",
    "nodes": [
        {
            "id": "start",
            "type": "START",
            "onSuccess": "user_type_resolver"
        },
        {
            "id": "user_type_resolver",
            "type": "TASK_EXECUTION",
            "executor": {
                "name": "UserTypeResolver"
            },
            "onSuccess": "basic_auth"
        },
        {
            "id": "basic_auth",
            "type": "TASK_EXECUTION",
            "executor": {
                "name": "BasicAuthExecutor"
            },
            "onSuccess": "ou_creation"
        },
        {
            "id": "ou_creation",
            "type": "TASK_EXECUTION",
            "executor": {
                "name": "OUExecutor"
            },
            "onSuccess": "publish_ou_event"
        },
        {
            "id": "publish_ou_event",
            "type": "TASK_EXECUTION",
            "properties": {
                "url": "<web-hook-url>",
                "method": "POST",
                "headers": {
                    "Content-Type": "application/json"
                },
                "body": {
                    "event": "OU_CREATED",
                    "ouName": "{{ context.ouName }}",
                    "ouId": "{{ context.ouId }}",
                    "ouHandle": "{{ context.ouHandle }}"
                },
                "timeout": 5
            },
            "executor": {
                "name": "HTTPRequestExecutor"
            },
            "onSuccess": "provisioning"
        },
        {
            
            "id": "provisioning",
            "type": "TASK_EXECUTION",
            "executor": {
                "name": "ProvisioningExecutor",
                "inputs": [
                    {
                        "ref": "input_001",
                        "identifier": "username",
                        "type": "TEXT_INPUT",
                        "required": true
                    },
                    {
                        "ref": "input_002",
                        "identifier": "password",
                        "type": "PASSWORD_INPUT",
                        "required": true
                    },
                    {
                        "ref": "input_003",
                        "identifier": "given_name",
                        "type": "TEXT_INPUT",
                        "required": true
                    },
                    {
                        "ref": "input_004",
                        "identifier": "family_name",
                        "type": "TEXT_INPUT",
                        "required": true
                    },
                    {
                        "ref": "input_005",
                        "identifier": "email",
                        "type": "EMAIL_INPUT",
                        "required": true
                    }
                ]
            },
            "onSuccess": "publish_user_creation_event"
        },
        {
            "id": "publish_user_creation_event",
            "type": "TASK_EXECUTION",
            "properties": {
                "url": "<web-hook-url>",
                "method": "POST",
                "headers": {
                    "Content-Type": "application/json"
                },
                "body": {
                    "event": "USER_CREATED",
                    "ouDescription": "{{ context.ouDescription }}",
                    "ouHandle": "{{ context.ouHandle }}",
                    "ouId": "{{ context.ouId }}",
                    "ouName": "{{ context.ouName }}",
                    "userId": "{{ context.userID }}",
                    "username": "{{ context.username }}"
                },
                "timeout": 5
            },
            "executor": {
                "name": "HTTPRequestExecutor"
            },
            "onSuccess": "auth_assert"
        },
        {
            "id": "auth_assert",
            "type": "TASK_EXECUTION",
            "executor": {
                "name": "AuthAssertExecutor"
            },
            "onSuccess": "end"
        },
        {
            "id": "end",
            "type": "END"
        }
    ]
}
```

#### Event published
```
{
  "event": "USER_CREATED",
  "ouDescription": "Test OU description",
  "ouHandle": "newOU",
  "ouId": "019daf5b-94ce-751c-a76c-43c699841828",
  "ouName": "newOU",
  "userId": "019daf5b-b5ee-74a7-8097-e0e8159cca73",
  "username": "kurt1"
}
```

### Related Issues
- https://github.com/asgardeo/thunder/issues/2274

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Outgoing HTTP requests now enrich and resolve organization-unit placeholders using the authenticated user's OU first, then a configured runtime OU; unresolved placeholders are preserved and failures emit warnings.
* **Tests**
  * Added tests validating OU placeholder resolution precedence, runtime enrichment, overwrite behavior, and graceful handling of lookup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->