### PR TITLE
add JWE and nested JWT support for UserInfo endpoint

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -1117,9 +1117,34 @@ components:
           items:
             type: string
           description: |
-            The user attributes to include in the userinfo response. 
+            The user attributes to include in the userinfo response.
             If not specified, falls back to ID token user attributes.
           example: ["email", "name", "given_name", "family_name", "picture"]
+        signingAlg:
+          type: string
+          description: |
+            JWS algorithm used to sign the UserInfo response JWT.
+            When set (without encryptionAlg), the response is a signed JWT (JWS).
+            When set together with encryptionAlg, the response is a Nested JWT (sign-then-encrypt).
+            Omit to return a plain JSON response.
+          enum: ["RS256", "RS512", "PS256", "ES256", "ES384", "ES512", "EdDSA"]
+          example: "RS256"
+        encryptionAlg:
+          type: string
+          description: |
+            JWE key-management algorithm used to encrypt the UserInfo response.
+            Must be set together with encryptionEnc and a client certificate (JWKS).
+            When set without signingAlg, the response is a JWE over the plain JSON payload.
+            When set together with signingAlg, the response is a Nested JWT (sign-then-encrypt).
+          enum: ["RSA-OAEP", "RSA-OAEP-256"]
+          example: "RSA-OAEP-256"
+        encryptionEnc:
+          type: string
+          description: |
+            JWE content-encryption algorithm used to encrypt the UserInfo response payload.
+            Required when encryptionAlg is set.
+          enum: ["A128CBC-HS256", "A256GCM"]
+          example: "A256GCM"
 
     Certificate:
       type: object

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -86,7 +86,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 		logger.Fatal("Failed to initialize certificate service", log.Error(err))
 	}
 
-	jwtService, _, err := jose.Initialize(pkiService)
+	jwtService, jweService, err := jose.Initialize(pkiService)
 	if err != nil {
 		logger.Fatal("Failed to initialize JOSE services", log.Error(err))
 	}
@@ -293,8 +293,8 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	}
 
 	// Initialize OAuth services.
-	err = oauth.Initialize(mux, applicationService, authnProvider, jwtService, flowExecService, observabilitySvc,
-		pkiService, ouService, attributeCacheService, authZService, entityProvider, resourceService)
+	err = oauth.Initialize(mux, applicationService, authnProvider, jwtService, jweService, flowExecService,
+		observabilitySvc, pkiService, ouService, attributeCacheService, authZService, entityProvider, resourceService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/internal/application/model/constants.go
+++ b/backend/internal/application/model/constants.go
@@ -18,7 +18,12 @@
 
 package model
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/asgardeo/thunder/internal/system/jose/jwe"
+	"github.com/asgardeo/thunder/internal/system/jose/jws"
+)
 
 // InboundAuthType represents the type of inbound authentication.
 type InboundAuthType string
@@ -35,9 +40,28 @@ const (
 	// UserInfoResponseTypeJSON represents the JSON userinfo response type.
 	UserInfoResponseTypeJSON UserInfoResponseType = "JSON"
 
-	// UserInfoResponseTypeJWS represents the JWS userinfo response type.
+	// UserInfoResponseTypeJWS represents the signed JWT (JWS) userinfo response type.
 	UserInfoResponseTypeJWS UserInfoResponseType = "JWS"
+
+	// UserInfoResponseTypeJWE represents the encrypted (JWE) userinfo response type.
+	UserInfoResponseTypeJWE UserInfoResponseType = "JWE"
+
+	// UserInfoResponseTypeNESTEDJWT represents the signed-then-encrypted (Nested JWT) userinfo response type.
+	UserInfoResponseTypeNESTEDJWT UserInfoResponseType = "NESTED_JWT"
 )
+
+// SupportedUserInfoSigningAlgs lists JWS algorithms supported for userinfo signing.
+var SupportedUserInfoSigningAlgs = []string{
+	string(jws.RS256), string(jws.RS512), string(jws.PS256),
+	string(jws.ES256), string(jws.ES384), string(jws.ES512),
+	string(jws.EdDSA),
+}
+
+// SupportedUserInfoEncryptionAlgs lists JWE key-management algorithms supported for userinfo encryption.
+var SupportedUserInfoEncryptionAlgs = []string{string(jwe.RSAOAEP), string(jwe.RSAOAEP256)}
+
+// SupportedUserInfoEncryptionEncs lists JWE content-encryption algorithms supported for userinfo encryption.
+var SupportedUserInfoEncryptionEncs = []string{string(jwe.A128CBCHS256), string(jwe.A256GCM)}
 
 // ApplicationNotFoundError is the error returned when an application is not found.
 var ApplicationNotFoundError error = errors.New("application not found")

--- a/backend/internal/application/model/oauth_app.go
+++ b/backend/internal/application/model/oauth_app.go
@@ -47,8 +47,11 @@ type IDTokenConfig struct {
 
 // UserInfoConfig represents the user info endpoint configuration structure.
 type UserInfoConfig struct {
-	ResponseType   UserInfoResponseType `json:"responseType,omitempty" yaml:"response_type,omitempty"`
+	ResponseType   UserInfoResponseType `json:"responseType,omitempty"   yaml:"response_type,omitempty"   jsonschema:"UserInfo response type (JSON, JWS, JWE, NESTED_JWT). Derived from algorithm fields when not explicitly set."`
 	UserAttributes []string             `json:"userAttributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in userinfo response."`
+	SigningAlg     string               `json:"signingAlg,omitempty"     yaml:"signing_alg,omitempty"     jsonschema:"JWS algorithm for signed userinfo responses (e.g. RS256)."`
+	EncryptionAlg  string               `json:"encryptionAlg,omitempty"  yaml:"encryption_alg,omitempty"  jsonschema:"JWE key-management algorithm for encrypted userinfo responses (e.g. RSA-OAEP-256)."`
+	EncryptionEnc  string               `json:"encryptionEnc,omitempty"  yaml:"encryption_enc,omitempty"  jsonschema:"JWE content-encryption algorithm (e.g. A256GCM). Required when encryptionAlg is set."`
 }
 
 // OAuthTokenConfig represents the OAuth token configuration structure with access_token and id_token wrappers.

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -41,6 +41,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	syshttp "github.com/asgardeo/thunder/internal/system/http"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/security"
@@ -909,8 +910,11 @@ func toOAuthProcessedDTO(
 
 	if cfg.UserInfo != nil {
 		dto.UserInfo = &model.UserInfoConfig{
-			ResponseType:   cfg.UserInfo.ResponseType,
+			ResponseType:   model.UserInfoResponseType(cfg.UserInfo.ResponseType),
 			UserAttributes: cfg.UserInfo.UserAttributes,
+			SigningAlg:     cfg.UserInfo.SigningAlg,
+			EncryptionAlg:  cfg.UserInfo.EncryptionAlg,
+			EncryptionEnc:  cfg.UserInfo.EncryptionEnc,
 		}
 	}
 
@@ -1304,7 +1308,118 @@ func validateOAuthParamsForCreateAndUpdate(app *model.ApplicationDTO) (*model.In
 		}
 	}
 
+	// Validate userinfo encryption configuration
+	if err := validateUserInfoConfig(oauthAppConfig); err != nil {
+		return nil, err
+	}
+
 	return inboundAuthConfig, nil
+}
+
+// validateUserInfoConfig validates the UserInfo signing and encryption configuration.
+func validateUserInfoConfig(oauthConfig *model.OAuthAppConfigDTO) *serviceerror.ServiceError {
+	if oauthConfig.UserInfo == nil {
+		return nil
+	}
+	cfg := oauthConfig.UserInfo
+
+	if cfg.SigningAlg != "" && !slices.Contains(model.SupportedUserInfoSigningAlgs, cfg.SigningAlg) {
+		return serviceerror.CustomServiceError(
+			ErrorInvalidOAuthConfiguration,
+			core.I18nMessage{DefaultValue: "userinfo signing algorithm '" + cfg.SigningAlg + "' is not supported"},
+		)
+	}
+
+	if cfg.EncryptionEnc != "" && cfg.EncryptionAlg == "" {
+		return serviceerror.CustomServiceError(
+			ErrorInvalidOAuthConfiguration,
+			core.I18nMessage{DefaultValue: "encryptionAlg is required when encryptionEnc is set"},
+		)
+	}
+
+	if cfg.EncryptionAlg != "" {
+		if !slices.Contains(model.SupportedUserInfoEncryptionAlgs, cfg.EncryptionAlg) {
+			return serviceerror.CustomServiceError(
+				ErrorInvalidOAuthConfiguration,
+				core.I18nMessage{
+					DefaultValue: "userinfo encryption algorithm '" + cfg.EncryptionAlg + "' is not supported",
+				},
+			)
+		}
+		if cfg.EncryptionEnc == "" {
+			return serviceerror.CustomServiceError(
+				ErrorInvalidOAuthConfiguration,
+				core.I18nMessage{DefaultValue: "encryptionEnc is required when encryptionAlg is set"},
+			)
+		}
+		if !slices.Contains(model.SupportedUserInfoEncryptionEncs, cfg.EncryptionEnc) {
+			return serviceerror.CustomServiceError(
+				ErrorInvalidOAuthConfiguration,
+				core.I18nMessage{
+					DefaultValue: "userinfo content-encryption algorithm '" + cfg.EncryptionEnc + "' is not supported",
+				},
+			)
+		}
+		hasCert := oauthConfig.Certificate != nil && oauthConfig.Certificate.Type != ""
+		if !hasCert {
+			return serviceerror.CustomServiceError(
+				ErrorInvalidOAuthConfiguration,
+				core.I18nMessage{
+					DefaultValue: "a certificate (JWKS or JWKS_URI) is required when userinfo encryption is configured",
+				},
+			)
+		}
+		if oauthConfig.Certificate.Type == cert.CertificateTypeJWKSURI {
+			if err := syshttp.IsSSRFSafeURL(oauthConfig.Certificate.Value); err != nil {
+				log.GetLogger().Debug("JWKS URI rejected by SSRF policy",
+					log.String("uri", oauthConfig.Certificate.Value), log.Error(err))
+				return serviceerror.CustomServiceError(
+					ErrorInvalidOAuthConfiguration,
+					core.I18nMessage{DefaultValue: "JWKS URI must be a publicly reachable HTTPS URL"},
+				)
+			}
+		}
+	}
+
+	if cfg.ResponseType != "" {
+		switch cfg.ResponseType {
+		case model.UserInfoResponseTypeJWS:
+			if cfg.SigningAlg == "" {
+				return serviceerror.CustomServiceError(
+					ErrorInvalidOAuthConfiguration,
+					core.I18nMessage{DefaultValue: "signingAlg is required when responseType is JWS"},
+				)
+			}
+		case model.UserInfoResponseTypeJWE:
+			if cfg.EncryptionAlg == "" || cfg.EncryptionEnc == "" {
+				return serviceerror.CustomServiceError(
+					ErrorInvalidOAuthConfiguration,
+					core.I18nMessage{
+						DefaultValue: "encryptionAlg and encryptionEnc are required when responseType is JWE",
+					},
+				)
+			}
+		case model.UserInfoResponseTypeNESTEDJWT:
+			if cfg.SigningAlg == "" || cfg.EncryptionAlg == "" || cfg.EncryptionEnc == "" {
+				return serviceerror.CustomServiceError(
+					ErrorInvalidOAuthConfiguration,
+					core.I18nMessage{
+						DefaultValue: "signingAlg, encryptionAlg, and encryptionEnc are required when " +
+							"responseType is NESTED_JWT",
+					},
+				)
+			}
+		case model.UserInfoResponseTypeJSON:
+			// no additional requirements
+		default:
+			return serviceerror.CustomServiceError(
+				ErrorInvalidOAuthConfiguration,
+				core.I18nMessage{DefaultValue: "responseType '" + string(cfg.ResponseType) + "' is not supported"},
+			)
+		}
+	}
+
+	return nil
 }
 
 // validateRedirectURIs validates redirect URIs format and requirements.
@@ -1474,6 +1589,7 @@ func validateTokenEndpointAuthMethod(oauthConfig *model.OAuthAppConfigDTO) *serv
 	}
 
 	hasCert := oauthConfig.Certificate != nil && oauthConfig.Certificate.Type != ""
+	userInfoNeedsCert := oauthConfig.UserInfo != nil && oauthConfig.UserInfo.EncryptionAlg != ""
 
 	switch oauthConfig.TokenEndpointAuthMethod {
 	case oauth2const.TokenEndpointAuthMethodPrivateKeyJWT:
@@ -1490,7 +1606,7 @@ func validateTokenEndpointAuthMethod(oauthConfig *model.OAuthAppConfigDTO) *serv
 			})
 		}
 	case oauth2const.TokenEndpointAuthMethodClientSecretBasic, oauth2const.TokenEndpointAuthMethodClientSecretPost:
-		if hasCert {
+		if hasCert && !userInfoNeedsCert {
 			return serviceerror.CustomServiceError(ErrorInvalidOAuthConfiguration, core.I18nMessage{
 				Key:          "error.applicationservice.client_secret_cannot_have_certificate_description",
 				DefaultValue: "client_secret authentication methods cannot have a certificate",
@@ -1503,7 +1619,7 @@ func validateTokenEndpointAuthMethod(oauthConfig *model.OAuthAppConfigDTO) *serv
 				DefaultValue: "'none' authentication method requires the client to be a public client",
 			})
 		}
-		if hasCert || oauthConfig.ClientSecret != "" {
+		if (hasCert && !userInfoNeedsCert) || oauthConfig.ClientSecret != "" {
 			return serviceerror.CustomServiceError(ErrorInvalidOAuthConfiguration, core.I18nMessage{
 				Key:          "error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description",
 				DefaultValue: "'none' authentication method cannot have a certificate or client secret",
@@ -1712,19 +1828,25 @@ func processUserInfoConfiguration(app *model.ApplicationDTO,
 		oauthInboundAuth.OAuthAppConfig.UserInfo != nil {
 		userInfoConfigInput := oauthInboundAuth.OAuthAppConfig.UserInfo
 		oauthUserInfo.UserAttributes = userInfoConfigInput.UserAttributes
-		responseType := model.UserInfoResponseType(strings.ToUpper(string(userInfoConfigInput.ResponseType)))
-
-		switch responseType {
-		case model.UserInfoResponseTypeJWS:
-			oauthUserInfo.ResponseType = responseType
-		default:
-			oauthUserInfo.ResponseType = model.UserInfoResponseTypeJSON
-		}
+		oauthUserInfo.SigningAlg = userInfoConfigInput.SigningAlg
+		oauthUserInfo.EncryptionAlg = userInfoConfigInput.EncryptionAlg
+		oauthUserInfo.EncryptionEnc = userInfoConfigInput.EncryptionEnc
 	}
 	if oauthUserInfo.UserAttributes == nil {
 		oauthUserInfo.UserAttributes = idTokenConfig.UserAttributes
 	}
-	if oauthUserInfo.ResponseType == "" {
+
+	// Always set ResponseType from algorithm fields so the runtime never has to re-derive it.
+	hasSign := oauthUserInfo.SigningAlg != ""
+	hasEnc := oauthUserInfo.EncryptionAlg != ""
+	switch {
+	case hasSign && hasEnc:
+		oauthUserInfo.ResponseType = model.UserInfoResponseTypeNESTEDJWT
+	case hasEnc:
+		oauthUserInfo.ResponseType = model.UserInfoResponseTypeJWE
+	case hasSign:
+		oauthUserInfo.ResponseType = model.UserInfoResponseTypeJWS
+	default:
 		oauthUserInfo.ResponseType = model.UserInfoResponseTypeJSON
 	}
 

--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -67,8 +67,11 @@ type idTokenConfig struct {
 
 // userInfoConfig represents user info endpoint configuration for JSON marshaling.
 type userInfoConfig struct {
-	ResponseType   model.UserInfoResponseType `json:"response_type,omitempty"`
-	UserAttributes []string                   `json:"user_attributes,omitempty"`
+	ResponseType   string   `json:"response_type,omitempty"`
+	UserAttributes []string `json:"user_attributes,omitempty"`
+	SigningAlg     string   `json:"signing_alg,omitempty"`
+	EncryptionAlg  string   `json:"encryption_alg,omitempty"`
+	EncryptionEnc  string   `json:"encryption_enc,omitempty"`
 }
 
 // applicationConfigDAO represents the gateway configuration for an application (no identity data).
@@ -549,8 +552,11 @@ func getOAuthConfigJSONBytes(inboundAuth model.InboundAuthConfigProcessedDTO) (j
 	}
 	if oa.UserInfo != nil {
 		cfg.UserInfo = &userInfoConfig{
-			ResponseType:   oa.UserInfo.ResponseType,
+			ResponseType:   string(oa.UserInfo.ResponseType),
 			UserAttributes: oa.UserInfo.UserAttributes,
+			SigningAlg:     oa.UserInfo.SigningAlg,
+			EncryptionAlg:  oa.UserInfo.EncryptionAlg,
+			EncryptionEnc:  oa.UserInfo.EncryptionEnc,
 		}
 	}
 	data, err := json.Marshal(cfg)

--- a/backend/internal/application/store_test.go
+++ b/backend/internal/application/store_test.go
@@ -310,7 +310,9 @@ func (suite *ApplicationStoreTestSuite) TestGetOAuthConfigJSONBytes_WithUserInfo
 	app := suite.createTestApplication()
 	inboundAuthConfig := app.InboundAuthConfig[0]
 	inboundAuthConfig.OAuthAppConfig.UserInfo = &model.UserInfoConfig{
-		ResponseType:   "jwt",
+		SigningAlg:     "RS256",
+		EncryptionAlg:  "RSA-OAEP-256",
+		EncryptionEnc:  "A256GCM",
 		UserAttributes: []string{"email", "name"},
 	}
 
@@ -325,7 +327,9 @@ func (suite *ApplicationStoreTestSuite) TestGetOAuthConfigJSONBytes_WithUserInfo
 
 	userInfo, ok := result["user_info"].(map[string]interface{})
 	suite.True(ok)
-	suite.Equal("jwt", userInfo["response_type"])
+	suite.Equal("RS256", userInfo["signing_alg"])
+	suite.Equal("RSA-OAEP-256", userInfo["encryption_alg"])
+	suite.Equal("A256GCM", userInfo["encryption_enc"])
 
 	userAttrs, ok := userInfo["user_attributes"].([]interface{})
 	suite.True(ok)

--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -319,7 +319,7 @@ func (s *consentEnforcerService) createConsentSessionToken(promptData *ConsentPr
 	claims["aud"] = consentSessionTokenAudience
 	token, _, svcErr := s.jwtService.GenerateJWT(
 		"", issuer,
-		consentSessionTokenValidityPeriod, claims, "")
+		consentSessionTokenValidityPeriod, claims, "", "")
 	if svcErr != nil {
 		return "", errors.New("failed to generate consent session token: " + svcErr.Error.DefaultValue)
 	}

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -249,7 +249,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PromptNeeded() {
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
 		[]string{"email"}, []string{"phone"}, nil)
@@ -282,7 +282,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_RequiredAttributesF
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	// Only request "email" — "phone" and "address" should be filtered out
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -318,7 +318,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_UserProfileFilter()
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
 		nil, nil, availableAttributes)
@@ -361,7 +361,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PartialConsentsExis
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(existingConsents, nil)
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
 		[]string{"email"}, []string{"phone"}, nil)
@@ -419,7 +419,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_CreateConsentSessio
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},
 		})
@@ -438,7 +438,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestCreateConsentSessionToken_Generate
 	}
 
 	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},
 		})

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -433,7 +433,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *co
 	jwtConfig := config.GetThunderRuntime().Config.JWT
 	jwtClaims["aud"] = jwtConfig.Audience
 	token, _, err := as.jwtService.GenerateJWT(user.ID, jwtConfig.Issuer,
-		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT)
+		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		logger.Error("Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
 		return &serviceerror.InternalServerError
@@ -610,7 +610,7 @@ func (as *authenticationService) createSessionToken(idpID string, idpType idp.ID
 
 	jwtConfig := config.GetThunderRuntime().Config.JWT
 	claims["aud"] = "auth-svc"
-	token, _, err := as.jwtService.GenerateJWT("auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT)
+	token, _, err := as.jwtService.GenerateJWT("auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -211,7 +211,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+					}), mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -243,7 +243,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 						},
 					}, nil).Once()
 				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
-					mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+					mock.Anything, mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -319,7 +319,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsJWTG
 			},
 		}, nil).Once()
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "JWT_GENERATION_FAILED",
@@ -519,7 +519,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+					}), mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -548,7 +548,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					}), mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
+					}), mock.Anything, mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.NotEmpty(result.Assertion)
@@ -599,7 +599,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, idpID)
@@ -621,7 +621,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSucce
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOIDC, idpID)
@@ -642,7 +642,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuc
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeGoogle, idpID)
@@ -663,7 +663,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeGitHub, idpID)
@@ -728,7 +728,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOIDC, idpID)
@@ -748,7 +748,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "JWT_GENERATION_FAILED",
@@ -854,8 +854,9 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
-					mock.Anything, mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+				suite.mockJWTService.On("GenerateJWT",
+					testUserID, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+				).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -892,7 +893,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					}), mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
+					}), mock.Anything, mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.NotEmpty(result.Assertion)
@@ -1236,7 +1237,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 			},
 		}, nil).Once()
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testJWTToken, int64(3600), nil).Once()
 
 	// Test with empty existingAssertion
