### PR TITLE
Fix prompt node to skip already satisfied inputs in meta

### DIFF
--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -146,7 +146,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 
 	// Include meta in the response if verbose mode is enabled
 	if ctx.Verbose && n.GetMeta() != nil {
-		nodeResp.Meta = n.GetMeta()
+		nodeResp.Meta = n.trimMetaToRequestedInputs(nodeResp.Inputs, nodeResp.Actions)
 	}
 
 	nodeResp.Status = common.NodeStatusIncomplete
@@ -260,6 +260,18 @@ func (n *promptNode) appendMissingInputs(ctx *NodeContext, nodeResp *common.Node
 	requireInputs := false
 	for _, input := range requiredInputs {
 		if _, ok := ctx.UserInputs[input.Identifier]; !ok {
+			if _, ok := ctx.RuntimeData[input.Identifier]; ok {
+				logger.Debug("Input available in runtime data, skipping",
+					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
+				continue
+			}
+			if value, ok := ctx.ForwardedData[input.Identifier]; ok {
+				if _, isString := value.(string); isString {
+					logger.Debug("Input available in forwarded data, skipping",
+						log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
+					continue
+				}
+			}
 			if input.Required {
 				requireInputs = true
 			}
@@ -404,4 +416,86 @@ func (n *promptNode) getActionTypeForRef(actionRef string) string {
 		}
 	}
 	return ""
+}
+
+// trimMetaToRequestedInputs returns a copy of n.meta with the "components" list trimmed to only
+// include components matching the given inputs and actions (plus structural components like TEXT
+// and BLOCK containers that are not themselves inputs or actions).
+func (n *promptNode) trimMetaToRequestedInputs(inputs []common.Input, actions []common.Action) interface{} {
+	metaMap, ok := n.meta.(map[string]interface{})
+	if !ok {
+		return n.meta
+	}
+
+	allowedRefs := make(map[string]struct{})
+	for _, input := range inputs {
+		if input.Ref != "" {
+			allowedRefs[input.Ref] = struct{}{}
+		}
+	}
+	for _, action := range actions {
+		if action.Ref != "" {
+			allowedRefs[action.Ref] = struct{}{}
+		}
+	}
+
+	knownInputActionRefs := make(map[string]struct{})
+	for _, input := range n.getAllInputs() {
+		if input.Ref != "" {
+			knownInputActionRefs[input.Ref] = struct{}{}
+		}
+	}
+	for _, action := range n.getAllActions() {
+		if action.Ref != "" {
+			knownInputActionRefs[action.Ref] = struct{}{}
+		}
+	}
+
+	trimmed := make(map[string]interface{}, len(metaMap))
+	for k, v := range metaMap {
+		trimmed[k] = v
+	}
+	if comps, ok := metaMap["components"]; ok {
+		if compSlice, ok := comps.([]interface{}); ok {
+			trimmed["components"] = filterMetaComponents(compSlice, allowedRefs, knownInputActionRefs)
+		}
+	}
+	return trimmed
+}
+
+// filterMetaComponents filters a meta components slice, dropping satisfied input/action components
+// while keeping structural components (TEXT, BLOCK containers, etc.) and recursively trimming
+// their children.
+func filterMetaComponents(comps []interface{}, allowedRefs, knownInputActionRefs map[string]struct{}) []interface{} {
+	result := make([]interface{}, 0, len(comps))
+	for _, comp := range comps {
+		compMap, ok := comp.(map[string]interface{})
+		if !ok {
+			result = append(result, comp)
+			continue
+		}
+
+		id, _ := compMap["id"].(string)
+		if _, isKnown := knownInputActionRefs[id]; isKnown {
+			if _, isAllowed := allowedRefs[id]; isAllowed {
+				result = append(result, comp)
+			}
+			continue
+		}
+
+		// Structural component — always keep; recurse into children if present.
+		if childComps, hasChildren := compMap["components"]; hasChildren {
+			if childSlice, ok := childComps.([]interface{}); ok {
+				trimmedComp := make(map[string]interface{}, len(compMap))
+				for k, v := range compMap {
+					trimmedComp[k] = v
+				}
+				trimmedComp["components"] = filterMetaComponents(childSlice, allowedRefs, knownInputActionRefs)
+				result = append(result, trimmedComp)
+				continue
+			}
+		}
+		result = append(result, comp)
+	}
+	return result
 }

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -1564,6 +1564,365 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_MultipleAction
 	s.Equal("social_github", resp2.ForwardedData[common.ForwardedDataKeyActionType])
 }
 
+func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInRuntimeData() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: "username", Ref: "input_username", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		RuntimeData:   map[string]string{"email": "user@example.com"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 1)
+	s.Equal("username", resp.Inputs[0].Identifier, "email should be skipped because it is in RuntimeData")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInForwardedDataString() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: "username", Ref: "input_username", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{"email": "user@example.com"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 1)
+	s.Equal("username", resp.Inputs[0].Identifier, "email should be skipped because it is a string in ForwardedData")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_DoesNotSkipForwardedDataNonString() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Ref: "input_email", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{
+			"email": []common.Input{{Identifier: "email"}},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 1, "email should NOT be skipped because forwarded value is not a string")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_RuntimeDataDoesNotAffectNonMatchingInputs() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: "username", Ref: "input_username", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		RuntimeData:   map[string]string{"someOtherKey": "value"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 2, "both inputs should appear because RuntimeData has no matching keys")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_PartialInputSet() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "TEXT", "id": "heading"},
+			map[string]interface{}{
+				"type": "BLOCK",
+				"id":   "form_block",
+				"components": []interface{}{
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_given_name"},
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_family_name"},
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_email"},
+					map[string]interface{}{"type": "ACTION", "id": "action_submit"},
+				},
+			},
+		},
+	}
+
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "given_name", Ref: "input_given_name", Required: true},
+				{Identifier: "family_name", Ref: "input_family_name", Required: true},
+				{Identifier: "email", Ref: "input_email", Required: true},
+			},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{"email": "user@example.com"},
+		Verbose:     true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 2)
+	s.NotNil(resp.Meta)
+
+	respMeta, ok := resp.Meta.(map[string]interface{})
+	s.True(ok)
+	topComps, ok := respMeta["components"].([]interface{})
+	s.True(ok)
+	s.Len(topComps, 2)
+
+	// TEXT heading is always kept
+	headingComp, ok := topComps[0].(map[string]interface{})
+	s.True(ok)
+	s.Equal("heading", headingComp["id"])
+
+	// BLOCK contains only the two remaining inputs and the action
+	blockComp, ok := topComps[1].(map[string]interface{})
+	s.True(ok)
+	s.Equal("form_block", blockComp["id"])
+	nestedComps, ok := blockComp["components"].([]interface{})
+	s.True(ok)
+	s.Len(nestedComps, 3)
+
+	ids := make([]string, 0, len(nestedComps))
+	for _, c := range nestedComps {
+		if m, ok := c.(map[string]interface{}); ok {
+			ids = append(ids, m["id"].(string))
+		}
+	}
+	s.ElementsMatch([]string{"input_given_name", "input_family_name", "action_submit"}, ids)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_AllInputsMissing() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "TEXT", "id": "heading"},
+			map[string]interface{}{
+				"type": "BLOCK",
+				"id":   "form_block",
+				"components": []interface{}{
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_given_name"},
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_family_name"},
+					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_email"},
+					map[string]interface{}{"type": "ACTION", "id": "action_submit"},
+				},
+			},
+		},
+	}
+
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "given_name", Ref: "input_given_name", Required: true},
+				{Identifier: "family_name", Ref: "input_family_name", Required: true},
+				{Identifier: "email", Ref: "input_email", Required: true},
+			},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		Verbose:     true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Len(resp.Inputs, 3)
+	s.NotNil(resp.Meta)
+
+	respMeta, ok := resp.Meta.(map[string]interface{})
+	s.True(ok)
+	topComps, ok := respMeta["components"].([]interface{})
+	s.True(ok)
+	s.Len(topComps, 2)
+
+	blockComp, ok := topComps[1].(map[string]interface{})
+	s.True(ok)
+	nestedComps, ok := blockComp["components"].([]interface{})
+	s.True(ok)
+	s.Len(nestedComps, 4, "all components should be present when all inputs are missing")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_AllInputsSatisfied_ActionOnly() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "TEXT_INPUT", "id": "input_given_name"},
+			map[string]interface{}{"type": "ACTION", "id": "action_submit"},
+			map[string]interface{}{"type": "ACTION", "id": "action_cancel"},
+		},
+	}
+
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "given_name", Ref: "input_given_name", Required: true},
+			},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+		{
+			Action: &common.Action{Ref: "action_cancel", NextNode: "exit"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "",
+		UserInputs:    map[string]string{"given_name": "Alice"},
+		Verbose:       true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 0, "all inputs satisfied")
+	s.Len(resp.Actions, 2)
+	s.NotNil(resp.Meta)
+
+	respMeta, ok := resp.Meta.(map[string]interface{})
+	s.True(ok)
+	comps, ok := respMeta["components"].([]interface{})
+	s.True(ok)
+	s.Len(comps, 2, "input component should be dropped; only action components remain")
+
+	ids := make([]string, 0, len(comps))
+	for _, c := range comps {
+		if m, ok := c.(map[string]interface{}); ok {
+			ids = append(ids, m["id"].(string))
+		}
+	}
+	s.ElementsMatch([]string{"action_submit", "action_cancel"}, ids)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_DisabledWhenVerboseFalse() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "TEXT_INPUT", "id": "input_email"},
+			map[string]interface{}{"type": "TEXT_INPUT", "id": "input_username"},
+			map[string]interface{}{"type": "ACTION", "id": "action_submit"},
+		},
+	}
+
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: "username", Ref: "input_username", Required: true},
+			},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	// email is satisfied via RuntimeData; username is still missing — partial inputs
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{"email": "user@example.com"},
+		Verbose:     false,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Nil(resp.Meta, "Meta should be nil when verbose is false regardless of input state")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_MetaNotMapStructure() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta("plain string meta")
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "username", Ref: "input_username", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+	}
+
+	s.NotPanics(func() {
+		resp, err := node.Execute(ctx)
+		s.Nil(err)
+		s.NotNil(resp)
+		s.Equal("plain string meta", resp.Meta, "non-map meta should be returned unchanged")
+	})
+}
+
 func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_NoTypeField() {
 	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
 	promptNode := node.(PromptNodeInterface)


### PR DESCRIPTION
### Purpose
promptNode.appendMissingInputs only checked ctx.UserInputs before marking an input as missing, while the base executor's equivalent method also checks ctx.RuntimeData and ctx.ForwardedData. This caused prompt nodes to re-request inputs (e.g. email set by a prior Google OAuth step) that the executor had already correctly satisfied, breaking flows where upstream steps populate context data.

Additionally, when verbose mode is enabled, the prompt node attached the full n.GetMeta() to the response even when only a subset of inputs were still pending. Clients received a meta describing N fields while inputs listed a smaller subset, causing form rendering mismatches.

### Approach

- Fix 1 — Context-aware missing input detection (appendMissingInputs)
After a ctx.UserInputs miss, the method now checks ctx.RuntimeData (skip if present) and ctx.ForwardedData (skip only if the value is a string — non-string values such as []common.Input stored under ForwardedDataKeyInputs must not be treated as satisfied). This aligns promptNode with the existing executor.appendMissingInputs logic.

- Fix 2 — Verbose meta trimming (trimMetaToRequestedInputs + filterMetaComponents)
A new trimMetaToRequestedInputs method builds two ref sets: allowedRefs (inputs/actions still pending in nodeResp) and knownInputActionRefs (all static inputs/actions defined on the node). It shallow-copies the top-level meta map and replaces "components" with the output of filterMetaComponents, a recursive helper that drops components whose id matches a satisfied input/action, while always preserving structural components (TEXT, BLOCK containers, etc.) and recursing into their children. The display-only node path is unchanged.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better missing-input detection: inputs present in runtime data or forwarded data (when the forwarded value is a string) are treated as satisfied and not re-requested.

* **New Features**
  * Verbose mode now returns streamlined metadata containing only components relevant to the actually requested inputs/actions; non-map metadata is preserved and verbose=false yields no meta.

* **Tests**
  * Added tests covering input availability rules, verbose metadata trimming, and edge cases (non-string forwarded values, non-map meta, verbose off).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->