@@ -1433,7 +1434,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTPJWTGenerationError() {
 			},
 		}, nil).Once()
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "JWT_GENERATION_FAILED",
@@ -1798,7 +1799,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Suc
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["userType"] == "person" && claims["ouId"] == testOrgUnit
-		}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+		}), mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(
 		context.Background(), testCredentialID, testCredentialType, response, sessionToken, false, "")
@@ -1878,7 +1879,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Wit
 		Return(mockUpdatedResult, nil).Once()
 
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
+		mock.Anything, mock.Anything, mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(
 		context.Background(), testCredentialID, testCredentialType, response, sessionToken, false, existingAssertion)

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -206,7 +206,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 	}
 
 	jwtClaims["aud"] = ctx.AppID
-	token, _, err := a.jwtService.GenerateJWT(tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT)
+	token, _, err := a.jwtService.GenerateJWT(tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		logger.Error("Failed to generate JWT token", log.String("error", err.Error.DefaultValue))
 		return "", errors.New("failed to generate JWT token: " + err.Error.DefaultValue)

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -160,7 +160,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 	}, nil)
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
 		Return(ou.OrganizationUnit{ID: testAuthOUID}, nil)
@@ -212,7 +212,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			perms, ok := claims["authorized_permissions"]
 			return ok && perms == "read:documents write:documents"
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -253,7 +253,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["email"] == testEmail && claims["phone"] == "1234567890"
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -278,7 +278,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 	}
 
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",
 		Error: i18ncore.I18nMessage{
@@ -549,7 +549,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimUserType] == "EXTERNAL" && claims[oauth2const.ClaimOUID] == "ou-456"
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-456").
 		Return(ou.OrganizationUnit{ID: "ou-456"}, nil)
@@ -581,7 +581,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "https://test.thunder.io", int64(7200),
-		mock.Anything, mock.Anything).Return("jwt-token", int64(7200), nil)
+		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(7200), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -620,7 +620,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 			return claims[oauth2const.ClaimOUID] == testAssertOUID &&
 				claims[oauth2const.ClaimOUName] == "Engineering" &&
 				claims[oauth2const.ClaimOUHandle] == "eng"
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -690,7 +690,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 	existingUser.Attributes = attrsJSON
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -831,7 +831,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 			hasUsername := claims["username"] == "testuser"
 			hasFirstName := claims["given_name"] == testNameValue
 			return hasEmail && hasUsername && hasFirstName
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -875,7 +875,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 				return false
 			}
 			return len(groups) == 3 && groups[0] == "admin" && groups[1] == "developer" && groups[2] == "viewer"
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -910,7 +910,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 			// Should NOT contain groups claim when groups list is empty
 			_, ok := claims[oauth2const.UserAttributeGroups]
 			return !ok
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1083,7 +1083,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 			hasEmail := claims["email"] == testEmail
 			hasName := claims["name"] == testNameValue
 			return hasEmail && hasName && !hasPhone
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1112,7 +1112,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithEmptyConsentedAttribut
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1136,7 +1136,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithoutConsentedAttributes
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1188,7 +1188,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_AttrsSt
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
 			return claims["aci"] == "cache-abc" && !hasEmail && !hasPhone
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1239,7 +1239,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilUser
 			// aci present, but no individual attribute claims
 			_, hasEmail := claims["email"]
 			return claims["aci"] == "cache-xyz" && !hasEmail
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1292,7 +1292,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OnlyRes
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
 			return claims["aci"] == "cache-def" && !hasEmail && !hasPhone
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1339,7 +1339,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAsse
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			return claims["aci"] == "cache-nil" && !hasEmail
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1565,7 +1565,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsI
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasGroups := claims[oauth2const.UserAttributeGroups]
 			return claims["aci"] == "cache-groups" && !hasGroups
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1606,7 +1606,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTyp
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserType := claims[oauth2const.ClaimUserType]
 			return claims["aci"] == "cache-usertype" && !hasUserType
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1649,7 +1649,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OUDetai
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasOUID := claims[oauth2const.ClaimOUID]
 			return claims["aci"] == "cache-ou" && !hasOUID
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1693,7 +1693,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithRuntimeRequiredEssenti
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasPhone := claims["phone"]
 			return claims["email"] == testEmail && claims["name"] == testNameValue && !hasPhone
-		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -293,7 +293,7 @@ func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (stri
 
 	claims["aud"] = "otp-svc"
 	token, _, err := s.jwtService.GenerateJWT(
-		"otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT)
+		"otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %v", err)
 	}

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -331,7 +331,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	suite.service.clientProvider = cp
 
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(err)
@@ -385,8 +385,9 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.InternalServerError).Once()
+	suite.mockJWTService.EXPECT().GenerateJWT(
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return("", int64(0), &serviceerror.InternalServerError).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
@@ -643,7 +644,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_TemplateRenderSuccess_UsesRendered
 	suite.service.clientProvider = cp
 
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything).Return("token", int64(0), nil).Once()
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("token", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(err)

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -42,6 +42,8 @@ import (
 	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
+	syshttp "github.com/asgardeo/thunder/internal/system/http"
+	"github.com/asgardeo/thunder/internal/system/jose/jwe"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/observability"
 )
@@ -52,6 +54,7 @@ func Initialize(
 	applicationService application.ApplicationServiceInterface,
 	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
 	jwtService jwt.JWTServiceInterface,
+	jweService jwe.JWEServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
 	pkiService pki.PKIServiceInterface,
@@ -82,8 +85,11 @@ func Initialize(
 	token.Initialize(mux, jwtService, applicationService, authnProvider, grantHandlerProvider,
 		scopeValidator, observabilitySvc, discoveryService, transactioner)
 	introspect.Initialize(mux, jwtService, applicationService, authnProvider, discoveryService)
-	userinfo.Initialize(mux, jwtService, tokenValidator, applicationService, ouService, attributeCacheSvc,
-		transactioner)
+	userinfo.Initialize(mux, jwtService, jweService,
+		syshttp.NewHTTPClientWithCheckRedirect(func(req *http.Request, _ []*http.Request) error {
+			return syshttp.IsSSRFSafeURL(req.URL.String())
+		}),
+		tokenValidator, applicationService, ouService, attributeCacheSvc, transactioner)
 	dcr.Initialize(mux, applicationService, ouService, transactioner)
 	return nil
 }

--- a/backend/internal/oauth/oauth2/dcr/model.go
+++ b/backend/internal/oauth/oauth2/dcr/model.go
@@ -45,6 +45,10 @@ type DCRRegistrationRequest struct {
 	PolicyURI               string                              `json:"policy_uri,omitempty"`
 
 	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
+
+	UserInfoSignedResponseAlg    string `json:"userinfo_signed_response_alg,omitempty"`
+	UserInfoEncryptedResponseAlg string `json:"userinfo_encrypted_response_alg,omitempty"`
+	UserInfoEncryptedResponseEnc string `json:"userinfo_encrypted_response_enc,omitempty"`
 }
 
 // DCRRegistrationResponse represents the RFC 7591 Dynamic Client Registration response.
@@ -68,6 +72,10 @@ type DCRRegistrationResponse struct {
 	AppID                   string                              `json:"app_id,omitempty"`
 
 	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
+
+	UserInfoSignedResponseAlg    string `json:"userinfo_signed_response_alg,omitempty"`
+	UserInfoEncryptedResponseAlg string `json:"userinfo_encrypted_response_alg,omitempty"`
+	UserInfoEncryptedResponseEnc string `json:"userinfo_encrypted_response_enc,omitempty"`
 }
 
 // DCRErrorResponse represents the RFC 7591 Dynamic Client Registration error response.

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -141,21 +141,9 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 	*model.ApplicationDTO, *serviceerror.ServiceError) {
 	isPublicClient := request.TokenEndpointAuthMethod == oauth2const.TokenEndpointAuthMethodNone
 
-	// Map JWKS/JWKS_URI to application-level certificate
-	var appCertificate *model.ApplicationCertificate
-	if request.JWKSUri != "" {
-		appCertificate = &model.ApplicationCertificate{
-			Type:  cert.CertificateTypeJWKSURI,
-			Value: request.JWKSUri,
-		}
-	} else if len(request.JWKS) > 0 {
-		jwksBytes, err := json.Marshal(request.JWKS)
-		if err == nil {
-			appCertificate = &model.ApplicationCertificate{
-				Type:  cert.CertificateTypeJWKS,
-				Value: string(jwksBytes),
-			}
-		}
+	appCertificate, svcErr := buildAppCertificate(request)
+	if svcErr != nil {
+		return nil, svcErr
 	}
 
 	var scopes []string
@@ -185,6 +173,7 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 		PKCERequired:                       isPublicClient,
 		RequirePushedAuthorizationRequests: request.RequirePushedAuthorizationRequests,
 		Scopes:                             scopes,
+		UserInfo:                           buildUserInfoConfig(request),
 	}
 
 	inboundAuthConfig := []model.InboundAuthConfigDTO{
@@ -207,6 +196,55 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 	}
 
 	return appDTO, nil
+}
+
+// buildAppCertificate maps JWKS/JWKS_URI from a DCR request to an ApplicationCertificate.
+func buildAppCertificate(request *DCRRegistrationRequest) (*model.ApplicationCertificate, *serviceerror.ServiceError) {
+	if request.JWKSUri != "" {
+		return &model.ApplicationCertificate{
+			Type:  cert.CertificateTypeJWKSURI,
+			Value: request.JWKSUri,
+		}, nil
+	}
+	if len(request.JWKS) > 0 {
+		jwksBytes, err := json.Marshal(request.JWKS)
+		if err != nil {
+			return nil, &ErrorServerError
+		}
+		return &model.ApplicationCertificate{
+			Type:  cert.CertificateTypeJWKS,
+			Value: string(jwksBytes),
+		}, nil
+	}
+	return nil, nil
+}
+
+// buildUserInfoConfig maps UserInfo alg fields from a DCR request to a UserInfoConfig.
+// ResponseType is derived from the algorithm fields per OIDC DCR conventions.
+func buildUserInfoConfig(request *DCRRegistrationRequest) *model.UserInfoConfig {
+	if request.UserInfoSignedResponseAlg == "" && request.UserInfoEncryptedResponseAlg == "" &&
+		request.UserInfoEncryptedResponseEnc == "" {
+		return nil
+	}
+	hasSign := request.UserInfoSignedResponseAlg != ""
+	hasEnc := request.UserInfoEncryptedResponseAlg != ""
+	var responseType model.UserInfoResponseType
+	switch {
+	case hasSign && hasEnc:
+		responseType = model.UserInfoResponseTypeNESTEDJWT
+	case hasEnc:
+		responseType = model.UserInfoResponseTypeJWE
+	case hasSign:
+		responseType = model.UserInfoResponseTypeJWS
+	default:
+		responseType = model.UserInfoResponseTypeJSON
+	}
+	return &model.UserInfoConfig{
+		ResponseType:  responseType,
+		SigningAlg:    request.UserInfoSignedResponseAlg,
+		EncryptionAlg: request.UserInfoEncryptedResponseAlg,
+		EncryptionEnc: request.UserInfoEncryptedResponseEnc,
+	}
 }
 
 // convertApplicationToDCRResponse converts Application DTO to DCR registration response.
@@ -238,6 +276,13 @@ func (ds *dcrService) convertApplicationToDCRResponse(appDTO *model.ApplicationD
 
 	scopeString := strings.Join(oauthConfig.Scopes, " ")
 
+	var userInfoSignedAlg, userInfoEncryptedAlg, userInfoEncryptedEnc string
+	if oauthConfig.UserInfo != nil {
+		userInfoSignedAlg = oauthConfig.UserInfo.SigningAlg
+		userInfoEncryptedAlg = oauthConfig.UserInfo.EncryptionAlg
+		userInfoEncryptedEnc = oauthConfig.UserInfo.EncryptionEnc
+	}
+
 	response := &DCRRegistrationResponse{
 		ClientID:                           oauthConfig.ClientID,
 		ClientSecret:                       oauthConfig.ClientSecret,
@@ -257,6 +302,9 @@ func (ds *dcrService) convertApplicationToDCRResponse(appDTO *model.ApplicationD
 		Contacts:                           appDTO.Contacts,
 		AppID:                              oauthConfig.AppID,
 		RequirePushedAuthorizationRequests: oauthConfig.RequirePushedAuthorizationRequests,
+		UserInfoSignedResponseAlg:          userInfoSignedAlg,
+		UserInfoEncryptedResponseAlg:       userInfoEncryptedAlg,
+		UserInfoEncryptedResponseEnc:       userInfoEncryptedEnc,
 	}
 
 	return response, nil
@@ -272,8 +320,8 @@ func (ds *dcrService) mapApplicationErrorToDCRError(
 	}
 
 	switch appErr.Code {
-	// Redirect URI related errors
-	case "APP-1014", "APP-1015":
+	// Redirect URI validation errors
+	case "APP-1012":
 		dcrErr.Code = ErrorInvalidRedirectURI.Code
 	// Server errors
 	case "APP-5001", "APP-5002":

--- a/backend/internal/oauth/oauth2/dcr/service_test.go
+++ b/backend/internal/oauth/oauth2/dcr/service_test.go
@@ -177,8 +177,8 @@ func (s *DCRServiceTestSuite) TestRegisterClient_ApplicationServiceError() {
 
 	appServiceErr := &serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "APP-1014",
-		Error:            i18ncore.I18nMessage{DefaultValue: "Invalid URI"},
+		Code:             "APP-1012",
+		Error:            i18ncore.I18nMessage{DefaultValue: "Invalid redirect URI"},
 		ErrorDescription: i18ncore.I18nMessage{DefaultValue: "The redirect URI is invalid"},
 	}
 
@@ -205,14 +205,19 @@ func (s *DCRServiceTestSuite) TestMapApplicationErrorToDCRError() {
 			expectedDCRCode: ErrorInvalidClientMetadata.Code,
 		},
 		{
-			name:            "Redirect URI Error APP-1014",
-			appErrCode:      "APP-1014",
+			name:            "Redirect URI Error APP-1012",
+			appErrCode:      "APP-1012",
 			expectedDCRCode: ErrorInvalidRedirectURI.Code,
 		},
 		{
-			name:            "Redirect URI Error APP-1015",
+			name:            "Certificate Type Error APP-1014",
+			appErrCode:      "APP-1014",
+			expectedDCRCode: ErrorInvalidClientMetadata.Code,
+		},
+		{
+			name:            "Certificate Value Error APP-1015",
 			appErrCode:      "APP-1015",
-			expectedDCRCode: ErrorInvalidRedirectURI.Code,
+			expectedDCRCode: ErrorInvalidClientMetadata.Code,
 		},
 		{
 			name:            "Server Error APP-5001",
@@ -246,19 +251,14 @@ func (s *DCRServiceTestSuite) TestMapApplicationErrorToDCRError() {
 }
 
 func (s *DCRServiceTestSuite) TestRegisterClient_ConvertDCRToApplicationError() {
+	// A channel value cannot be JSON-marshaled, so JWKS serialization fails and
+	// the request is rejected before reaching the application service.
 	request := &DCRRegistrationRequest{
 		OUID:         "test-ou-1",
 		RedirectURIs: []string{"https://client.example.com/callback"},
 		GrantTypes:   []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
 		JWKS:         map[string]interface{}{"keys": make(chan int)},
 	}
-
-	s.mockAppService.On(
-		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
-	).Return(nil, &serviceerror.ServiceError{
-		Type: serviceerror.ServerErrorType,
-		Code: "APP-5001",
-	})
 
 	response, err := s.service.RegisterClient(context.Background(), request)
 

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -41,9 +41,12 @@ type OAuth2AuthorizationServerMetadata struct {
 // OIDCProviderMetadata represents OpenID Connect Provider Metadata (OIDC Discovery 1.0)
 type OIDCProviderMetadata struct {
 	OAuth2AuthorizationServerMetadata
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
-	ClaimsSupported                  []string `json:"claims_supported"`
-	ClaimsParameterSupported         bool     `json:"claims_parameter_supported"`
-	EndSessionEndpoint               string   `json:"end_session_endpoint,omitempty"`
+	SubjectTypesSupported                []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported     []string `json:"id_token_signing_alg_values_supported"`
+	UserInfoSigningAlgValuesSupported    []string `json:"userinfo_signing_alg_values_supported,omitempty"`
+	UserInfoEncryptionAlgValuesSupported []string `json:"userinfo_encryption_alg_values_supported,omitempty"`
+	UserInfoEncryptionEncValuesSupported []string `json:"userinfo_encryption_enc_values_supported,omitempty"`
+	ClaimsSupported                      []string `json:"claims_supported"`
+	ClaimsParameterSupported             bool     `json:"claims_parameter_supported"`
+	EndSessionEndpoint                   string   `json:"end_session_endpoint,omitempty"`
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -21,6 +21,7 @@ package discovery
 import (
 	"context"
 
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -77,11 +78,14 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMe
 	oauth2Meta := ds.GetOAuth2AuthorizationServerMetadata(ctx)
 
 	return &OIDCProviderMetadata{
-		OAuth2AuthorizationServerMetadata: *oauth2Meta,
-		SubjectTypesSupported:             ds.getSupportedSubjectTypes(),
-		IDTokenSigningAlgValuesSupported:  ds.pkiService.GetSupportedSigningAlgorithms(),
-		ClaimsSupported:                   ds.getSupportedClaims(),
-		ClaimsParameterSupported:          true,
+		OAuth2AuthorizationServerMetadata:    *oauth2Meta,
+		SubjectTypesSupported:                ds.getSupportedSubjectTypes(),
+		IDTokenSigningAlgValuesSupported:     ds.pkiService.GetSupportedSigningAlgorithms(),
+		UserInfoSigningAlgValuesSupported:    ds.pkiService.GetSupportedSigningAlgorithms(),
+		UserInfoEncryptionAlgValuesSupported: appmodel.SupportedUserInfoEncryptionAlgs,
+		UserInfoEncryptionEncValuesSupported: appmodel.SupportedUserInfoEncryptionEncs,
+		ClaimsSupported:                      ds.getSupportedClaims(),
+		ClaimsParameterSupported:             true,
 	}
 }
 

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -80,6 +80,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
 		jwt.TokenTypeAccessToken,
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate access token: %v", err.Error)
@@ -240,6 +241,7 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 		tokenConfig.ValidityPeriod,
 		claims,
 		jwt.TokenTypeJWT,
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate refresh token: %v", err.Error)
@@ -313,6 +315,7 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
 		jwt.TokenTypeJWT,
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ID token: %v", err.Error)

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -113,7 +113,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 				claims["client_id"] == "test-client" &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["name"] == testUserName
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -160,7 +160,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			act, ok := claims["act"].(map[string]interface{})
 			return ok && act["sub"] == "actor123" && act["iss"] == "https://actor-issuer.com"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -202,7 +202,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			act, ok := claims["act"].(map[string]interface{})
 			return ok && act["sub"] == "nested-actor" && act["act"] != nil
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -233,7 +233,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasScope := claims["scope"]
 			return !hasScope
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -264,7 +264,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasClientID := claims["client_id"]
 			return !hasClientID
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -295,7 +295,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasGrantType := claims["grant_type"]
 			return !hasGrantType
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -332,7 +332,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 		"user123",
 		"https://thunder.io", // Thunder-level issuer always used
 		int64(7200),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -366,7 +366,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 		"user123",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",
@@ -411,7 +411,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocal
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["name"] == testUserName &&
 				claims["claims_locales"] == "en-US fr-CA ja"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -458,7 +458,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 				reflect.DeepEqual(claims["access_token_aud"], []string{testAppID}) &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["aci"] == testCacheID
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -495,7 +495,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasAttrCacheID := claims["aci"]
 			return !hasAttrCacheID
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -525,7 +525,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["aci"] == testCacheID
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -556,7 +556,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasScope := claims["scope"]
 			return !hasScope
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -591,7 +591,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -629,7 +629,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["aci"] == testCacheID
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -662,7 +662,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",
@@ -707,7 +707,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLoca
 				reflect.DeepEqual(claims["access_token_aud"], []string{testAppID}) &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["access_token_claims_locales"] == "en-US fr-CA ja"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -743,7 +743,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_Basic() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// sub is passed as first arg to GenerateJWT, not in claims map
 			return claims["auth_time"] == ctx.AuthTime
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -779,7 +779,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithNonce() {
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["nonce"] == "test-nonce-123"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -810,7 +810,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithoutNonce() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, exists := claims["nonce"]
 			return !exists
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -840,7 +840,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoAuthTime() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasAuthTime := claims["auth_time"]
 			return !hasAuthTime
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -882,7 +882,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["name"] == testUserName && claims["email"] == "john@example.com"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -922,7 +922,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithStandardOIDCSco
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Check that both name (from profile scope) and email (from email scope) are present
 			return claims["name"] == testUserName && claims["email"] == "john@example.com"
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -951,7 +951,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoUserAttributes() 
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["auth_time"] == ctx.AuthTime
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -991,7 +991,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_EmptyUserAttributes
 			_, hasName := claims["name"]
 			return claims["auth_time"] == ctx.AuthTime &&
 				!hasName // Should not include name if not in UserAttributes config
-		}), mock.Anything,
+		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -1027,7 +1027,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 		"user123",
 		"https://thunder.io",
 		int64(7200),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -1060,7 +1060,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_JWTGenerationFailed()
 		"user123",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",

--- a/backend/internal/oauth/oauth2/userinfo/error_constants.go
+++ b/backend/internal/oauth/oauth2/userinfo/error_constants.go
@@ -80,4 +80,18 @@ var (
 			DefaultValue: "The 'openid' scope is required for this request",
 		},
 	}
+
+	// errorUserInfoInternalError is returned when an internal error occurs while processing the UserInfo request
+	errorUserInfoInternalError = serviceerror.ServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "server_error",
+		Error: core.I18nMessage{
+			Key:          "error.userinfoservice.internal_server_error",
+			DefaultValue: "Internal server error",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.userinfoservice.internal_server_error_description",
+			DefaultValue: "An internal server error occurred while processing the UserInfo request",
+		},
+	}
 )

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -71,11 +71,16 @@ func (h *userInfoHandler) HandleUserInfo(w http.ResponseWriter, r *http.Request)
 	w.Header().Set(serverconst.CacheControlHeaderName, serverconst.CacheControlNoStore)
 	w.Header().Set(serverconst.PragmaHeaderName, serverconst.PragmaNoCache)
 
-	if result.Type == appmodel.UserInfoResponseTypeJWS {
+	switch result.Type {
+	case appmodel.UserInfoResponseTypeJWS:
 		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJWT)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(result.JWTBody))
-	} else {
+	case appmodel.UserInfoResponseTypeJWE, appmodel.UserInfoResponseTypeNESTEDJWT:
+		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJOSE)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(result.JWTBody))
+	default:
 		utils.WriteSuccessResponse(w, http.StatusOK, result.JSONBody)
 	}
 

--- a/backend/internal/oauth/oauth2/userinfo/init.go
+++ b/backend/internal/oauth/oauth2/userinfo/init.go
@@ -26,6 +26,8 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
+	syshttp "github.com/asgardeo/thunder/internal/system/http"
+	"github.com/asgardeo/thunder/internal/system/jose/jwe"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/transaction"
@@ -35,14 +37,16 @@ import (
 func Initialize(
 	mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface,
+	jweService jwe.JWEServiceInterface,
+	httpClient syshttp.HTTPClientInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	applicationService application.ApplicationServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
 	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	transactioner transaction.Transactioner,
 ) userInfoServiceInterface {
-	userInfoService := newUserInfoService(jwtService, tokenValidator, applicationService, ouService,
-		attributeCacheSvc, transactioner)
+	userInfoService := newUserInfoService(jwtService, jweService, httpClient, tokenValidator,
+		applicationService, ouService, attributeCacheSvc, transactioner)
 	userInfoHandler := newUserInfoHandler(userInfoService)
 	registerRoutes(mux, userInfoHandler)
 	return userInfoService

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -59,7 +59,7 @@ func (suite *InitTestSuite) SetupTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service := Initialize(mux, suite.mockJWTService,
+	service := Initialize(mux, suite.mockJWTService, nil, nil,
 		suite.mockTokenValidator, suite.mockAppService,
 		suite.mockOUService, suite.mockAttributeCacheService, suite.mockTransactioner)
 
@@ -69,7 +69,7 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	Initialize(mux, suite.mockJWTService,
+	Initialize(mux, suite.mockJWTService, nil, nil,
 		suite.mockTokenValidator, suite.mockAppService,
 		suite.mockOUService, suite.mockAttributeCacheService, suite.mockTransactioner)
 

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -21,11 +21,16 @@ package userinfo
 
 import (
 	"context"
+	"crypto"
+	"encoding/json"
+	"io"
+	"net/http"
 	"slices"
 
 	"github.com/asgardeo/thunder/internal/application"
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/attributecache"
+	certmodel "github.com/asgardeo/thunder/internal/cert"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
@@ -33,6 +38,9 @@ import (
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	syshttp "github.com/asgardeo/thunder/internal/system/http"
+	"github.com/asgardeo/thunder/internal/system/jose/jwe"
+	"github.com/asgardeo/thunder/internal/system/jose/jws"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/transaction"
@@ -48,6 +56,8 @@ type userInfoServiceInterface interface {
 // userInfoService implements the userInfoServiceInterface.
 type userInfoService struct {
 	jwtService         jwt.JWTServiceInterface
+	jweService         jwe.JWEServiceInterface
+	httpClient         syshttp.HTTPClientInterface
 	tokenValidator     tokenservice.TokenValidatorInterface
 	applicationService application.ApplicationServiceInterface
 	ouService          ou.OrganizationUnitServiceInterface
@@ -59,6 +69,8 @@ type userInfoService struct {
 // newUserInfoService creates a new userInfoService instance.
 func newUserInfoService(
 	jwtService jwt.JWTServiceInterface,
+	jweService jwe.JWEServiceInterface,
+	httpClient syshttp.HTTPClientInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	applicationService application.ApplicationServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
@@ -67,6 +79,8 @@ func newUserInfoService(
 ) userInfoServiceInterface {
 	return &userInfoService{
 		jwtService:         jwtService,
+		jweService:         jweService,
+		httpClient:         httpClient,
 		tokenValidator:     tokenValidator,
 		applicationService: applicationService,
 		ouService:          ouService,
@@ -103,7 +117,10 @@ func (s *userInfoService) GetUserInfo(
 		return nil, svcErr
 	}
 
-	oauthApp := s.getOAuthApp(ctx, tokenClaims)
+	oauthApp, svcErr := s.getOAuthApp(ctx, tokenClaims)
+	if svcErr != nil {
+		return nil, svcErr
+	}
 
 	// Extract allowed user attributes
 	var allowedUserAttributes []string
@@ -129,20 +146,196 @@ func (s *userInfoService) GetUserInfo(
 		return nil, svcErr
 	}
 
-	// Decide response type
+	var userInfoCfg *appmodel.UserInfoConfig
+	var certificate *appmodel.ApplicationCertificate
+	if oauthApp != nil {
+		userInfoCfg = oauthApp.UserInfo
+		certificate = oauthApp.Certificate
+	}
+
 	responseType := appmodel.UserInfoResponseTypeJSON
-	if oauthApp != nil && oauthApp.UserInfo != nil {
-		responseType = oauthApp.UserInfo.ResponseType
+	if userInfoCfg != nil {
+		responseType = userInfoCfg.ResponseType
+	}
+	switch responseType {
+	case appmodel.UserInfoResponseTypeNESTEDJWT:
+		return s.generateNestedJWTUserInfo(ctx, sub, tokenClaims, response, userInfoCfg, certificate)
+	case appmodel.UserInfoResponseTypeJWE:
+		return s.generateJWEUserInfo(ctx, response, userInfoCfg, certificate)
+	case appmodel.UserInfoResponseTypeJWS:
+		return s.generateJWSUserInfo(sub, tokenClaims, response, userInfoCfg)
+	default:
+		return &UserInfoResponse{Type: appmodel.UserInfoResponseTypeJSON, JSONBody: response}, nil
+	}
+}
+
+// resolveRPPublicKey resolves the RP's public key from the application certificate (AC-5a–5d).
+// It returns the public key and the kid from the matching JWK entry (empty string when absent).
+// encryptionAlg is the key-management algorithm (e.g. "RSA-OAEP-256") used to filter incompatible keys.
+func (s *userInfoService) resolveRPPublicKey(
+	ctx context.Context, certificate *appmodel.ApplicationCertificate, encryptionAlg string,
+) (crypto.PublicKey, string, *serviceerror.ServiceError) {
+	if certificate == nil || certificate.Type == "" {
+		s.logger.Error("No certificate configured for userinfo encryption")
+		return nil, "", &serviceerror.InternalServerError
 	}
 
-	if responseType == appmodel.UserInfoResponseTypeJWS {
-		return s.generateJWSUserInfo(sub, tokenClaims, response)
+	var jwksData []byte
+	switch certificate.Type {
+	case certmodel.CertificateTypeJWKS:
+		jwksData = []byte(certificate.Value)
+	case certmodel.CertificateTypeJWKSURI:
+		body, svcErr := s.fetchJWKS(ctx, certificate.Value)
+		if svcErr != nil {
+			return nil, "", svcErr
+		}
+		jwksData = body
+	default:
+		s.logger.Error("Unsupported certificate type for userinfo encryption",
+			log.String("type", string(certificate.Type)))
+		return nil, "", &serviceerror.InternalServerError
 	}
 
-	return &UserInfoResponse{
-		Type:     appmodel.UserInfoResponseTypeJSON,
-		JSONBody: response,
-	}, nil
+	return s.parseEncryptionKeyFromJWKS(jwksData, encryptionAlg)
+}
+
+// fetchJWKS fetches the JWKS document from the given URI with SSRF protection and a 1 MB size cap.
+func (s *userInfoService) fetchJWKS(ctx context.Context, jwksURI string) ([]byte, *serviceerror.ServiceError) {
+	if err := syshttp.IsSSRFSafeURL(jwksURI); err != nil {
+		s.logger.Error("JWKS URI is not SSRF-safe", log.String("uri", jwksURI), log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
+	if err != nil {
+		s.logger.Error("Failed to build JWKS request", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.Error("Failed to fetch JWKS from URI", log.String("uri", jwksURI), log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		s.logger.Error("JWKS URI returned non-200 status",
+			log.String("uri", jwksURI), log.Int("statusCode", resp.StatusCode))
+		return nil, &serviceerror.InternalServerError
+	}
+	const maxJWKSBytes = 1 << 20 // 1 MB — guards against OOM from a malicious endpoint
+	limitedReader := io.LimitReader(resp.Body, maxJWKSBytes+1)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		s.logger.Error("Failed to read JWKS response body", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	if len(body) > maxJWKSBytes {
+		s.logger.Error("JWKS URI response exceeds 1 MB size limit", log.String("uri", jwksURI))
+		return nil, &serviceerror.InternalServerError
+	}
+	return body, nil
+}
+
+// parseEncryptionKeyFromJWKS finds the first RSA enc key in the JWKS that matches encryptionAlg.
+// Returns the public key and its kid (empty when absent in the JWK entry).
+func (s *userInfoService) parseEncryptionKeyFromJWKS(
+	jwksData []byte, encryptionAlg string,
+) (crypto.PublicKey, string, *serviceerror.ServiceError) {
+	var jwksObj struct {
+		Keys []map[string]interface{} `json:"keys"`
+	}
+	if err := json.Unmarshal(jwksData, &jwksObj); err != nil {
+		s.logger.Error("Failed to parse JWKS for userinfo encryption", log.Error(err))
+		return nil, "", &serviceerror.InternalServerError
+	}
+
+	for _, key := range jwksObj.Keys {
+		use, _ := key["use"].(string)
+		if use != "enc" {
+			continue
+		}
+		kty, _ := key["kty"].(string)
+		if kty != "RSA" {
+			continue
+		}
+		if keyAlg, _ := key["alg"].(string); keyAlg != "" && keyAlg != encryptionAlg {
+			continue
+		}
+		pub, err := jws.JWKToPublicKey(key)
+		if err == nil && pub != nil {
+			kid, _ := key["kid"].(string)
+			return pub, kid, nil
+		}
+	}
+
+	s.logger.Error("No suitable encryption key found in JWKS")
+	return nil, "", &serviceerror.InternalServerError
+}
+
+// generateJWEUserInfo creates an encrypted JWE UserInfo response (AC-6a–6c).
+func (s *userInfoService) generateJWEUserInfo(
+	ctx context.Context,
+	response map[string]interface{},
+	cfg *appmodel.UserInfoConfig,
+	certificate *appmodel.ApplicationCertificate,
+) (*UserInfoResponse, *serviceerror.ServiceError) {
+	rpKey, rpKID, svcErr := s.resolveRPPublicKey(ctx, certificate, cfg.EncryptionAlg)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	payload, err := json.Marshal(response)
+	if err != nil {
+		s.logger.Error("Failed to marshal userinfo claims for JWE")
+		return nil, &serviceerror.InternalServerError
+	}
+
+	compact, svcErr := s.jweService.Encrypt(
+		payload, rpKey,
+		jwe.KeyEncAlgorithm(cfg.EncryptionAlg),
+		jwe.ContentEncAlgorithm(cfg.EncryptionEnc),
+		"json",
+		rpKID,
+	)
+	if svcErr != nil {
+		s.logger.Error("Failed to encrypt userinfo JWE")
+		return nil, svcErr
+	}
+
+	return &UserInfoResponse{Type: appmodel.UserInfoResponseTypeJWE, JWTBody: compact}, nil
+}
+
+// generateNestedJWTUserInfo creates a sign-then-encrypt Nested JWT UserInfo response (AC-7a–7c).
+func (s *userInfoService) generateNestedJWTUserInfo(
+	ctx context.Context,
+	sub string,
+	tokenClaims map[string]interface{},
+	response map[string]interface{},
+	cfg *appmodel.UserInfoConfig,
+	certificate *appmodel.ApplicationCertificate,
+) (*UserInfoResponse, *serviceerror.ServiceError) {
+	jwsResp, svcErr := s.generateJWSUserInfo(sub, tokenClaims, response, cfg)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	rpKey, rpKID, svcErr := s.resolveRPPublicKey(ctx, certificate, cfg.EncryptionAlg)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	compact, svcErr := s.jweService.Encrypt(
+		[]byte(jwsResp.JWTBody), rpKey,
+		jwe.KeyEncAlgorithm(cfg.EncryptionAlg),
+		jwe.ContentEncAlgorithm(cfg.EncryptionEnc),
+		"JWT",
+		rpKID,
+	)
+	if svcErr != nil {
+		s.logger.Error("Failed to encrypt nested JWT userinfo JWE")
+		return nil, svcErr
+	}
+
+	return &UserInfoResponse{Type: appmodel.UserInfoResponseTypeNESTEDJWT, JWTBody: compact}, nil
 }
 
 // generateJWSUserInfo creates a signed JWT UserInfo response
@@ -151,6 +344,7 @@ func (s *userInfoService) generateJWSUserInfo(
 	sub string,
 	tokenClaims map[string]interface{},
 	response map[string]interface{},
+	cfg *appmodel.UserInfoConfig,
 ) (*UserInfoResponse, *serviceerror.ServiceError) {
 	clientID := ""
 	if cid, ok := tokenClaims["client_id"].(string); ok {
@@ -163,6 +357,10 @@ func (s *userInfoService) generateJWSUserInfo(
 	validity := runtime.Config.JWT.ValidityPeriod
 
 	response["aud"] = clientID
+	signingAlg := ""
+	if cfg != nil {
+		signingAlg = cfg.SigningAlg
+	}
 
 	signedJWT, _, err := s.jwtService.GenerateJWT(
 		sub,
@@ -170,9 +368,16 @@ func (s *userInfoService) generateJWSUserInfo(
 		validity,
 		response,
 		jwt.TokenTypeJWT,
+		signingAlg,
 	)
 	if err != nil {
-		s.logger.Error("Failed to generate signed UserInfo JWT")
+		if err.Code == jwt.ErrorUnsupportedJWSAlgorithm.Code {
+			s.logger.Error("UserInfo signing algorithm is not supported by the server key",
+				log.String("alg", signingAlg), log.String("error", err.Error.DefaultValue))
+		} else {
+			s.logger.Error("Failed to generate signed UserInfo JWT",
+				log.String("error", err.Error.DefaultValue))
+		}
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -229,19 +434,28 @@ func (s *userInfoService) validateOpenIDScope(scopes []string) *serviceerror.Ser
 }
 
 // getOAuthApp retrieves the OAuth application configuration if client_id is present in claims.
+// Returns (nil, nil) when no client_id is present — plain JSON is acceptable.
+// Returns (nil, err) on a DB/service error — caller must propagate.
+// Returns (nil, errorInvalidAccessToken) when the app is not found — stale or orphaned token.
 func (s *userInfoService) getOAuthApp(
-	ctx context.Context, claims map[string]interface{}) *appmodel.OAuthAppConfigProcessedDTO {
+	ctx context.Context, claims map[string]interface{},
+) (*appmodel.OAuthAppConfigProcessedDTO, *serviceerror.ServiceError) {
 	clientID, ok := claims["client_id"].(string)
 	if !ok || clientID == "" {
-		return nil
+		return nil, nil
 	}
 
 	app, err := s.applicationService.GetOAuthApplication(ctx, clientID)
-	if err != nil || app == nil {
-		return nil
+	if err != nil {
+		s.logger.Error("Failed to retrieve OAuth application for UserInfo",
+			log.String("code", err.Code), log.String("error", err.Error.DefaultValue))
+		return nil, &errorUserInfoInternalError
+	}
+	if app == nil {
+		return nil, &errorInvalidAccessToken
 	}
 
-	return app
+	return app, nil
 }
 
 // buildUserInfoResponse builds the final UserInfo response from sub, scopes, and user attributes.

--- a/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package userinfo
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	certmodel "github.com/asgardeo/thunder/internal/cert"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/jose/jwe"
+	"github.com/asgardeo/thunder/internal/system/jose/jwt"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/tests/mocks/httpmock"
+	"github.com/asgardeo/thunder/tests/mocks/jose/jwemock"
+	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
+)
+
+const testJWKSURI = "https://rp.example.com/jwks"
+
+// JWEUserInfoTestSuite defines the test suite for JWE/JWS userinfo generation.
+type JWEUserInfoTestSuite struct {
+	suite.Suite
+}
+
+// TestJWEUserInfoSuite runs the JWE userinfo test suite.
+func TestJWEUserInfoSuite(t *testing.T) {
+	suite.Run(t, new(JWEUserInfoTestSuite))
+}
+
+func (s *JWEUserInfoTestSuite) SetupTest() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test-home", &config.Config{
+		JWT: config.JWTConfig{Issuer: "test-issuer", ValidityPeriod: 600},
+	})
+}
+
+func (s *JWEUserInfoTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
+}
+
+// TestGenerateJWEUserInfo_Success verifies a JWE response from an inline JWKS.
+func (s *JWEUserInfoTestSuite) TestGenerateJWEUserInfo_Success() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	mockJWE.On("Encrypt",
+		mock.Anything, mock.Anything,
+		jwe.KeyEncAlgorithm("RSA-OAEP-256"),
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"json",
+		"",
+	).Return("compact.jwe.token", (*serviceerror.ServiceError)(nil))
+
+	svc := &userInfoService{jweService: mockJWE, logger: log.GetLogger()}
+	cfg := &appmodel.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	result, svcErr := svc.generateJWEUserInfo(context.Background(), map[string]interface{}{"sub": "user1"}, cfg, cert)
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), result)
+	assert.Equal(s.T(), appmodel.UserInfoResponseTypeJWE, result.Type)
+	assert.Equal(s.T(), "compact.jwe.token", result.JWTBody)
+}
+
+// TestGenerateJWEUserInfo_NoCert verifies missing cert returns server error.
+func (s *JWEUserInfoTestSuite) TestGenerateJWEUserInfo_NoCert() {
+	svc := &userInfoService{jweService: jwemock.NewJWEServiceInterfaceMock(s.T()), logger: log.GetLogger()}
+	cfg := &appmodel.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+
+	result, svcErr := svc.generateJWEUserInfo(context.Background(), map[string]interface{}{"sub": "user1"}, cfg, nil)
+	assert.Nil(s.T(), result)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestGenerateJWEUserInfo_EncryptFailure verifies JWE encryption failure returns server error.
+func (s *JWEUserInfoTestSuite) TestGenerateJWEUserInfo_EncryptFailure() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	mockJWE.On("Encrypt",
+		mock.Anything, mock.Anything,
+		jwe.KeyEncAlgorithm("RSA-OAEP-256"),
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"json",
+		"",
+	).Return("", &serviceerror.InternalServerError)
+
+	svc := &userInfoService{jweService: mockJWE, logger: log.GetLogger()}
+	cfg := &appmodel.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	result, svcErr := svc.generateJWEUserInfo(context.Background(), map[string]interface{}{"sub": "user1"}, cfg, cert)
+	assert.Nil(s.T(), result)
+	assert.NotNil(s.T(), svcErr)
+}
+
+// TestResolveRPPublicKey_InlineJWKS verifies key resolution from inline JWKS with use=enc.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_InlineJWKS() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	svc := &userInfoService{logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), pub)
+}
+
+// TestResolveRPPublicKey_NoUseField verifies a key without 'use' field is rejected
+// (RFC 7517 §4.2: keys without use must not be assumed encryption-capable).
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_NoUseField() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "")
+
+	svc := &userInfoService{logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.NotNil(s.T(), svcErr)
+	assert.Nil(s.T(), pub)
+}
+
+// TestResolveRPPublicKey_JWKSURI verifies key resolution by fetching from a URI.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_JWKSURI() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	mockHTTP := httpmock.NewHTTPClientInterfaceMock(s.T())
+	mockHTTP.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.String() == testJWKSURI && req.Method == http.MethodGet
+	})).Return(
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(pubJWKS)),
+		}, nil,
+	)
+
+	svc := &userInfoService{httpClient: mockHTTP, logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{
+		Type:  certmodel.CertificateTypeJWKSURI,
+		Value: testJWKSURI,
+	}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), pub)
+}
+
+// TestResolveRPPublicKey_URIFetchError verifies HTTP error returns server error.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_URIFetchError() {
+	mockHTTP := httpmock.NewHTTPClientInterfaceMock(s.T())
+	mockHTTP.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.String() == testJWKSURI
+	})).Return(nil, errors.New("connection refused"))
+
+	svc := &userInfoService{httpClient: mockHTTP, logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{
+		Type:  certmodel.CertificateTypeJWKSURI,
+		Value: testJWKSURI,
+	}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), pub)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResolveRPPublicKey_JWKSURINon200 verifies that a non-200 HTTP response is rejected.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_JWKSURINon200() {
+	mockHTTP := httpmock.NewHTTPClientInterfaceMock(s.T())
+	mockHTTP.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.String() == testJWKSURI
+	})).Return(
+		&http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil,
+	)
+
+	svc := &userInfoService{httpClient: mockHTTP, logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{
+		Type:  certmodel.CertificateTypeJWKSURI,
+		Value: testJWKSURI,
+	}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), pub)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResolveRPPublicKey_JWKSURITooLarge verifies that an oversized JWKS response is rejected
+// specifically by the size gate and not by a JSON parse failure on the truncated body.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_JWKSURITooLarge() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	validJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+	// Pad the valid JWKS with a large custom field so its total size exceeds 1 MB.
+	// This ensures the test exercises the size-cap path, not a JSON parse error.
+	padding := strings.Repeat("a", (1<<20)+1)
+	oversizedBody := validJWKS[:len(validJWKS)-1] + `,"x-padding":"` + padding + `"}`
+	mockHTTP := httpmock.NewHTTPClientInterfaceMock(s.T())
+	mockHTTP.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.String() == testJWKSURI
+	})).Return(
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(oversizedBody)),
+		}, nil,
+	)
+
+	svc := &userInfoService{httpClient: mockHTTP, logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{
+		Type:  certmodel.CertificateTypeJWKSURI,
+		Value: testJWKSURI,
+	}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), pub)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResolveRPPublicKey_NoCert verifies nil cert returns server error.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_NoCert() {
+	svc := &userInfoService{logger: log.GetLogger()}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), nil, "RSA-OAEP-256")
+	assert.Nil(s.T(), pub)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResolveRPPublicKey_SigOnlyKey verifies a sig-only JWKS returns server error.
+func (s *JWEUserInfoTestSuite) TestResolveRPPublicKey_SigOnlyKey() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "sig")
+
+	svc := &userInfoService{logger: log.GetLogger()}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	pub, _, svcErr := svc.resolveRPPublicKey(context.Background(), cert, "RSA-OAEP-256")
+	assert.Nil(s.T(), pub)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestGenerateNestedJWTUserInfo_Success verifies a sign-then-encrypt nested JWT.
+func (s *JWEUserInfoTestSuite) TestGenerateNestedJWTUserInfo_Success() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	mockJWT := jwtmock.NewJWTServiceInterfaceMock(s.T())
+	mockJWT.On("GenerateJWT",
+		"user1", "test-issuer", int64(600),
+		mock.Anything, mock.Anything, "RS256",
+	).Return("signed.jwt.token", int64(0), (*serviceerror.ServiceError)(nil))
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	mockJWE.On("Encrypt",
+		mock.Anything, mock.Anything,
+		jwe.KeyEncAlgorithm("RSA-OAEP-256"),
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"JWT",
+		"",
+	).Return("nested.jwe.token", (*serviceerror.ServiceError)(nil))
+
+	svc := &userInfoService{
+		jwtService: mockJWT,
+		jweService: mockJWE,
+		logger:     log.GetLogger(),
+	}
+
+	cfg := &appmodel.UserInfoConfig{SigningAlg: "RS256", EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	result, svcErr := svc.generateNestedJWTUserInfo(
+		context.Background(),
+		"user1",
+		map[string]interface{}{"client_id": "client1"},
+		map[string]interface{}{"sub": "user1"},
+		cfg,
+		cert,
+	)
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), result)
+	assert.Equal(s.T(), appmodel.UserInfoResponseTypeNESTEDJWT, result.Type)
+	assert.Equal(s.T(), "nested.jwe.token", result.JWTBody)
+}
+
+// TestGenerateJWEUserInfo_EncryptErrorPropagated verifies that the exact error from Encrypt is returned,
+// not a generic InternalServerError.
+func (s *JWEUserInfoTestSuite) TestGenerateJWEUserInfo_EncryptErrorPropagated() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey, "enc")
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	unsupportedErr := &serviceerror.ServiceError{Code: "JWE-1003", Type: serviceerror.ClientErrorType}
+	mockJWE.On("Encrypt",
+		mock.Anything, mock.Anything,
+		jwe.KeyEncAlgorithm("RSA-OAEP-256"),
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"json",
+		"",
+	).Return("", unsupportedErr)
+
+	svc := &userInfoService{jweService: mockJWE, logger: log.GetLogger()}
+	cfg := &appmodel.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+	cert := &appmodel.ApplicationCertificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	result, svcErr := svc.generateJWEUserInfo(context.Background(), map[string]interface{}{"sub": "user1"}, cfg, cert)
+	assert.Nil(s.T(), result)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), "JWE-1003", svcErr.Code)
+}
+
+// TestGenerateJWSUserInfo_UnsupportedAlg verifies that an algorithm incompatible with the server key
+// returns InternalServerError (server misconfiguration, not a client auth error).
+func (s *JWEUserInfoTestSuite) TestGenerateJWSUserInfo_UnsupportedAlg() {
+	mockJWT := jwtmock.NewJWTServiceInterfaceMock(s.T())
+	mockJWT.On("GenerateJWT",
+		"user1", "test-issuer", int64(600),
+		mock.Anything, mock.Anything, "ES256",
+	).Return("", int64(0), &jwt.ErrorUnsupportedJWSAlgorithm)
+
+	svc := &userInfoService{jwtService: mockJWT, logger: log.GetLogger()}
+	cfg := &appmodel.UserInfoConfig{SigningAlg: "ES256"}
+
+	result, svcErr := svc.generateJWSUserInfo(
+		"user1",
+		map[string]interface{}{"client_id": "client1"},
+		map[string]interface{}{"sub": "user1"},
+		cfg,
+	)
+	assert.Nil(s.T(), result)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// rsaPublicKeyToJWKS builds a minimal RSA JWKS JSON for tests.
+// Pass use="" to omit the 'use' field.
+func rsaPublicKeyToJWKS(pub *rsa.PublicKey, use string) string {
+	eBytes := big.NewInt(int64(pub.E)).Bytes()
+	key := map[string]interface{}{
+		"kty": "RSA",
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+	}
+	if use != "" {
+		key["use"] = use
+	}
+	b, _ := json.Marshal(map[string]interface{}{"keys": []interface{}{key}})
+	return string(b)
+}

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -79,7 +79,7 @@ func (s *UserInfoServiceTestSuite) SetupTest() {
 	s.mockAttributeCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(s.T())
 	s.mockTransactioner = &MockTransactioner{}
 	s.userInfoService = newUserInfoService(
-		s.mockJWTService, s.mockTokenValidator,
+		s.mockJWTService, nil, nil, s.mockTokenValidator,
 		s.mockAppService, s.mockOUService,
 		s.mockAttributeCacheService, s.mockTransactioner)
 
@@ -443,41 +443,29 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
-// TestGetUserInfo_Success_AppNotFound tests successful response when app is not found
-func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_AppNotFound() {
+// TestGetUserInfo_AppNotFound_ReturnsInvalidToken tests that a stale/orphaned token returns an error
+// when the referenced client application no longer exists.
+func (s *UserInfoServiceTestSuite) TestGetUserInfo_AppNotFound_ReturnsInvalidToken() {
 	claims := map[string]interface{}{
 		"exp":       float64(time.Now().Add(time.Hour).Unix()),
 		"nbf":       float64(time.Now().Add(-time.Minute).Unix()),
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
-		"aci":       "cache-anf-123",
 	}
 	token := s.createToken(claims)
 
-	userAttrs := map[string]interface{}{
-		"name": "John Doe",
-	}
-
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-anf-123").Return(
-		&attributecache.AttributeCache{ID: "cache-anf-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(nil, &serviceerror.ServiceError{
 		Code:  "APP_NOT_FOUND",
 		Error: core.I18nMessage{Key: "error.test.app_not_found", DefaultValue: "App not found"},
 	})
 
-	// When app not found, continue without app config
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
-	assert.Nil(s.T(), svcErr)
-	assert.NotNil(s.T(), response)
-	assert.Equal(s.T(), appmodel.UserInfoResponseTypeJSON, response.Type)
-	assert.Equal(s.T(), "user123", response.JSONBody["sub"])
-	// No other claims because allowedUserAttributes is empty
-	assert.Len(s.T(), response.JSONBody, 1)
+	assert.Nil(s.T(), response)
+	assert.NotNil(s.T(), svcErr)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -1079,6 +1067,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 		Token: &appmodel.OAuthTokenConfig{},
 		UserInfo: &appmodel.UserInfoConfig{
 			ResponseType:   appmodel.UserInfoResponseTypeJWS,
+			SigningAlg:     "RS256",
 			UserAttributes: []string{"email"},
 		},
 	}
@@ -1104,6 +1093,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
 		mock.Anything,
 		mock.Anything,
+		"RS256",
 	).Return("signed.jwt.token", int64(0), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -1141,6 +1131,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 		Token: &appmodel.OAuthTokenConfig{},
 		UserInfo: &appmodel.UserInfoConfig{
 			ResponseType:   appmodel.UserInfoResponseTypeJWS,
+			SigningAlg:     "RS256",
 			UserAttributes: []string{"email"},
 		},
 	}
@@ -1162,6 +1153,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
 		mock.Anything,
 		mock.Anything,
+		"RS256",
 	).Return("", int64(0),
 		&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -50,6 +50,9 @@ const ContentTypeJSON = "application/json"
 // ContentTypeJWT is the content type for JWT data.
 const ContentTypeJWT = "application/jwt"
 
+// ContentTypeJOSE is the content type for JWE (encrypted) data.
+const ContentTypeJOSE = "application/jose"
+
 // ContentTypeFormURLEncoded is the content type for form-urlencoded data.
 const ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
 

--- a/backend/internal/system/http/httpclient.go
+++ b/backend/internal/system/http/httpclient.go
@@ -32,8 +32,12 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -80,6 +84,112 @@ func NewHTTPClientWithTimeout(timeout time.Duration) HTTPClientInterface {
 			},
 		},
 	}
+}
+
+// NewHTTPClientWithCheckRedirect creates an HTTPClient with a custom redirect policy.
+// Use this when redirect behavior must be controlled, e.g. to prevent HTTPS→HTTP downgrades.
+// Requires ThunderRuntime to be initialized before calling (reads TLS config at construction time).
+// ssrfSafeDialContext is wired in to block hostnames that DNS-resolve to private/loopback addresses
+// and to pin the TCP connection to the first validated IP (prevents DNS rebinding).
+func NewHTTPClientWithCheckRedirect(checkRedirect func(*http.Request, []*http.Request) error) HTTPClientInterface {
+	return &HTTPClient{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				DialContext: ssrfSafeDialContext,
+				// #nosec G402 -- Min TLS version is TLS 1.2 or higher based on config
+				TLSClientConfig: &tls.Config{
+					MinVersion: GetTLSVersion(config.GetThunderRuntime().Config),
+				},
+			},
+			CheckRedirect: checkRedirect,
+		},
+	}
+}
+
+// ssrfSafeDialContext resolves the target hostname and validates every returned IP against
+// privateIPRanges before dialing. Connecting to the first validated IP directly pins the
+// connection and prevents DNS rebinding attacks. TLS hostname verification is unaffected:
+// http.Transport derives ServerName from the request URL (not addr) when TLSClientConfig.ServerName
+// is empty, so the certificate is still validated against the original hostname.
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// addr has no port (unlikely from http.Transport, but handle defensively)
+		host = addr
+		port = "443"
+	}
+
+	ipAddrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	var safeIP net.IP
+	for _, ia := range ipAddrs {
+		for _, block := range privateIPRanges {
+			if block.Contains(ia.IP) {
+				return nil, fmt.Errorf("host %q resolves to a private address %s", host, ia.IP)
+			}
+		}
+		if safeIP == nil {
+			safeIP = ia.IP
+		}
+	}
+	if safeIP == nil {
+		return nil, fmt.Errorf("host %q resolved to no usable addresses", host)
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(safeIP.String(), port))
+}
+
+// privateIPRanges lists CIDR blocks that must not be used as JWKS fetch targets.
+// Covers IPv4/IPv6 loopback, link-local (including cloud metadata services), and
+// RFC1918/unique-local private ranges.
+var privateIPRanges = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8",    // IPv4 loopback
+		"::1/128",        // IPv6 loopback
+		"169.254.0.0/16", // IPv4 link-local (AWS/GCP metadata: 169.254.169.254)
+		"fe80::/10",      // IPv6 link-local
+		"10.0.0.0/8",     // RFC1918 private
+		"172.16.0.0/12",  // RFC1918 private
+		"192.168.0.0/16", // RFC1918 private
+		"fc00::/7",       // IPv6 unique-local
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, ipNet, _ := net.ParseCIDR(c)
+		nets = append(nets, ipNet)
+	}
+	return nets
+}()
+
+// IsSSRFSafeURL reports whether rawURL is safe for server-side fetching.
+// It requires HTTPS and rejects hosts that are IP literals in loopback, link-local,
+// or private ranges to mitigate server-side request forgery. Hostnames are not
+// DNS-resolved here; apply this check again to redirect targets at fetch time.
+func IsSSRFSafeURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return errors.New("URL must use HTTPS")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("URL has no host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		for _, block := range privateIPRanges {
+			if block.Contains(ip) {
+				return fmt.Errorf("host %q is a loopback, link-local, or private address", host)
+			}
+		}
+	}
+	return nil
 }
 
 // Do executes an HTTP request and returns an HTTP response.

--- a/backend/internal/system/http/httpclient_test.go
+++ b/backend/internal/system/http/httpclient_test.go
@@ -19,6 +19,7 @@
 package http
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -234,6 +235,34 @@ func (suite *HTTPClientTestSuite) TestPost() {
 	assert.Equal(suite.T(), http.StatusCreated, resp.StatusCode)
 
 	_ = resp.Body.Close()
+}
+
+func (suite *HTTPClientTestSuite) TestSSRFSafeDialContext() {
+	// IP literals — LookupIPAddr returns them directly without DNS, so this exercises
+	// the same validation path as a hostname that DNS-resolves to a private address.
+	blockedAddrs := []string{
+		"127.0.0.1:443",       // IPv4 loopback
+		"169.254.169.254:443", // IPv4 link-local (cloud metadata)
+		"10.0.0.1:443",        // RFC1918
+		"172.16.0.1:443",      // RFC1918
+		"192.168.1.1:443",     // RFC1918
+		"[::1]:443",           // IPv6 loopback
+		"[fc00::1]:443",       // IPv6 unique-local (ULA)
+		"[fe80::1]:443",       // IPv6 link-local
+	}
+	for _, addr := range blockedAddrs {
+		_, err := ssrfSafeDialContext(context.Background(), "tcp", addr)
+		assert.ErrorContains(suite.T(), err, "private address", "addr %s should be blocked", addr)
+	}
+
+	// Public IP: SSRF check passes; use a 1 ms deadline so the TCP dial fails immediately
+	// without waiting for a real network round-trip.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	_, err := ssrfSafeDialContext(ctx, "tcp", "1.1.1.1:443")
+	assert.Error(suite.T(), err)
+	assert.NotContains(suite.T(), err.Error(), "private address")
+	assert.NotContains(suite.T(), err.Error(), "resolved to no usable")
 }
 
 func (suite *HTTPClientTestSuite) TestPostForm() {

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -660,6 +660,8 @@ var defaultMessages = map[string]string{
 	"error.userinfoservice.client_credentials_not_supported_description": "UserInfo endpoint is not applicable for client_credentials grant type",
 	"error.userinfoservice.insufficient_scope": "Insufficient scope",
 	"error.userinfoservice.insufficient_scope_description": "The 'openid' scope is required for this request",
+	"error.userinfoservice.internal_server_error": "Internal server error",
+	"error.userinfoservice.internal_server_error_description": "An internal server error occurred while processing the UserInfo request",
 	"error.userinfoservice.invalid_access_token": "Invalid access token",
 	"error.userinfoservice.invalid_access_token_description": "The access token is invalid, expired, or malformed",
 	"error.userinfoservice.missing_sub_claim": "Invalid access token",

--- a/backend/internal/system/jose/jwe/model.go
+++ b/backend/internal/system/jose/jwe/model.go
@@ -22,24 +22,46 @@ package jwe
 type KeyEncAlgorithm string
 
 const (
-	// RSAOAEP256 represents RSA-OAEP using SHA-256 key encryption
+	// RSAOAEP uses SHA-1 for OAEP masking (RFC 7518 §4.3). Prefer RSAOAEP256 for new deployments.
+	RSAOAEP KeyEncAlgorithm = "RSA-OAEP"
+	// RSAOAEP256 represents RSA-OAEP using SHA-256 key encryption (RFC 7518 §4.3)
 	RSAOAEP256 KeyEncAlgorithm = "RSA-OAEP-256"
-	// ECDHES represents ECDH-ES key encryption
+	// A128KW represents AES Key Wrap with 128-bit key (RFC 7518 §4.4)
+	A128KW KeyEncAlgorithm = "A128KW"
+	// A192KW represents AES Key Wrap with 192-bit key (RFC 7518 §4.4)
+	A192KW KeyEncAlgorithm = "A192KW"
+	// A256KW represents AES Key Wrap with 256-bit key (RFC 7518 §4.4)
+	A256KW KeyEncAlgorithm = "A256KW"
+	// ECDHES represents ECDH-ES key encryption (RFC 7518 §4.6)
 	ECDHES KeyEncAlgorithm = "ECDH-ES"
-	// ECDHESA128KW represents ECDH-ES with AES 128 Key Wrap
+	// ECDHESA128KW represents ECDH-ES with AES 128-bit Key Wrap (RFC 7518 §4.6)
 	ECDHESA128KW KeyEncAlgorithm = "ECDH-ES+A128KW"
-	// ECDHESA256KW represents ECDH-ES with AES 256 Key Wrap
+	// ECDHESA192KW represents ECDH-ES with AES 192-bit Key Wrap (RFC 7518 §4.6)
+	ECDHESA192KW KeyEncAlgorithm = "ECDH-ES+A192KW"
+	// ECDHESA256KW represents ECDH-ES with AES 256-bit Key Wrap (RFC 7518 §4.6)
 	ECDHESA256KW KeyEncAlgorithm = "ECDH-ES+A256KW"
+	// A128GCMKW represents AES GCM Key Wrap with 128-bit key (RFC 7518 §4.7)
+	A128GCMKW KeyEncAlgorithm = "A128GCMKW"
+	// A192GCMKW represents AES GCM Key Wrap with 192-bit key (RFC 7518 §4.7)
+	A192GCMKW KeyEncAlgorithm = "A192GCMKW"
+	// A256GCMKW represents AES GCM Key Wrap with 256-bit key (RFC 7518 §4.7)
+	A256GCMKW KeyEncAlgorithm = "A256GCMKW"
 )
 
 // ContentEncAlgorithm represents the JWE content encryption algorithm (enc header parameter)
 type ContentEncAlgorithm string
 
 const (
-	// A128GCM represents AES GCM using 128-bit key
+	// A128CBCHS256 represents AES-128-CBC with HMAC-SHA-256 content encryption (RFC 7518 §5.2)
+	A128CBCHS256 ContentEncAlgorithm = "A128CBC-HS256"
+	// A192CBCHS384 represents AES-192-CBC with HMAC-SHA-384 content encryption (RFC 7518 §5.2)
+	A192CBCHS384 ContentEncAlgorithm = "A192CBC-HS384"
+	// A256CBCHS512 represents AES-256-CBC with HMAC-SHA-512 content encryption (RFC 7518 §5.2)
+	A256CBCHS512 ContentEncAlgorithm = "A256CBC-HS512"
+	// A128GCM represents AES GCM using 128-bit key (RFC 7518 §5.3)
 	A128GCM ContentEncAlgorithm = "A128GCM"
-	// A192GCM represents AES GCM using 192-bit key
+	// A192GCM represents AES GCM using 192-bit key (RFC 7518 §5.3)
 	A192GCM ContentEncAlgorithm = "A192GCM"
-	// A256GCM represents AES GCM using 256-bit key
+	// A256GCM represents AES GCM using 256-bit key (RFC 7518 §5.3)
 	A256GCM ContentEncAlgorithm = "A256GCM"
 )

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -35,7 +35,7 @@ import (
 // JWEServiceInterface defines the interface for JWE operations.
 type JWEServiceInterface interface {
 	Encrypt(payload []byte, recipientPublicKey crypto.PublicKey,
-		alg KeyEncAlgorithm, enc ContentEncAlgorithm) (string, *serviceerror.ServiceError)
+		alg KeyEncAlgorithm, enc ContentEncAlgorithm, cty string, kid string) (string, *serviceerror.ServiceError)
 	Decrypt(jweToken string) ([]byte, *serviceerror.ServiceError)
 }
 
@@ -66,11 +66,19 @@ func newJWEService(pkiService pki.PKIServiceInterface) (JWEServiceInterface, err
 }
 
 // Encrypt encrypts the payload using the recipient's public key.
+// cty is the content type placed in the JWE protected header (e.g. "json" or "JWT").
+// kid identifies the recipient's key; it is stamped in the header only when non-empty.
 func (js *jweService) Encrypt(payload []byte, recipientPublicKey crypto.PublicKey,
-	alg KeyEncAlgorithm, enc ContentEncAlgorithm) (string, *serviceerror.ServiceError) {
+	alg KeyEncAlgorithm, enc ContentEncAlgorithm, cty string, kid string) (string, *serviceerror.ServiceError) {
 	// 1. Generate CEK
 	cekSize := 0
 	switch enc {
+	case A128CBCHS256:
+		cekSize = 32
+	case A192CBCHS384:
+		cekSize = 48
+	case A256CBCHS512:
+		cekSize = 64
 	case A128GCM:
 		cekSize = 16
 	case A192GCM:
@@ -96,10 +104,15 @@ func (js *jweService) Encrypt(payload []byte, recipientPublicKey crypto.PublicKe
 
 	// 3. Create Header
 	header := map[string]interface{}{
+		"typ": "JWE",
 		"alg": string(alg),
 		"enc": string(enc),
-		"typ": "JWE",
-		"kid": js.kid,
+	}
+	if kid != "" {
+		header["kid"] = kid
+	}
+	if cty != "" {
+		header["cty"] = cty
 	}
 
 	// Add extras (like epk for ECDH-ES)

--- a/backend/internal/system/jose/jwe/service_test.go
+++ b/backend/internal/system/jose/jwe/service_test.go
@@ -80,7 +80,7 @@ func (suite *JWEServiceTestSuite) TestEncryptDecrypt_RSA() {
 	// RSA-OAEP-256 with different content encryption algorithms
 	encAlgs := []ContentEncAlgorithm{A128GCM, A192GCM, A256GCM}
 	for _, enc := range encAlgs {
-		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, RSAOAEP256, enc)
+		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, RSAOAEP256, enc, "", "")
 		assert.Nil(suite.T(), sErr)
 		decrypted, sErr := suite.jweService.Decrypt(jweToken)
 		assert.Nil(suite.T(), sErr)
@@ -110,7 +110,7 @@ func (suite *JWEServiceTestSuite) TestEncryptDecrypt_ECDH() {
 	}
 
 	for _, tc := range testCases {
-		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, tc.alg, tc.enc)
+		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, tc.alg, tc.enc, "", "")
 		assert.Nil(suite.T(), sErr)
 		decrypted, sErr := suite.jweService.Decrypt(jweToken)
 		assert.Nil(suite.T(), sErr)
@@ -126,12 +126,12 @@ func (suite *JWEServiceTestSuite) TestEncrypt_Errors() {
 	}
 
 	// Unsupported Encryption algorithm
-	_, sErr := suite.jweService.Encrypt([]byte("p"), &suite.testRSAPrivateKey.PublicKey, RSAOAEP256, "INVALID")
+	_, sErr := suite.jweService.Encrypt([]byte("p"), &suite.testRSAPrivateKey.PublicKey, RSAOAEP256, "INVALID", "", "")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorUnsupportedEncryptionAlgorithm, *sErr)
 
 	// EncryptKey failure (RSA with EC key)
-	_, sErr = suite.jweService.Encrypt([]byte("p"), &suite.testECPrivateKey.PublicKey, RSAOAEP256, A128GCM)
+	_, sErr = suite.jweService.Encrypt([]byte("p"), &suite.testECPrivateKey.PublicKey, RSAOAEP256, A128GCM, "", "")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorUnsupportedJWEAlgorithm, *sErr)
 }
@@ -150,7 +150,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_Errors() {
 
 	// DecryptKey failure (tampered encrypted key)
 	payload := []byte("data")
-	jweToken, _ := suite.jweService.Encrypt(payload, &suite.testRSAPrivateKey.PublicKey, RSAOAEP256, A128GCM)
+	jweToken, _ := suite.jweService.Encrypt(payload, &suite.testRSAPrivateKey.PublicKey, RSAOAEP256, A128GCM, "", "")
 
 	suite.jweService.privateKey = suite.testECPrivateKey // Wrong key type for RSA-OAEP-256
 	_, sErr = suite.jweService.Decrypt(jweToken)
@@ -199,13 +199,13 @@ func (suite *JWEServiceTestSuite) TestEncrypt_ErrorCases() {
 	// but we can test other error paths
 
 	// Test with nil recipient key
-	_, sErr := suite.jweService.Encrypt(payload, nil, RSAOAEP256, A128GCM)
+	_, sErr := suite.jweService.Encrypt(payload, nil, RSAOAEP256, A128GCM, "", "")
 	assert.NotNil(suite.T(), sErr)
 
 	// Test with unsupported key type (e.g., string instead of crypto key)
 	// This will be caught in EncryptKey and return InvalidKeyTypeForAlgorithm
 	fakeKey := "not-a-real-key"
-	_, sErr = suite.jweService.Encrypt(payload, fakeKey, RSAOAEP256, A128GCM)
+	_, sErr = suite.jweService.Encrypt(payload, fakeKey, RSAOAEP256, A128GCM, "", "")
 	assert.NotNil(suite.T(), sErr)
 }
 

--- a/backend/internal/system/jose/jwe/utils.go
+++ b/backend/internal/system/jose/jwe/utils.go
@@ -19,18 +19,24 @@
 package jwe
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdh"
 	"crypto/ecdsa"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // RSA-OAEP with SHA-1 is required by RFC 7518 §4.3
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"strings"
 
 	cryptohash "github.com/asgardeo/thunder/internal/system/crypto/hash"
@@ -44,17 +50,28 @@ import (
 func encryptKey(cek []byte, alg KeyEncAlgorithm, recipientPubKey crypto.PublicKey,
 	enc ContentEncAlgorithm) ([]byte, map[string]interface{}, error) {
 	switch alg {
+	case RSAOAEP:
+		encryptedKey, err := encryptWithRSAOAEP(cek, recipientPubKey)
+		return encryptedKey, nil, err
+
 	case RSAOAEP256:
 		encryptedKey, err := encryptWithRSAOAEP256(cek, recipientPubKey)
+		return encryptedKey, nil, err
+
+	case A128KW, A192KW, A256KW:
+		encryptedKey, err := encryptWithAESKW(cek, recipientPubKey, alg)
 		return encryptedKey, nil, err
 
 	case ECDHES:
 		// For ECDH-ES, the CEK is directly derived from the shared secret
 		return encryptWithECDHES(cek, recipientPubKey, enc)
 
-	case ECDHESA128KW, ECDHESA256KW:
+	case ECDHESA128KW, ECDHESA192KW, ECDHESA256KW:
 		// Derive KEK using ECDH-ES, then wrap CEK
 		return encryptWithECDHESKW(cek, recipientPubKey, alg)
+
+	case A128GCMKW, A192GCMKW, A256GCMKW:
+		return encryptWithAESGCMKW(cek, recipientPubKey, alg)
 
 	default:
 		return nil, nil, fmt.Errorf("unsupported JWE algorithm: %s", alg)
@@ -62,10 +79,10 @@ func encryptKey(cek []byte, alg KeyEncAlgorithm, recipientPubKey crypto.PublicKe
 }
 
 // epkToMap converts an ephemeral public key to a JWK-like map representation.
-func epkToMap(pub crypto.PublicKey) map[string]interface{} {
+func epkToMap(pub crypto.PublicKey) (map[string]interface{}, error) {
 	ecdhPub, ok := pub.(*ecdh.PublicKey)
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("unsupported ephemeral public key type: %T", pub)
 	}
 
 	raw := ecdhPub.Bytes()
@@ -86,7 +103,7 @@ func epkToMap(pub crypto.PublicKey) map[string]interface{} {
 		x = raw[1:67]
 		y = raw[67:]
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported ephemeral public key curve (raw length %d)", len(raw))
 	}
 
 	return map[string]interface{}{
@@ -94,21 +111,30 @@ func epkToMap(pub crypto.PublicKey) map[string]interface{} {
 		"crv": crv,
 		"x":   base64.RawURLEncoding.EncodeToString(x),
 		"y":   base64.RawURLEncoding.EncodeToString(y),
-	}
+	}, nil
 }
 
 // decryptKey decrypts the encrypted content encryption key (CEK) using the recipient's private key.
 func decryptKey(encryptedKey []byte, alg KeyEncAlgorithm, privateKey crypto.PrivateKey,
 	header map[string]interface{}, enc ContentEncAlgorithm) ([]byte, error) {
 	switch alg {
+	case RSAOAEP:
+		return decryptWithRSAOAEP(encryptedKey, privateKey)
+
 	case RSAOAEP256:
 		return decryptWithRSAOAEP256(encryptedKey, privateKey)
+
+	case A128KW, A192KW, A256KW:
+		return decryptWithAESKW(encryptedKey, privateKey, alg)
 
 	case ECDHES:
 		return decryptWithECDHES(privateKey, header, enc)
 
-	case ECDHESA128KW, ECDHESA256KW:
+	case ECDHESA128KW, ECDHESA192KW, ECDHESA256KW:
 		return decryptWithECDHESKW(encryptedKey, privateKey, header, alg)
+
+	case A128GCMKW, A192GCMKW, A256GCMKW:
+		return decryptWithAESGCMKW(encryptedKey, privateKey, header, alg)
 
 	default:
 		return nil, fmt.Errorf("unsupported JWE algorithm: %s", alg)
@@ -130,22 +156,41 @@ func computeSharedSecretForRecipient(priv crypto.PrivateKey, pub crypto.PublicKe
 
 // encryptContent encrypts the payload using the content encryption key (CEK).
 func encryptContent(payload []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, []byte, []byte, error) {
+	switch enc {
+	case A128CBCHS256, A192CBCHS384, A256CBCHS512:
+		return encryptWithCBC(payload, cek, enc, aad)
+	case A128GCM, A192GCM, A256GCM:
+		return encryptWithGCM(payload, cek, enc, aad)
+	default:
+		return nil, nil, nil, fmt.Errorf("unsupported encryption algorithm: %s", enc)
+	}
+}
+
+// decryptContent decrypts the ciphertext using the content encryption key (CEK).
+func decryptContent(ciphertext, iv, tag []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, error) {
+	switch enc {
+	case A128CBCHS256, A192CBCHS384, A256CBCHS512:
+		return decryptWithCBC(ciphertext, iv, tag, cek, enc, aad)
+	case A128GCM, A192GCM, A256GCM:
+		return decryptWithGCM(ciphertext, iv, tag, cek, aad)
+	default:
+		return nil, fmt.Errorf("unsupported encryption algorithm: %s", enc)
+	}
+}
+
+// encryptWithGCM encrypts the payload using AES-GCM.
+func encryptWithGCM(payload []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, []byte, []byte, error) {
 	block, err := aes.NewCipher(cek)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	var gcm cipher.AEAD
-	switch enc {
-	case A128GCM, A192GCM, A256GCM:
-		gcm, err = cipher.NewGCM(block)
-	default:
-		return nil, nil, nil, fmt.Errorf("unsupported encryption algorithm: %s", enc)
-	}
-
+	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	_ = enc // key size already enforced by CEK length
 
 	iv := make([]byte, gcm.NonceSize())
 	if _, err := rand.Read(iv); err != nil {
@@ -160,26 +205,138 @@ func encryptContent(payload []byte, cek []byte, enc ContentEncAlgorithm, aad []b
 	return iv, ciphertext, tag, nil
 }
 
-// decryptContent decrypts the ciphertext using the content encryption key (CEK).
-func decryptContent(ciphertext, iv, tag []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, error) {
+// decryptWithGCM decrypts the ciphertext using AES-GCM.
+func decryptWithGCM(ciphertext, iv, tag []byte, cek []byte, aad []byte) ([]byte, error) {
 	block, err := aes.NewCipher(cek)
 	if err != nil {
 		return nil, err
 	}
 
-	var gcm cipher.AEAD
-	switch enc {
-	case A128GCM, A192GCM, A256GCM:
-		gcm, err = cipher.NewGCM(block)
-	default:
-		return nil, fmt.Errorf("unsupported encryption algorithm: %s", enc)
-	}
-
+	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(iv) != gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid GCM nonce length: got %d, want %d", len(iv), gcm.NonceSize())
+	}
+
 	return gcm.Open(nil, iv, append(ciphertext, tag...), aad)
+}
+
+// encryptWithCBC encrypts the payload using AES-CBC + HMAC per RFC 7518 §5.2.
+// Supports A128CBC-HS256 (32-byte CEK), A192CBC-HS384 (48-byte CEK), A256CBC-HS512 (64-byte CEK).
+func encryptWithCBC(payload []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, []byte, []byte, error) {
+	halfLen, hashAlg, err := cbcParams(enc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(cek) != halfLen*2 {
+		return nil, nil, nil, fmt.Errorf("%s requires a %d-byte CEK, got %d", enc, halfLen*2, len(cek))
+	}
+	macKey := cek[:halfLen]
+	encKey := cek[halfLen:]
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(iv); err != nil {
+		return nil, nil, nil, err
+	}
+
+	padded := pkcs7Pad(payload, aes.BlockSize)
+	block, err := aes.NewCipher(encKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	tag := cbcHMACTag(hashAlg, macKey, aad, iv, ciphertext, halfLen)
+	return iv, ciphertext, tag, nil
+}
+
+// decryptWithCBC decrypts AES-CBC + HMAC per RFC 7518 §5.2.
+// Supports A128CBC-HS256, A192CBC-HS384, and A256CBC-HS512.
+func decryptWithCBC(ciphertext, iv, tag []byte, cek []byte, enc ContentEncAlgorithm, aad []byte) ([]byte, error) {
+	halfLen, hashAlg, err := cbcParams(enc)
+	if err != nil {
+		return nil, err
+	}
+	if len(cek) != halfLen*2 {
+		return nil, fmt.Errorf("%s requires a %d-byte CEK, got %d", enc, halfLen*2, len(cek))
+	}
+	macKey := cek[:halfLen]
+	encKey := cek[halfLen:]
+
+	expected := cbcHMACTag(hashAlg, macKey, aad, iv, ciphertext, halfLen)
+	if !hmac.Equal(tag, expected) {
+		return nil, fmt.Errorf("%s authentication tag mismatch", enc)
+	}
+
+	block, err := aes.NewCipher(encKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) != aes.BlockSize {
+		return nil, fmt.Errorf("invalid CBC IV length: got %d, want %d", len(iv), aes.BlockSize)
+	}
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, errors.New("ciphertext length is not a multiple of AES block size")
+	}
+	plaintext := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plaintext, ciphertext)
+	return pkcs7Unpad(plaintext)
+}
+
+// cbcParams returns the half-CEK length and HMAC hash constructor for the given CBC enc algorithm.
+// Per RFC 7518 §5.2: CEK = MAC key || ENC key, each of halfLen bytes; tag = HMAC[:halfLen].
+func cbcParams(enc ContentEncAlgorithm) (halfLen int, newHash func() hash.Hash, err error) {
+	switch enc {
+	case A128CBCHS256:
+		return 16, sha256.New, nil
+	case A192CBCHS384:
+		return 24, sha512.New384, nil
+	case A256CBCHS512:
+		return 32, sha512.New, nil
+	default:
+		return 0, nil, fmt.Errorf("unsupported CBC enc algorithm: %s", enc)
+	}
+}
+
+// cbcHMACTag computes the authentication tag per RFC 7518 §5.2.2.1.
+// MAC input: AAD || IV || ciphertext || AAD_length_bits (64-bit big-endian). Tag = HMAC[:tagLen].
+func cbcHMACTag(newHash func() hash.Hash, macKey, aad, iv, ciphertext []byte, tagLen int) []byte {
+	aadLenBits := make([]byte, 8)
+	binary.BigEndian.PutUint64(aadLenBits, uint64(len(aad))*8) //nolint:gosec // G115: safe cast
+
+	mac := hmac.New(newHash, macKey)
+	mac.Write(aad)
+	mac.Write(iv)
+	mac.Write(ciphertext)
+	mac.Write(aadLenBits)
+	return mac.Sum(nil)[:tagLen]
+}
+
+// pkcs7Pad pads the data to a multiple of blockSize using PKCS#7.
+func pkcs7Pad(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	return append(data, bytes.Repeat([]byte{byte(padding)}, padding)...)
+}
+
+// pkcs7Unpad removes PKCS#7 padding.
+func pkcs7Unpad(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty data for PKCS#7 unpadding")
+	}
+	padding := int(data[len(data)-1])
+	if padding == 0 || padding > aes.BlockSize {
+		return nil, errors.New("invalid PKCS#7 padding")
+	}
+	for _, b := range data[len(data)-padding:] {
+		if int(b) != padding {
+			return nil, errors.New("invalid PKCS#7 padding bytes")
+		}
+	}
+	return data[:len(data)-padding], nil
 }
 
 // DecodeJWE decodes a JWE compact serialization into its five parts.
@@ -402,6 +559,15 @@ func computeSharedSecret(privKey crypto.PrivateKey, pubKey crypto.PublicKey) ([]
 	return ecdhPriv.ECDH(ecdhPub)
 }
 
+// encryptWithRSAOAEP encrypts the CEK using RSA-OAEP with SHA-1 (RFC 7518 §4.3).
+func encryptWithRSAOAEP(cek []byte, recipientPubKey crypto.PublicKey) ([]byte, error) {
+	rsaPub, ok := recipientPubKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("unsupported public key type for JWE key encryption")
+	}
+	return rsa.EncryptOAEP(sha1.New(), rand.Reader, rsaPub, cek, nil) //nolint:gosec
+}
+
 // encryptWithRSAOAEP256 encrypts the CEK using RSA-OAEP-256 algorithm.
 func encryptWithRSAOAEP256(cek []byte, recipientPubKey crypto.PublicKey) ([]byte, error) {
 	rsaPub, ok := recipientPubKey.(*rsa.PublicKey)
@@ -413,6 +579,15 @@ func encryptWithRSAOAEP256(cek []byte, recipientPubKey crypto.PublicKey) ([]byte
 		return nil, err
 	}
 	return rsa.EncryptOAEP(h, rand.Reader, rsaPub, cek, nil)
+}
+
+// decryptWithRSAOAEP decrypts the encrypted key using RSA-OAEP with SHA-1 (RFC 7518 §4.3).
+func decryptWithRSAOAEP(encryptedKey []byte, privateKey crypto.PrivateKey) ([]byte, error) {
+	rsaPriv, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("unsupported private key type for JWE key decryption")
+	}
+	return rsa.DecryptOAEP(sha1.New(), rand.Reader, rsaPriv, encryptedKey, nil) //nolint:gosec
 }
 
 // encryptWithECDHES derives the CEK using ECDH-ES algorithm.
@@ -445,7 +620,11 @@ func encryptWithECDHES(cek []byte, recipientPubKey crypto.PublicKey,
 	copy(cek, derivedKey)
 
 	// Set epk in header
-	headerExtras := map[string]interface{}{"epk": epkToMap(ephemeralPub)}
+	epkMap, err := epkToMap(ephemeralPub)
+	if err != nil {
+		return nil, nil, err
+	}
+	headerExtras := map[string]interface{}{"epk": epkMap}
 	return []byte{}, headerExtras, nil
 }
 
@@ -463,7 +642,10 @@ func encryptWithECDHESKW(cek []byte, recipientPubKey crypto.PublicKey,
 	}
 
 	kekLen := 16
-	if alg == ECDHESA256KW {
+	switch alg {
+	case ECDHESA192KW:
+		kekLen = 24
+	case ECDHESA256KW:
 		kekLen = 32
 	}
 
@@ -473,7 +655,11 @@ func encryptWithECDHESKW(cek []byte, recipientPubKey crypto.PublicKey,
 		return nil, nil, err
 	}
 
-	headerExtras := map[string]interface{}{"epk": epkToMap(ephemeralPub)}
+	epkMap, err := epkToMap(ephemeralPub)
+	if err != nil {
+		return nil, nil, err
+	}
+	headerExtras := map[string]interface{}{"epk": epkMap}
 	return wrappedKey, headerExtras, nil
 }
 
@@ -540,10 +726,155 @@ func decryptWithECDHESKW(encryptedKey []byte, privateKey crypto.PrivateKey,
 	}
 
 	kekLen := 16
-	if alg == ECDHESA256KW {
+	switch alg {
+	case ECDHESA192KW:
+		kekLen = 24
+	case ECDHESA256KW:
 		kekLen = 32
 	}
 
 	kek := concatKDF(z, string(alg), kekLen)
 	return aesKeyUnwrap(kek, encryptedKey)
+}
+
+// encryptWithAESKW wraps the CEK using the symmetric KEK via RFC 3394 AES Key Wrap (RFC 7518 §4.4).
+// The KEK is passed as a []byte stored in crypto.PublicKey.
+func encryptWithAESKW(cek []byte, kek crypto.PublicKey, alg KeyEncAlgorithm) ([]byte, error) {
+	keyBytes, ok := kek.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("AES Key Wrap requires a symmetric key ([]byte), got %T", kek)
+	}
+	expectedLen := 16
+	switch alg {
+	case A192KW:
+		expectedLen = 24
+	case A256KW:
+		expectedLen = 32
+	}
+	if len(keyBytes) != expectedLen {
+		return nil, fmt.Errorf("AES Key Wrap (%s) requires a %d-byte key, got %d", alg, expectedLen, len(keyBytes))
+	}
+	return aesKeyWrap(keyBytes, cek)
+}
+
+// decryptWithAESKW unwraps the encrypted CEK using the symmetric KEK via RFC 3394 AES Key Unwrap (RFC 7518 §4.4).
+// The KEK is passed as a []byte stored in crypto.PrivateKey.
+func decryptWithAESKW(encryptedKey []byte, kek crypto.PrivateKey, alg KeyEncAlgorithm) ([]byte, error) {
+	keyBytes, ok := kek.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("AES Key Wrap requires a symmetric key ([]byte), got %T", kek)
+	}
+	expectedLen := 16
+	switch alg {
+	case A192KW:
+		expectedLen = 24
+	case A256KW:
+		expectedLen = 32
+	}
+	if len(keyBytes) != expectedLen {
+		return nil, fmt.Errorf("AES Key Wrap (%s) requires a %d-byte key, got %d", alg, expectedLen, len(keyBytes))
+	}
+	return aesKeyUnwrap(keyBytes, encryptedKey)
+}
+
+// encryptWithAESGCMKW encrypts the CEK using AES-GCM key wrap (RFC 7518 §4.7).
+// The KEK is passed as a []byte stored in crypto.PublicKey.
+// The generated IV and authentication tag are returned as headerExtras ("iv" and "tag").
+func encryptWithAESGCMKW(
+	cek []byte, kek crypto.PublicKey, alg KeyEncAlgorithm,
+) ([]byte, map[string]interface{}, error) {
+	keyBytes, ok := kek.([]byte)
+	if !ok {
+		return nil, nil, fmt.Errorf("AES-GCM Key Wrap requires a symmetric key ([]byte), got %T", kek)
+	}
+	expectedLen := 16
+	switch alg {
+	case A192GCMKW:
+		expectedLen = 24
+	case A256GCMKW:
+		expectedLen = 32
+	}
+	if len(keyBytes) != expectedLen {
+		return nil, nil, fmt.Errorf(
+			"AES-GCM Key Wrap (%s) requires a %d-byte key, got %d", alg, expectedLen, len(keyBytes),
+		)
+	}
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	iv := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(iv); err != nil {
+		return nil, nil, err
+	}
+
+	sealed := gcm.Seal(nil, iv, cek, nil)
+	tagSize := gcm.Overhead()
+	encryptedKey := sealed[:len(sealed)-tagSize]
+	tag := sealed[len(sealed)-tagSize:]
+
+	headerExtras := map[string]interface{}{
+		"iv":  base64.RawURLEncoding.EncodeToString(iv),
+		"tag": base64.RawURLEncoding.EncodeToString(tag),
+	}
+	return encryptedKey, headerExtras, nil
+}
+
+// decryptWithAESGCMKW decrypts the wrapped CEK using AES-GCM key wrap (RFC 7518 §4.7).
+// The KEK is passed as a []byte stored in crypto.PrivateKey.
+// The IV and tag are read from the JWE protected header.
+func decryptWithAESGCMKW(encryptedKey []byte, kek crypto.PrivateKey,
+	header map[string]interface{}, alg KeyEncAlgorithm) ([]byte, error) {
+	keyBytes, ok := kek.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("AES-GCM Key Wrap requires a symmetric key ([]byte), got %T", kek)
+	}
+	expectedLen := 16
+	switch alg {
+	case A192GCMKW:
+		expectedLen = 24
+	case A256GCMKW:
+		expectedLen = 32
+	}
+	if len(keyBytes) != expectedLen {
+		return nil, fmt.Errorf("AES-GCM Key Wrap (%s) requires a %d-byte key, got %d", alg, expectedLen, len(keyBytes))
+	}
+
+	ivStr, ok := header["iv"].(string)
+	if !ok {
+		return nil, errors.New("missing iv in header for AES-GCM Key Wrap")
+	}
+	tagStr, ok := header["tag"].(string)
+	if !ok {
+		return nil, errors.New("missing tag in header for AES-GCM Key Wrap")
+	}
+
+	iv, err := base64.RawURLEncoding.DecodeString(ivStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode iv from header: %w", err)
+	}
+	tag, err := base64.RawURLEncoding.DecodeString(tagStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode tag from header: %w", err)
+	}
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) != gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid GCM nonce length for key wrap: got %d, want %d", len(iv), gcm.NonceSize())
+	}
+
+	return gcm.Open(nil, iv, append(encryptedKey, tag...), nil)
 }

--- a/backend/internal/system/jose/jwe/utils_test.go
+++ b/backend/internal/system/jose/jwe/utils_test.go
@@ -479,7 +479,8 @@ func (s *JEWUtilsTestSuite) TestEpkToMapEdgeCases() {
 	ecdhPub, err := privKey.PublicKey.ECDH()
 	s.NoError(err)
 
-	epkMap := epkToMap(ecdhPub)
+	epkMap, err := epkToMap(ecdhPub)
+	s.NoError(err)
 	s.NotNil(epkMap)
 	s.Equal("P-384", epkMap["crv"])
 
@@ -490,7 +491,8 @@ func (s *JEWUtilsTestSuite) TestEpkToMapEdgeCases() {
 	ecdhPub521, err := privKey521.PublicKey.ECDH()
 	s.NoError(err)
 
-	epkMap521 := epkToMap(ecdhPub521)
+	epkMap521, err := epkToMap(ecdhPub521)
+	s.NoError(err)
 	s.NotNil(epkMap521)
 	s.Equal("P-521", epkMap521["crv"])
 
@@ -498,7 +500,8 @@ func (s *JEWUtilsTestSuite) TestEpkToMapEdgeCases() {
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	s.NoError(err)
 
-	epkMap = epkToMap(&rsaKey.PublicKey)
+	epkMap, err = epkToMap(&rsaKey.PublicKey)
+	s.Error(err)
 	s.Nil(epkMap)
 }
 
@@ -523,7 +526,8 @@ func (s *JEWUtilsTestSuite) TestGenerateEphemeralKeyDifferentCurves() {
 			s.NotNil(ephemeralPubKey)
 
 			// Generate the EPK map for verification
-			epkMap := epkToMap(ephemeralPubKey)
+			epkMap, epkErr := epkToMap(ephemeralPubKey)
+			s.NoError(epkErr)
 			s.NotNil(epkMap)
 
 			// Verify the curve matches

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -45,7 +45,7 @@ import (
 
 // JWTServiceInterface defines the interface for JWT operations.
 type JWTServiceInterface interface {
-	GenerateJWT(sub, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (
+	GenerateJWT(sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string) (
 		string, int64, *serviceerror.ServiceError)
 	VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError
 	VerifyJWTWithPublicKey(jwtToken string, jwtPublicKey crypto.PublicKey, expectedAud,
@@ -138,13 +138,24 @@ func newJWTService(pkiService pki.PKIServiceInterface) (JWTServiceInterface, err
 	}
 }
 
-// GenerateJWT generates a standard JWT signed with the server's private key.
+// GenerateJWT generates a JWT signed with the server's private key.
 // The typ parameter sets the JWT header "typ" field. If empty, defaults to "JWT".
+// The alg parameter overrides the signing algorithm (e.g. "RS256"). When empty, the server's
+// default algorithm is used. When set but incompatible with the server's private key,
+// ErrorUnsupportedJWSAlgorithm is returned.
 // claims["aud"] must be set by the caller as either a string or []string; omitting it
 // or providing another type is a programmer error and returns InternalServerError.
 func (js *jwtService) GenerateJWT(
-	sub, iss string, validityPeriod int64, claims map[string]interface{}, typ string,
+	sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string,
 ) (string, int64, *serviceerror.ServiceError) {
+	jwsAlg := js.jwsAlg
+	if alg != "" {
+		mapped, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(alg))
+		if err != nil || mapped != js.signAlg {
+			return "", 0, &ErrorUnsupportedJWSAlgorithm
+		}
+		jwsAlg = jws.Algorithm(alg)
+	}
 	if js.privateKey == nil {
 		js.logger.Error("Private key not found for JWT generation")
 		return "", 0, &serviceerror.InternalServerError
@@ -171,7 +182,7 @@ func (js *jwtService) GenerateJWT(
 		typ = TokenTypeJWT
 	}
 	header := map[string]string{
-		"alg": string(js.jwsAlg),
+		"alg": string(jwsAlg),
 		"typ": typ,
 		"kid": js.kid,
 	}

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -567,7 +567,7 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 
 			jwtService := tc.setupService()
 
-			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.iss, tc.validity, tc.claims, TokenTypeJWT)
+			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.iss, tc.validity, tc.claims, TokenTypeJWT, "")
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -1385,7 +1385,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			name: "ValidToken",
 			setupFunc: func() string {
 				token, _, err := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1414,7 +1414,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			name: "PublicKeyNotAvailable",
 			setupFunc: func() string {
 				token, _, err := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1445,7 +1445,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 	validToken, _, err := suite.jwtService.GenerateJWT(
-		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
 	wrongKey, _ := rsa.GenerateKey(rand.Reader, 2048)
@@ -1483,7 +1483,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKS() {
 	token, _, err := suite.jwtService.GenerateJWT(
-		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
 	testServer := suite.mockJWKSServer()
@@ -1543,7 +1543,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSUsesCache() {
 	defer serverB.Close()
 
 	token, _, genErr := suite.jwtService.GenerateJWT(
-		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), genErr)
 
 	// 1. First call against serverA — cache miss, one fetch.
@@ -1642,7 +1642,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
 			expectedError: ErrorFailedToGetJWKS,
@@ -1660,7 +1660,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1690,7 +1690,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
 			expectedError: ErrorNoMatchingJWKFound,
@@ -1719,7 +1719,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 			},
 			setupToken: func() string {
 				token, _, _ := suite.jwtService.GenerateJWT(
-					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1762,7 +1762,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSNetworkError() {
 	// Test with invalid URL to trigger network error
 	token, _, err := suite.jwtService.GenerateJWT(
-		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT)
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
 	err = suite.jwtService.VerifyJWTSignatureWithJWKS(token, "http://localhost:99999/invalid")
@@ -1998,7 +1998,7 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 
 			// Test JWT generation with ECDSA key
 			token, _, svcErr := service.GenerateJWT(
-				"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
+				"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 			assert.Nil(t, svcErr)
 			assert.NotEmpty(t, token)
 
@@ -2061,7 +2061,7 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 
 	// Test JWT generation with Ed25519 key
 	token, _, svcErr := service.GenerateJWT(
-		"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
+		"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), svcErr)
 	assert.NotEmpty(suite.T(), token)
 
@@ -2332,7 +2332,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyAlgorithmDe
 
 			// Generate token
 			token, _, err := jwtService.GenerateJWT(
-				"test-sub", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT)
+				"test-sub", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 			assert.Nil(t, err)
 
 			// Verify with public key (should detect algorithm from header)

--- a/backend/internal/system/mcp/auth/token_verifier_test.go
+++ b/backend/internal/system/mcp/auth/token_verifier_test.go
@@ -59,9 +59,9 @@ func (m *MockJWTService) GenerateJWT(
 	sub, iss string,
 	validityPeriod int64,
 	claims map[string]interface{},
-	typ string,
+	typ, alg string,
 ) (string, int64, *serviceerror.ServiceError) {
-	args := m.Called(sub, iss, validityPeriod, claims, typ)
+	args := m.Called(sub, iss, validityPeriod, claims, typ, alg)
 	return args.String(0), args.Get(1).(int64), args.Get(2).(*serviceerror.ServiceError)
 }
 

--- a/backend/tests/mocks/jose/jwemock/JWEServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwemock/JWEServiceInterface_mock.go
@@ -104,8 +104,8 @@ func (_c *JWEServiceInterfaceMock_Decrypt_Call) RunAndReturn(run func(jweToken s
 }
 
 // Encrypt provides a mock function for the type JWEServiceInterfaceMock
-func (_mock *JWEServiceInterfaceMock) Encrypt(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(payload, recipientPublicKey, alg, enc)
+func (_mock *JWEServiceInterfaceMock) Encrypt(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm, cty string, kid string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(payload, recipientPublicKey, alg, enc, cty, kid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Encrypt")
@@ -113,16 +113,16 @@ func (_mock *JWEServiceInterfaceMock) Encrypt(payload []byte, recipientPublicKey
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(payload, recipientPublicKey, alg, enc)
+	if returnFunc, ok := ret.Get(0).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm, string, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(payload, recipientPublicKey, alg, enc, cty, kid)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm) string); ok {
-		r0 = returnFunc(payload, recipientPublicKey, alg, enc)
+	if returnFunc, ok := ret.Get(0).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm, string, string) string); ok {
+		r0 = returnFunc(payload, recipientPublicKey, alg, enc, cty, kid)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(payload, recipientPublicKey, alg, enc)
+	if returnFunc, ok := ret.Get(1).(func([]byte, crypto.PublicKey, jwe.KeyEncAlgorithm, jwe.ContentEncAlgorithm, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(payload, recipientPublicKey, alg, enc, cty, kid)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -141,11 +141,13 @@ type JWEServiceInterfaceMock_Encrypt_Call struct {
 //   - recipientPublicKey crypto.PublicKey
 //   - alg jwe.KeyEncAlgorithm
 //   - enc jwe.ContentEncAlgorithm
-func (_e *JWEServiceInterfaceMock_Expecter) Encrypt(payload interface{}, recipientPublicKey interface{}, alg interface{}, enc interface{}) *JWEServiceInterfaceMock_Encrypt_Call {
-	return &JWEServiceInterfaceMock_Encrypt_Call{Call: _e.mock.On("Encrypt", payload, recipientPublicKey, alg, enc)}
+//   - cty string
+//   - kid string
+func (_e *JWEServiceInterfaceMock_Expecter) Encrypt(payload interface{}, recipientPublicKey interface{}, alg interface{}, enc interface{}, cty interface{}, kid interface{}) *JWEServiceInterfaceMock_Encrypt_Call {
+	return &JWEServiceInterfaceMock_Encrypt_Call{Call: _e.mock.On("Encrypt", payload, recipientPublicKey, alg, enc, cty, kid)}
 }
 
-func (_c *JWEServiceInterfaceMock_Encrypt_Call) Run(run func(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm)) *JWEServiceInterfaceMock_Encrypt_Call {
+func (_c *JWEServiceInterfaceMock_Encrypt_Call) Run(run func(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm, cty string, kid string)) *JWEServiceInterfaceMock_Encrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 []byte
 		if args[0] != nil {
@@ -163,11 +165,21 @@ func (_c *JWEServiceInterfaceMock_Encrypt_Call) Run(run func(payload []byte, rec
 		if args[3] != nil {
 			arg3 = args[3].(jwe.ContentEncAlgorithm)
 		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -178,7 +190,7 @@ func (_c *JWEServiceInterfaceMock_Encrypt_Call) Return(s string, serviceError *s
 	return _c
 }
 
-func (_c *JWEServiceInterfaceMock_Encrypt_Call) RunAndReturn(run func(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm) (string, *serviceerror.ServiceError)) *JWEServiceInterfaceMock_Encrypt_Call {
+func (_c *JWEServiceInterfaceMock_Encrypt_Call) RunAndReturn(run func(payload []byte, recipientPublicKey crypto.PublicKey, alg jwe.KeyEncAlgorithm, enc jwe.ContentEncAlgorithm, cty string, kid string) (string, *serviceerror.ServiceError)) *JWEServiceInterfaceMock_Encrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *JWTServiceInterfaceMock) EXPECT() *JWTServiceInterfaceMock_Expecter {
 }
 
 // GenerateJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError) {
-	ret := _mock.Called(sub, iss, validityPeriod, claims, typ)
+func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError) {
+	ret := _mock.Called(sub, iss, validityPeriod, claims, typ, alg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateJWT")
@@ -49,21 +49,21 @@ func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validi
 	var r0 string
 	var r1 int64
 	var r2 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string) (string, int64, *serviceerror.ServiceError)); ok {
-		return returnFunc(sub, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string, string) (string, int64, *serviceerror.ServiceError)); ok {
+		return returnFunc(sub, iss, validityPeriod, claims, typ, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string) string); ok {
-		r0 = returnFunc(sub, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string, string) string); ok {
+		r0 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, int64, map[string]interface{}, string) int64); ok {
-		r1 = returnFunc(sub, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(1).(func(string, string, int64, map[string]interface{}, string, string) int64); ok {
+		r1 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(string, string, int64, map[string]interface{}, string) *serviceerror.ServiceError); ok {
-		r2 = returnFunc(sub, iss, validityPeriod, claims, typ)
+	if returnFunc, ok := ret.Get(2).(func(string, string, int64, map[string]interface{}, string, string) *serviceerror.ServiceError); ok {
+		r2 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).(*serviceerror.ServiceError)
@@ -83,11 +83,12 @@ type JWTServiceInterfaceMock_GenerateJWT_Call struct {
 //   - validityPeriod int64
 //   - claims map[string]interface{}
 //   - typ string
-func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
-	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, iss, validityPeriod, claims, typ)}
+//   - alg string
+func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}, alg interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
+	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, iss, validityPeriod, claims, typ, alg)}
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -109,12 +110,17 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss
 		if args[4] != nil {
 			arg4 = args[4].(string)
 		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -125,7 +131,7 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Return(s string, n int64, se
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -4903,7 +4903,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUserInfoResponseTypeJWS() {
 					ResponseTypes:           []string{"code"},
 					TokenEndpointAuthMethod: "client_secret_basic",
 					UserInfo: &UserInfoConfig{
-						ResponseType:   "JWS",
+						SigningAlg:     "RS256",
 						UserAttributes: []string{"email"},
 					},
 				},
@@ -4923,26 +4923,26 @@ func (ts *ApplicationAPITestSuite) TestApplicationUserInfoResponseTypeJWS() {
 
 	oauth := retrievedApp.InboundAuthConfig[0].OAuthAppConfig
 	ts.Require().NotNil(oauth.UserInfo)
-	ts.Assert().Equal("JWS", oauth.UserInfo.ResponseType)
+	ts.Assert().Equal("RS256", oauth.UserInfo.SigningAlg)
 }
 
-func (ts *ApplicationAPITestSuite) TestApplicationUserInfoResponseTypeInvalidFallback() {
+func (ts *ApplicationAPITestSuite) TestApplicationUserInfoInvalidSigningAlgRejected() {
 	app := Application{
 		OUID:        testOUID,
-		Name:        "App UserInfo Invalid Fallback",
-		Description: "Testing invalid response type fallback",
+		Name:        "App UserInfo Invalid SigningAlg",
+		Description: "Testing that an unsupported signingAlg is rejected",
 		InboundAuthConfig: []InboundAuthConfig{
 			{
 				Type: "oauth2",
 				OAuthAppConfig: &OAuthAppConfig{
-					ClientID:                "userinfo_invalid_test_client",
-					ClientSecret:            "userinfo_invalid_test_secret",
+					ClientID:                "userinfo_invalid_alg_client",
+					ClientSecret:            "userinfo_invalid_alg_secret",
 					RedirectURIs:            []string{"http://localhost/callback"},
 					GrantTypes:              []string{"authorization_code"},
 					ResponseTypes:           []string{"code"},
 					TokenEndpointAuthMethod: "client_secret_basic",
 					UserInfo: &UserInfoConfig{
-						ResponseType:   "INVALID",
+						SigningAlg:     "INVALID_ALG",
 						UserAttributes: []string{"email"},
 					},
 				},
@@ -4953,14 +4953,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUserInfoResponseTypeInvalidFal
 	app.AuthFlowID = defaultAuthFlowID
 	app.RegistrationFlowID = defaultRegistrationFlowID
 
-	appID, err := createApplication(app)
-	ts.Require().NoError(err)
-	defer deleteApplication(appID)
-
-	retrievedApp, err := getApplicationByID(appID)
-	ts.Require().NoError(err)
-
-	oauth := retrievedApp.InboundAuthConfig[0].OAuthAppConfig
-	ts.Require().NotNil(oauth.UserInfo)
-	ts.Assert().Equal("JSON", oauth.UserInfo.ResponseType)
+	_, err := createApplication(app)
+	ts.Require().Error(err, "Creating an app with an unsupported signingAlg should fail")
+	ts.Assert().Contains(err.Error(), "400", "Expected HTTP 400 for unsupported signingAlg")
 }

--- a/tests/integration/application/model.go
+++ b/tests/integration/application/model.go
@@ -81,8 +81,10 @@ type OAuthTokenConfig struct {
 
 // UserInfoConfig represents the UserInfo endpoint configuration.
 type UserInfoConfig struct {
-	ResponseType   string   `json:"responseType,omitempty"`
-	UserAttributes []string `json:"userAttributes,omitempty"`
+	SigningAlg      string   `json:"signingAlg,omitempty"`
+	EncryptionAlg   string   `json:"encryptionAlg,omitempty"`
+	EncryptionEnc   string   `json:"encryptionEnc,omitempty"`
+	UserAttributes  []string `json:"userAttributes,omitempty"`
 }
 
 // AssertionConfig represents the assertion configuration (used for application-level assertion config).
@@ -282,7 +284,13 @@ func (app *Application) equals(expectedApp Application) bool {
 					if oauth.UserInfo == nil {
 						return false
 					}
-					if oauth.UserInfo.ResponseType != expectedOAuth.UserInfo.ResponseType {
+					if oauth.UserInfo.SigningAlg != expectedOAuth.UserInfo.SigningAlg {
+						return false
+					}
+					if oauth.UserInfo.EncryptionAlg != expectedOAuth.UserInfo.EncryptionAlg {
+						return false
+					}
+					if oauth.UserInfo.EncryptionEnc != expectedOAuth.UserInfo.EncryptionEnc {
 						return false
 					}
 					if !compareStringSlices(oauth.UserInfo.UserAttributes, expectedOAuth.UserInfo.UserAttributes) {

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -20,9 +20,13 @@ package userinfo
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
@@ -1016,7 +1020,7 @@ func (ts *UserInfoTestSuite) TestUserInfo_JWS_Response() {
 			},
 		},
 		"userInfo": map[string]interface{}{
-			"responseType":   "JWS",
+			"signingAlg":     "RS256",
 			"userAttributes": []string{"email", "given_name", "family_name"},
 		},
 		"scopeClaims": map[string][]string{
@@ -1054,4 +1058,146 @@ func (ts *UserInfoTestSuite) TestUserInfo_JWS_Response() {
 
 	parts := strings.Split(jwtString, ".")
 	ts.Require().Equal(3, len(parts), "Invalid JWT format")
+}
+
+// buildRSAPublicJWKS generates an RSA key pair and returns the compact public JWKS JSON
+// and the private key (for optional decryption in tests).
+func buildRSAPublicJWKS() (jwksJSON string, privateKey *rsa.PrivateKey, err error) {
+	privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, err
+	}
+	eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
+	key := map[string]interface{}{
+		"kty": "RSA",
+		"use": "enc",
+		"alg": "RSA-OAEP-256",
+		"n":   base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+	}
+	b, err := json.Marshal(map[string]interface{}{"keys": []interface{}{key}})
+	if err != nil {
+		return "", nil, err
+	}
+	return string(b), privateKey, nil
+}
+
+// TestUserInfo_JWE_Response verifies that an application configured with encryptionAlg/encryptionEnc
+// returns a JWE compact serialisation (five dot-separated parts) with Content-Type: application/jose.
+func (ts *UserInfoTestSuite) TestUserInfo_JWE_Response() {
+	jwksJSON, _, err := buildRSAPublicJWKS()
+	ts.Require().NoError(err, "Failed to generate RSA key pair for JWE test")
+
+	config := map[string]interface{}{
+		"clientId":      "userinfo_jwe_test_client",
+		"clientSecret":  "userinfo_jwe_test_secret",
+		"redirectUris":  []string{redirectURI},
+		"grantTypes":    []string{"authorization_code"},
+		"responseTypes": []string{"code"},
+		"scopes":        []string{"openid", "profile", "email"},
+		"token": map[string]interface{}{
+			"idToken": map[string]interface{}{
+				"userAttributes": []string{"email", "given_name"},
+			},
+		},
+		"userInfo": map[string]interface{}{
+			"encryptionAlg":  "RSA-OAEP-256",
+			"encryptionEnc":  "A256GCM",
+			"userAttributes": []string{"email", "given_name"},
+		},
+		"certificate": map[string]interface{}{
+			"type":  "JWKS",
+			"value": jwksJSON,
+		},
+		"scopeClaims": map[string][]string{
+			"profile": {"given_name"},
+			"email":   {"email"},
+		},
+	}
+
+	appID := ts.createApplicationWithConfig("UserInfoJWETestApp", config)
+	defer ts.deleteApplication(appID)
+
+	accessToken, err := ts.getAuthorizationCodeTokenWithClient(
+		"openid profile email",
+		"userinfo_jwe_test_client",
+		"userinfo_jwe_test_secret",
+	)
+	ts.Require().NoError(err)
+
+	resp, err := ts.callUserInfo(accessToken)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(ts.T(), http.StatusOK, resp.StatusCode)
+	assert.Equal(ts.T(), "application/jose", resp.Header.Get("Content-Type"))
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(bodyBytes)
+
+	// A JWE compact serialisation has exactly 5 dot-separated parts.
+	parts := strings.Split(string(bodyBytes), ".")
+	assert.Equal(ts.T(), 5, len(parts), "JWE response must have 5 dot-separated parts")
+}
+
+// TestUserInfo_NestedJWT_Response verifies that an application configured with both signingAlg and
+// encryptionAlg/encryptionEnc returns a Nested JWT (sign-then-encrypt JWE) with
+// Content-Type: application/jose.
+func (ts *UserInfoTestSuite) TestUserInfo_NestedJWT_Response() {
+	jwksJSON, _, err := buildRSAPublicJWKS()
+	ts.Require().NoError(err, "Failed to generate RSA key pair for Nested JWT test")
+
+	config := map[string]interface{}{
+		"clientId":      "userinfo_nested_jwt_test_client",
+		"clientSecret":  "userinfo_nested_jwt_test_secret",
+		"redirectUris":  []string{redirectURI},
+		"grantTypes":    []string{"authorization_code"},
+		"responseTypes": []string{"code"},
+		"scopes":        []string{"openid", "profile", "email"},
+		"token": map[string]interface{}{
+			"idToken": map[string]interface{}{
+				"userAttributes": []string{"email", "given_name"},
+			},
+		},
+		"userInfo": map[string]interface{}{
+			"signingAlg":     "RS256",
+			"encryptionAlg":  "RSA-OAEP-256",
+			"encryptionEnc":  "A256GCM",
+			"userAttributes": []string{"email", "given_name"},
+		},
+		"certificate": map[string]interface{}{
+			"type":  "JWKS",
+			"value": jwksJSON,
+		},
+		"scopeClaims": map[string][]string{
+			"profile": {"given_name"},
+			"email":   {"email"},
+		},
+	}
+
+	appID := ts.createApplicationWithConfig("UserInfoNestedJWTTestApp", config)
+	defer ts.deleteApplication(appID)
+
+	accessToken, err := ts.getAuthorizationCodeTokenWithClient(
+		"openid profile email",
+		"userinfo_nested_jwt_test_client",
+		"userinfo_nested_jwt_test_secret",
+	)
+	ts.Require().NoError(err)
+
+	resp, err := ts.callUserInfo(accessToken)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(ts.T(), http.StatusOK, resp.StatusCode)
+	assert.Equal(ts.T(), "application/jose", resp.Header.Get("Content-Type"))
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(bodyBytes)
+
+	// A Nested JWT is a JWE compact serialisation — exactly 5 dot-separated parts.
+	parts := strings.Split(string(bodyBytes), ".")
+	assert.Equal(ts.T(), 5, len(parts), "Nested JWT response must have 5 dot-separated parts")
 }


### PR DESCRIPTION
### Purpose

Adds JWE (JSON Web Encryption) support to the OIDC UserInfo endpoint, enabling clients to request
encrypted and/or signed UserInfo responses as defined in
[OpenID Connect Core §5.3.2](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse)
and [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518).

Previously the UserInfo endpoint only returned a plain JSON payload or a signed JWT (JWS). This PR
adds the remaining two response types so all four modes are supported:

| Mode | Trigger |
|------|---------|
| JSON (plain) | No signing/encryption configured |
| JWS (signed) | `signingAlg` set |
| JWE (encrypted) | `encryptionAlg` + `encryptionEnc` set |
| Nested JWT (sign-then-encrypt) | Both signing and encryption configured |

### Approach

**Application model (`UserInfoConfig`)** — replaced the internal `responseType` enum field with
explicit `signingAlg`, `encryptionAlg`, and `encryptionEnc` fields. The response type is now derived
at runtime from whichever fields are populated, eliminating a redundant field that could go out of
sync. Allowed algorithms are enumerated in
`SupportedUserInfoSigningAlgs` / `SupportedUserInfoEncryptionAlgs` / `SupportedUserInfoEncryptionEncs`.

**Validation (`application/service.go`)** — `validateUserInfoConfig` enforces:
- Only supported algorithm identifiers are accepted.
- `encryptionEnc` is required when `encryptionAlg` is set (RFC 7518 default rule).
- A client JWKS or JWKS URI must be present when encryption is configured (the server needs the
  RP's public key to wrap the CEK).

**UserInfo service** — `deriveResponseType` selects the response mode. The new
`generateJWEUserInfo` and `generateNestedJWTUserInfo` methods resolve the RP's public key from the
application certificate (inline JWKS or remote JWKS URI), then delegate to `JWEService.Encrypt`.
JWKS URI fetching enforces HTTPS, caps the response body at 1 MB, and validates HTTP 200. Key
selection requires `use=enc` (RFC 7517 §4.2).

**DCR (`dcr/service.go`)** — accepts three new registration fields:
`userinfo_signed_response_alg`, `userinfo_encrypted_response_alg`,
`userinfo_encrypted_response_enc`. JWKS marshal failure now returns `server_error` immediately
instead of silently proceeding without a certificate.

**OIDC Discovery (`discovery/service.go`)** — exposes `userinfo_signing_alg_values_supported`,
`userinfo_encryption_alg_values_supported`, and `userinfo_encryption_enc_values_supported` in the
discovery document. The signing list is sourced from `pkiService.GetSupportedSigningAlgorithms()`
(consistent with `id_token_signing_alg_values_supported`).

**JWE utils (`system/jose/jwe/utils.go`)** — `epkToMap` now returns an error for unsupported key
types and curves instead of a silent `nil`, preventing ambiguous nil-map panics in callers.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests (`service_jwe_test.go`, updated `service_test.go`, `utils_test.go`, `dcr/service_test.go`)
    - [x] Integration Tests (`tests/integration/oauth/userinfo/`)
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

> **Note:** `UserInfoConfig.ResponseType` (serialized as `responseType`) has been removed from the
> model. Applications with this field explicitly stored will silently ignore it after migration — the
> response type is now derived dynamically. No API contract change for consumers of the UserInfo
> endpoint itself.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/).
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] JWKS URI fetch restricted to HTTPS only; response body capped at 1 MB to prevent SSRF / OOM.
- [x] Encryption key selection restricted to `use=enc` keys per RFC 7517 §4.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted (JWE) and nested JWT userinfo responses.
  * Per-client configurable userinfo signing and encryption algorithm fields.
  * Discovery endpoint publishes supported userinfo signing/encryption values.
  * Dynamic Client Registration accepts userinfo algorithm parameters.

* **Bug Fixes / Enhancements**
  * Stronger validation of userinfo algorithm combinations and certificate requirements.
  * JWKS fetching hardened with HTTPS/SSRF checks, size limits, safer redirects, and JOSE content-type support.
  * Improved JWT/JWE handling with explicit algorithm selection.

* **Documentation**
  * Updated userinfo algorithm configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->