### PR TITLE
Route federated authenticators through authn provider

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -25,6 +25,13 @@ import (
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/authn"
+	authnAssert "github.com/asgardeo/thunder/internal/authn/assert"
+	authncm "github.com/asgardeo/thunder/internal/authn/common"
+	authnConsent "github.com/asgardeo/thunder/internal/authn/consent"
+	"github.com/asgardeo/thunder/internal/authn/github"
+	"github.com/asgardeo/thunder/internal/authn/google"
+	authnOAuth "github.com/asgardeo/thunder/internal/authn/oauth"
+	authnOIDC "github.com/asgardeo/thunder/internal/authn/oidc"
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
@@ -198,15 +205,29 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	// Initialize otp core service
 	otpCoreService := otp.Initialize(otpService, entityProvider)
 
+	// Initialize federated authentication services.
+	oauthAuthnService := authnOAuth.Initialize(idpService, entityProvider)
+	oidcAuthnService := authnOIDC.Initialize(idpService, entityProvider, jwtService)
+	googleAuthnService := google.Initialize(idpService, entityProvider, jwtService)
+	githubAuthnService := github.Initialize(idpService, entityProvider)
+
+	federatedAuths := map[idp.IDPType]authncm.FederatedAuthenticator{
+		idp.IDPTypeOAuth:  oauthAuthnService,
+		idp.IDPTypeOIDC:   oidcAuthnService,
+		idp.IDPTypeGoogle: googleAuthnService,
+		idp.IDPTypeGitHub: githubAuthnService,
+	}
+
 	// Initialize authn provider
-	authnProvider := authnprovidermgr.InitializeAuthnProviderManager(entityService, passkeyService, otpCoreService)
+	authnProvider := authnprovidermgr.InitializeAuthnProviderManager(entityService, passkeyService, otpCoreService,
+		federatedAuths)
 
 	// Initialize authentication services.
-	_, authSvcRegistry := authn.Initialize(
-		mux, mcpServer, idpService, jwtService,
-		entityProvider, authnProvider, consentService,
-		passkeyService, otpCoreService,
-	)
+	authAssertGen := authnAssert.Initialize()
+	consentEnforcer := authnConsent.Initialize(consentService, jwtService)
+
+	authn.Initialize(mux, mcpServer, idpService, jwtService, authnProvider, authAssertGen, passkeyService,
+		otpCoreService, oauthAuthnService, oidcAuthnService, googleAuthnService, githubAuthnService)
 
 	attributeCacheService := attributecache.Initialize()
 
@@ -219,11 +240,10 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 			"EmailExecutor will be registered but will not send emails.", log.Error(err))
 		emailClient = nil
 	}
-	execRegistry := executor.Initialize(flowFactory, ouService,
-		idpService, notifSenderSvc, jwtService, authSvcRegistry, authnProvider, otpCoreService,
-		passkeyService, authZService,
-		userSchemaService, observabilitySvc, groupService, roleService, entityProvider, attributeCacheService,
-		emailClient, templateService)
+	execRegistry := executor.Initialize(flowFactory, ouService, idpService, notifSenderSvc, jwtService, authAssertGen,
+		consentEnforcer, authnProvider, otpCoreService, passkeyService, authZService, userSchemaService,
+		observabilitySvc, groupService, roleService, entityProvider, attributeCacheService, emailClient,
+		templateService, oauthAuthnService, oidcAuthnService, githubAuthnService, googleAuthnService)
 
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(mux, mcpServer, flowFactory, execRegistry, graphCache)
 	if err != nil {

--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
+	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
 // AuthenticatedUser represents the user information of an authenticated user.
@@ -73,4 +75,27 @@ type AuthenticatorReference struct {
 	Step int `json:"step"`
 	// Timestamp is the authenticator engaged time (Unix epoch time in seconds)
 	Timestamp int64 `json:"timestamp"`
+}
+
+// FederatedAuthCredential carries the credential data for federated authentication.
+type FederatedAuthCredential struct {
+	IDPID   string
+	IDPType idp.IDPType
+	Code    string
+}
+
+// FederatedAuthResult is the result of a federated authentication attempt.
+// InternalEntity is nil when no local user was found or when the user is ambiguous.
+type FederatedAuthResult struct {
+	Sub             string
+	Claims          map[string]interface{}
+	InternalEntity  *entityprovider.Entity
+	IsAmbiguousUser bool
+}
+
+// FederatedAuthenticator defines the interface for federated authentication services.
+// Authenticate performs the full flow (code exchange, claims extraction, internal user lookup).
+// It returns an error only for actual failures; a missing internal user is NOT an error.
+type FederatedAuthenticator interface {
+	Authenticate(ctx context.Context, idpID, code string) (*FederatedAuthResult, *serviceerror.ServiceError)
 }

--- a/backend/internal/authn/error_constants.go
+++ b/backend/internal/authn/error_constants.go
@@ -104,4 +104,17 @@ var (
 			DefaultValue: "The passkey authentication attempt failed",
 		},
 	}
+	// ErrorFederatedAuthenticationFailed is the error when federated authentication fails.
+	ErrorFederatedAuthenticationFailed = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "AUTHN-FED-1001",
+		Error: core.I18nMessage{
+			Key:          "error.authnservice.federated_authentication_failed",
+			DefaultValue: "Federated authentication failed",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.authnservice.federated_authentication_failed_description",
+			DefaultValue: "The federated authentication attempt failed",
+		},
+	}
 )

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -54,14 +54,11 @@ func newGithubOAuthAuthnService(idpSvc idp.IDPServiceInterface,
 	httpClient := syshttp.NewHTTPClient()
 	internal := authnoauth.NewOAuthAuthnService(httpClient, idpSvc, entityProvider)
 
-	service := &githubOAuthAuthnService{
+	return &githubOAuthAuthnService{
 		internal:   internal,
 		httpClient: httpClient,
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
 	}
-	authncm.RegisterAuthenticator(service.getMetadata())
-
-	return service
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for GitHub OAuth authentication.
@@ -160,11 +157,50 @@ func (g *githubOAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpI
 	return g.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
-// getMetadata returns the authenticator metadata for GitHub OAuth authenticator.
-func (g *githubOAuthAuthnService) getMetadata() authncm.AuthenticatorMeta {
-	return authncm.AuthenticatorMeta{
-		Name:          authncm.AuthenticatorGithub,
-		Factors:       []authncm.AuthenticationFactor{authncm.FactorKnowledge},
-		AssociatedIDP: idp.IDPTypeGitHub,
+// Authenticate performs the full GitHub OAuth authentication flow: exchanges the code for a token,
+// fetches user info, and resolves the internal user.
+// A missing internal user is NOT an error — the caller decides how to handle it.
+func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
+	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
+	logger := g.logger.With(log.String("idpId", idpID))
+	logger.Debug("Performing federated GitHub OAuth authentication")
+
+	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
+	if svcErr != nil {
+		return nil, svcErr
 	}
+
+	userInfo, svcErr := g.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	sub := ""
+	if subVal, ok := userInfo["sub"]; ok && subVal != nil {
+		if subStr, ok := subVal.(string); ok && subStr != "" {
+			sub = subStr
+		}
+	}
+	if sub == "" {
+		logger.Debug("sub claim not found in user info")
+		return nil, &authncm.ErrorSubClaimNotFound
+	}
+
+	result := &authncm.FederatedAuthResult{
+		Sub:    sub,
+		Claims: userInfo,
+	}
+	user, svcErr := g.GetInternalUser(sub)
+	if svcErr != nil {
+		if svcErr.Code == authncm.ErrorUserNotFound.Code {
+			return result, nil
+		}
+		if svcErr.Code == authncm.ErrorAmbiguousUser.Code {
+			result.IsAmbiguousUser = true
+			return result, nil
+		}
+		return nil, svcErr
+	}
+	result.InternalEntity = user
+	return result, nil
 }

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -33,10 +33,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
-	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -384,11 +382,6 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestShouldFetchEmailAndGetMetadat
 
 	// shouldFetchEmail false
 	suite.False(gsvc.shouldFetchEmail([]string{"openid", "profile"}))
-
-	// getMetadata
-	meta := gsvc.getMetadata()
-	suite.Equal(authncm.AuthenticatorGithub, meta.Name)
-	suite.Equal(idp.IDPTypeGitHub, meta.AssociatedIDP)
 }
 
 func (suite *GithubOAuthAuthnServiceTestSuite) TestGetOAuthClientConfig() {

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -59,14 +59,11 @@ func newGoogleOIDCAuthnService(idpSvc idp.IDPServiceInterface, entityProvider en
 	httpClient := syshttp.NewHTTPClient()
 	internal := authnoidc.NewOIDCAuthnService(httpClient, idpSvc, entityProvider, jwtSvc)
 
-	service := &googleOIDCAuthnService{
+	return &googleOIDCAuthnService{
 		internal:   internal,
 		jwtService: jwtSvc,
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
 	}
-	common.RegisterAuthenticator(service.getMetadata())
-
-	return service
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for Google OIDC authentication.
@@ -246,11 +243,50 @@ func (g *googleOIDCAuthnService) GetOAuthClientConfig(ctx context.Context, idpID
 	return g.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
-// getMetadata returns the authenticator metadata for Google OIDC authenticator.
-func (g *googleOIDCAuthnService) getMetadata() common.AuthenticatorMeta {
-	return common.AuthenticatorMeta{
-		Name:          common.AuthenticatorGoogle,
-		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
-		AssociatedIDP: idp.IDPTypeGoogle,
+// Authenticate performs the full Google OIDC authentication flow: exchanges the code for a token,
+// extracts ID token claims, and resolves the internal user.
+// A missing internal user is NOT an error — the caller decides how to handle it.
+func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code string) (
+	*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	logger := g.logger.With(log.String("idpId", idpID))
+	logger.Debug("Performing federated Google OIDC authentication")
+
+	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
+	if svcErr != nil {
+		return nil, svcErr
 	}
+
+	claims, svcErr := g.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	sub := ""
+	if subVal, ok := claims["sub"]; ok && subVal != nil {
+		if subStr, ok := subVal.(string); ok && subStr != "" {
+			sub = subStr
+		}
+	}
+	if sub == "" {
+		logger.Debug("sub claim not found in ID token")
+		return nil, &common.ErrorSubClaimNotFound
+	}
+
+	result := &common.FederatedAuthResult{
+		Sub:    sub,
+		Claims: claims,
+	}
+	user, svcErr := g.GetInternalUser(sub)
+	if svcErr != nil {
+		if svcErr.Code == common.ErrorUserNotFound.Code {
+			return result, nil
+		}
+		if svcErr.Code == common.ErrorAmbiguousUser.Code {
+			result.IsAmbiguousUser = true
+			return result, nil
+		}
+		return nil, svcErr
+	}
+	result.InternalEntity = user
+	return result, nil
 }

--- a/backend/internal/authn/init.go
+++ b/backend/internal/authn/init.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/authn/assert"
 	"github.com/asgardeo/thunder/internal/authn/common"
-	"github.com/asgardeo/thunder/internal/authn/consent"
 	"github.com/asgardeo/thunder/internal/authn/github"
 	"github.com/asgardeo/thunder/internal/authn/google"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
@@ -34,22 +33,10 @@ import (
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	"github.com/asgardeo/thunder/internal/authn/reactsdk"
 	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
-	consentmgt "github.com/asgardeo/thunder/internal/consent"
-	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
-
-// AuthServiceRegistry holds references to all authentication services.
-type AuthServiceRegistry struct {
-	OAuthAuthnService       oauth.OAuthAuthnServiceInterface
-	OIDCAuthnService        oidc.OIDCAuthnServiceInterface
-	GithubOAuthAuthnService github.GithubOAuthAuthnServiceInterface
-	GoogleOIDCAuthnService  google.GoogleOIDCAuthnServiceInterface
-	AuthAssertGenerator     assert.AuthAssertGeneratorInterface
-	ConsentEnforcerService  consent.ConsentEnforcerServiceInterface
-}
 
 // Initialize initializes the authentication service and registers its routes.
 func Initialize(
@@ -57,45 +44,15 @@ func Initialize(
 	mcpServer *mcp.Server,
 	idpSvc idp.IDPServiceInterface,
 	jwtSvc jwt.JWTServiceInterface,
-	entityProvider entityprovider.EntityProviderInterface,
 	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
-	consentSvc consentmgt.ConsentServiceInterface,
+	authAssertGen assert.AuthAssertGeneratorInterface,
 	passkeySvc passkey.PasskeyServiceInterface,
 	otpSvc otp.OTPAuthnServiceInterface,
-) (AuthenticationServiceInterface, *AuthServiceRegistry) {
-	authServiceRegistry := createAuthServiceRegistry(idpSvc, jwtSvc,
-		entityProvider, consentSvc)
-	authnService := newAuthenticationService(
-		idpSvc,
-		jwtSvc,
-		authServiceRegistry.AuthAssertGenerator,
-		authnProvider,
-		otpSvc,
-		authServiceRegistry.OAuthAuthnService,
-		authServiceRegistry.OIDCAuthnService,
-		authServiceRegistry.GoogleOIDCAuthnService,
-		authServiceRegistry.GithubOAuthAuthnService,
-		passkeySvc,
-	)
-
-	authnHandler := newAuthenticationHandler(authnService)
-	registerRoutes(mux, authnHandler)
-
-	// Register MCP tools
-	if mcpServer != nil {
-		reactsdk.RegisterTools(mcpServer)
-	}
-
-	return authnService, authServiceRegistry
-}
-
-// createAuthServiceRegistry creates and returns an AuthServiceRegistry instance.
-func createAuthServiceRegistry(
-	idpSvc idp.IDPServiceInterface,
-	jwtSvc jwt.JWTServiceInterface,
-	entityProvider entityprovider.EntityProviderInterface,
-	consentSvc consentmgt.ConsentServiceInterface,
-) *AuthServiceRegistry {
+	oauthSvc oauth.OAuthAuthnServiceInterface,
+	oidcSvc oidc.OIDCAuthnServiceInterface,
+	googleSvc google.GoogleOIDCAuthnServiceInterface,
+	githubSvc github.GithubOAuthAuthnServiceInterface,
+) AuthenticationServiceInterface {
 	common.RegisterAuthenticator(common.AuthenticatorMeta{
 		Name:    common.AuthenticatorCredentials,
 		Factors: []common.AuthenticationFactor{common.FactorKnowledge},
@@ -108,14 +65,49 @@ func createAuthServiceRegistry(
 		Name:    common.AuthenticatorPasskey,
 		Factors: []common.AuthenticationFactor{common.FactorPossession, common.FactorInherence},
 	})
-	return &AuthServiceRegistry{
-		OAuthAuthnService:       oauth.Initialize(idpSvc, entityProvider),
-		OIDCAuthnService:        oidc.Initialize(idpSvc, entityProvider, jwtSvc),
-		GithubOAuthAuthnService: github.Initialize(idpSvc, entityProvider),
-		GoogleOIDCAuthnService:  google.Initialize(idpSvc, entityProvider, jwtSvc),
-		AuthAssertGenerator:     assert.Initialize(),
-		ConsentEnforcerService:  consent.Initialize(consentSvc, jwtSvc),
+	common.RegisterAuthenticator(common.AuthenticatorMeta{
+		Name:          common.AuthenticatorOAuth,
+		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
+		AssociatedIDP: idp.IDPTypeOAuth,
+	})
+	common.RegisterAuthenticator(common.AuthenticatorMeta{
+		Name:          common.AuthenticatorOIDC,
+		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
+		AssociatedIDP: idp.IDPTypeOIDC,
+	})
+	common.RegisterAuthenticator(common.AuthenticatorMeta{
+		Name:          common.AuthenticatorGithub,
+		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
+		AssociatedIDP: idp.IDPTypeGitHub,
+	})
+	common.RegisterAuthenticator(common.AuthenticatorMeta{
+		Name:          common.AuthenticatorGoogle,
+		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
+		AssociatedIDP: idp.IDPTypeGoogle,
+	})
+
+	authnService := newAuthenticationService(
+		idpSvc,
+		jwtSvc,
+		authAssertGen,
+		authnProvider,
+		otpSvc,
+		oauthSvc,
+		oidcSvc,
+		googleSvc,
+		githubSvc,
+		passkeySvc,
+	)
+
+	authnHandler := newAuthenticationHandler(authnService)
+	registerRoutes(mux, authnHandler)
+
+	// Register MCP tools
+	if mcpServer != nil {
+		reactsdk.RegisterTools(mcpServer)
 	}
+
+	return authnService
 }
 
 // registerRoutes registers the routes for the authentication.

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -47,6 +47,7 @@ type OAuthAuthnCoreServiceInterface interface {
 		map[string]interface{}, *serviceerror.ServiceError)
 	GetInternalUser(sub string) (*entityprovider.Entity, *serviceerror.ServiceError)
 	GetOAuthClientConfig(ctx context.Context, idpID string) (*OAuthClientConfig, *serviceerror.ServiceError)
+	Authenticate(ctx context.Context, idpID, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)
 }
 
 // OAuthAuthnServiceInterface defines the contract for OAuth based authenticator services.
@@ -69,15 +70,12 @@ type oAuthAuthnService struct {
 func newOAuthAuthnService(httpClient syshttp.HTTPClientInterface,
 	idpSvc idp.IDPServiceInterface, entityProvider entityprovider.EntityProviderInterface,
 ) OAuthAuthnServiceInterface {
-	service := &oAuthAuthnService{
+	return &oAuthAuthnService{
 		httpClient:     httpClient,
 		idpService:     idpSvc,
 		entityProvider: entityProvider,
 		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
 	}
-	common.RegisterAuthenticator(service.getMetadata())
-
-	return service
 }
 
 // NewOAuthAuthnService creates a new instance of OAuth authenticator service.
@@ -308,11 +306,50 @@ func (s *oAuthAuthnService) GetInternalUser(sub string) (*entityprovider.Entity,
 	return user, nil
 }
 
-// getMetadata returns the authenticator metadata for OAuth authenticator.
-func (s *oAuthAuthnService) getMetadata() common.AuthenticatorMeta {
-	return common.AuthenticatorMeta{
-		Name:          common.AuthenticatorOAuth,
-		Factors:       []common.AuthenticationFactor{common.FactorKnowledge},
-		AssociatedIDP: idp.IDPTypeOAuth,
+// Authenticate performs the full OAuth authentication flow: exchanges the code for a token,
+// fetches user info, extracts the subject claim, and resolves the internal user.
+// A missing internal user is NOT an error — the caller decides how to handle it.
+func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
+	*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	logger := s.logger.With(log.String("idpId", idpID))
+	logger.Debug("Performing federated OAuth authentication")
+
+	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
+	if svcErr != nil {
+		return nil, svcErr
 	}
+
+	userInfo, svcErr := s.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	sub := ""
+	if subVal, ok := userInfo["sub"]; ok && subVal != nil {
+		if subStr, ok := subVal.(string); ok && subStr != "" {
+			sub = subStr
+		}
+	}
+	if sub == "" {
+		logger.Debug("sub claim not found in user info")
+		return nil, &common.ErrorSubClaimNotFound
+	}
+
+	result := &common.FederatedAuthResult{
+		Sub:    sub,
+		Claims: userInfo,
+	}
+	user, svcErr := s.GetInternalUser(sub)
+	if svcErr != nil {
+		if svcErr.Code == common.ErrorUserNotFound.Code {
+			return result, nil
+		}
+		if svcErr.Code == common.ErrorAmbiguousUser.Code {
+			result.IsAmbiguousUser = true
+			return result, nil
+		}
+		return nil, svcErr
+	}
+	result.InternalEntity = user
+	return result, nil
 }

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -612,14 +612,6 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithServiceError() {
 	}
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestGetMetadata() {
-	svcImpl, ok := suite.service.(*oAuthAuthnService)
-	suite.True(ok)
-
-	meta := svcImpl.getMetadata()
-	suite.Equal(common.AuthenticatorOAuth, meta.Name)
-}
-
 func (suite *OAuthAuthnServiceTestSuite) TestValidateTokenResponseSuccess() {
 	tokenResp := &TokenResponse{
 		AccessToken: "access_token_123",

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -64,14 +64,11 @@ func newOIDCAuthnService(httpClient httpservice.HTTPClientInterface,
 	jwtSvc jwt.JWTServiceInterface) OIDCAuthnServiceInterface {
 	internal := authnoauth.NewOAuthAuthnService(httpClient, idpSvc, entityProvider)
 
-	service := &oidcAuthnService{
+	return &oidcAuthnService{
 		internal:   internal,
 		jwtService: jwtSvc,
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
 	}
-	authncm.RegisterAuthenticator(service.getMetadata())
-
-	return service
 }
 
 // NewOIDCAuthnService creates a new instance of OIDC authenticator service.
@@ -212,11 +209,68 @@ func (s *oidcAuthnService) GetInternalUser(sub string) (*entityprovider.Entity, 
 	return s.internal.GetInternalUser(sub)
 }
 
-// getMetadata returns the authenticator metadata for OIDC authenticator.
-func (s *oidcAuthnService) getMetadata() authncm.AuthenticatorMeta {
-	return authncm.AuthenticatorMeta{
-		Name:          authncm.AuthenticatorOIDC,
-		Factors:       []authncm.AuthenticationFactor{authncm.FactorKnowledge},
-		AssociatedIDP: idp.IDPTypeOIDC,
+// Authenticate performs the full OIDC authentication flow: exchanges the code for a token,
+// extracts ID token claims, and resolves the internal user.
+// A missing internal user is NOT an error — the caller decides how to handle it.
+func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string) (
+	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
+	logger := s.logger.With(log.String("idpId", idpID))
+	logger.Debug("Performing federated OIDC authentication")
+
+	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
+	if svcErr != nil {
+		return nil, svcErr
 	}
+
+	claims, svcErr := s.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Extract sub claim from the ID token claims.
+	sub := ""
+	if subVal, ok := claims["sub"]; ok && subVal != nil {
+		if subStr, ok := subVal.(string); ok && subStr != "" {
+			sub = subStr
+		}
+	}
+	if sub == "" {
+		logger.Debug("sub claim not found in ID token")
+		return nil, &authncm.ErrorSubClaimNotFound
+	}
+
+	// Fetch user info if additional scopes are configured so callers get the full attribute set.
+	oauthConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
+	if svcErr == nil && len(oauthConfig.Scopes) > 1 {
+		userInfo, infoErr := s.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
+		if infoErr == nil {
+			if userInfoSub, ok := userInfo["sub"].(string); !ok || userInfoSub == sub {
+				for k, v := range userInfo {
+					if _, exists := claims[k]; !exists {
+						claims[k] = v
+					}
+				}
+			} else {
+				logger.Debug("UserInfo sub mismatch, skipping attribute merge")
+			}
+		}
+	}
+
+	result := &authncm.FederatedAuthResult{
+		Sub:    sub,
+		Claims: claims,
+	}
+	user, svcErr := s.GetInternalUser(sub)
+	if svcErr != nil {
+		if svcErr.Code == authncm.ErrorUserNotFound.Code {
+			return result, nil
+		}
+		if svcErr.Code == authncm.ErrorAmbiguousUser.Code {
+			result.IsAmbiguousUser = true
+			return result, nil
+		}
+		return nil, svcErr
+	}
+	result.InternalEntity = user
+	return result, nil
 }

--- a/backend/internal/authn/oidc/service_test.go
+++ b/backend/internal/authn/oidc/service_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -434,11 +433,6 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseValidateIDToken
 func (suite *OIDCAuthnServiceTestSuite) TestNewOIDCAuthnService_HttpClientFallback() {
 	svc := NewOIDCAuthnService(nil, suite.mockIdpService, suite.mockEntityProvider, suite.mockJWTService)
 	suite.NotNil(svc)
-	// type assert to concrete to inspect metadata
-	if concrete, ok := svc.(*oidcAuthnService); ok {
-		meta := concrete.getMetadata()
-		suite.Equal(authncm.AuthenticatorOIDC, meta.Name)
-	}
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestGetIDTokenClaimsMalformedToken() {

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -44,7 +44,6 @@ import (
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
-	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 const svcLoggerComponentName = "AuthenticationService"
@@ -320,25 +319,33 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 		return nil, svcErr
 	}
 
-	// Route to appropriate service based on IDP type from session
-	var user *entityprovider.Entity
-	switch sessionData.IDPType {
-	case idp.IDPTypeOAuth:
-		_, user, svcErr = as.finishOAuthAuthentication(ctx, sessionData.IDPID, code, logger)
-	case idp.IDPTypeOIDC:
-		_, user, svcErr = as.finishOIDCAuthentication(ctx, sessionData.IDPID, code, logger)
-	case idp.IDPTypeGoogle:
-		_, user, svcErr = as.finishGoogleAuthentication(ctx, sessionData.IDPID, code, logger)
-	case idp.IDPTypeGitHub:
-		_, user, svcErr = as.finishGithubAuthentication(ctx, sessionData.IDPID, code, logger)
-	default:
-		logger.Error("Unsupported IDP type in session", log.String("idpId", sessionData.IDPID),
-			log.String("type", string(sessionData.IDPType)))
+	credentials := map[string]interface{}{
+		"federated": &common.FederatedAuthCredential{
+			IDPID:   sessionData.IDPID,
+			IDPType: sessionData.IDPType,
+			Code:    code,
+		},
+	}
+	_, basicResult, svcErr := as.authnProvider.AuthenticateUser(
+		ctx, nil, credentials, nil, nil, authnprovidermgr.AuthUser{})
+	if svcErr != nil {
+		return nil, as.mapFederatedAuthnError(svcErr, logger)
+	}
+	if basicResult == nil {
+		logger.Error("Federated authenticate response is nil")
 		return nil, &serviceerror.InternalServerError
 	}
+	if basicResult.IsAmbiguousUser {
+		return nil, &common.ErrorUserNotFound
+	}
+	if !basicResult.IsExistingUser {
+		return nil, &common.ErrorUserNotFound
+	}
 
-	if svcErr != nil {
-		return nil, svcErr
+	user := &entityprovider.Entity{
+		ID:   basicResult.UserID,
+		Type: basicResult.UserType,
+		OUID: basicResult.OUID,
 	}
 
 	authResponse := &common.AuthenticationResponse{
@@ -506,114 +513,21 @@ func (as *authenticationService) extractClaimsFromAssertion(assertion string,
 	return &assuranceCtx, sub, nil
 }
 
-// finishOAuthAuthentication handles OAuth authentication completion.
-func (as *authenticationService) finishOAuthAuthentication(ctx context.Context, idpID, code string,
-	logger *log.Logger) (string, *entityprovider.Entity, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.oauthService.ExchangeCodeForToken(ctx, idpID, code, true)
-	if svcErr != nil {
-		return "", nil, svcErr
+// mapFederatedAuthnError maps provider manager errors to federated-authentication-specific service errors.
+func (as *authenticationService) mapFederatedAuthnError(svcErr *serviceerror.ServiceError,
+	logger *log.Logger) *serviceerror.ServiceError {
+	switch svcErr.Code {
+	case authnprovidermgr.ErrorAuthenticationFailed.Code:
+		return &ErrorFederatedAuthenticationFailed
+	case authnprovidermgr.ErrorUserNotFound.Code:
+		return &ErrorFederatedAuthenticationFailed
+	case authnprovidermgr.ErrorInvalidRequest.Code:
+		return &ErrorFederatedAuthenticationFailed
+	default:
+		logger.Error("Error occurred while performing federated authentication",
+			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
+		return &serviceerror.InternalServerError
 	}
-
-	userInfo, svcErr := as.oauthService.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	sub, svcErr := as.getSubClaim(userInfo, logger)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	user, svcErr := as.oauthService.GetInternalUser(sub)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	return sub, user, nil
-}
-
-// finishOIDCAuthentication handles OIDC authentication completion.
-func (as *authenticationService) finishOIDCAuthentication(ctx context.Context, idpID, code string,
-	logger *log.Logger) (string, *entityprovider.Entity, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.oidcService.ExchangeCodeForToken(ctx, idpID, code, true)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	claims, svcErr := as.oidcService.GetIDTokenClaims(tokenResp.IDToken)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
-	//  support is added
-
-	sub, svcErr := as.getSubClaim(claims, logger)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	user, svcErr := as.oidcService.GetInternalUser(sub)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	return sub, user, nil
-}
-
-// finishGoogleAuthentication handles Google authentication completion.
-func (as *authenticationService) finishGoogleAuthentication(ctx context.Context, idpID, code string,
-	logger *log.Logger) (string, *entityprovider.Entity, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.googleService.ExchangeCodeForToken(ctx, idpID, code, true)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	claims, svcErr := as.googleService.GetIDTokenClaims(tokenResp.IDToken)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
-	//  support is added
-
-	sub, svcErr := as.getSubClaim(claims, logger)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	user, svcErr := as.googleService.GetInternalUser(sub)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	return sub, user, nil
-}
-
-// finishGithubAuthentication handles GitHub authentication completion.
-func (as *authenticationService) finishGithubAuthentication(ctx context.Context, idpID, code string,
-	logger *log.Logger) (string, *entityprovider.Entity, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.githubService.ExchangeCodeForToken(ctx, idpID, code, true)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	userInfo, svcErr := as.githubService.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	sub, svcErr := as.getSubClaim(userInfo, logger)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	user, svcErr := as.githubService.GetInternalUser(sub)
-	if svcErr != nil {
-		return "", nil, svcErr
-	}
-
-	return sub, user, nil
 }
 
 // mapCredentialsAuthnError maps provider manager errors to credentials-specific service errors.
@@ -742,28 +656,6 @@ func (as *authenticationService) verifyAndDecodeSessionToken(token string, logge
 	}
 
 	return &sessionData, nil
-}
-
-// getSubClaim extracts the 'sub' claim from user info claims.
-func (as *authenticationService) getSubClaim(userClaims map[string]interface{}, logger *log.Logger) (
-	string, *serviceerror.ServiceError) {
-	sub, ok := userClaims["sub"]
-	if ok && sub != nil {
-		if subStr, ok := sub.(string); ok && subStr != "" {
-			return subStr, nil
-		}
-	}
-
-	// Try 'id' field as fallback
-	id, ok := userClaims["id"]
-	if ok && id != nil {
-		if idStr := sysutils.ConvertInterfaceValueToString(id); idStr != "" {
-			return idStr, nil
-		}
-	}
-
-	logger.Debug("sub claim not found in user info claims")
-	return "", &common.ErrorSubClaimNotFound
 }
 
 // StartPasskeyRegistration starts the passkey registration process.

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/authn/assert"
 	"github.com/asgardeo/thunder/internal/authn/common"
-	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
 	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
@@ -768,30 +767,27 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationOAuthSuccess() {
-	testUser := &entityprovider.Entity{
-		ID:   testUserID,
-		Type: "person",
-		OUID: testOrgUnit,
-	}
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		TokenType:   "Bearer",
-	}
-	userInfo := map[string]interface{}{
-		"sub": testUserID,
-	}
-
-	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
+func (suite *AuthenticationServiceTestSuite) mockFederatedAuthnSuccess(idpType idp.IDPType) string {
+	sessionToken := suite.createSessionToken(idpType)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			UserID:         testUserID,
+			UserType:       "person",
+			OUID:           testOrgUnit,
+			IsExistingUser: true,
+		}, nil).Once()
+	return sessionToken
+}
 
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationOAuthSuccess() {
+	sessionToken := suite.mockFederatedAuthnSuccess(idp.IDPTypeOAuth)
 	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOAuth, sessionToken, true, "",
 		testAuthCode)
-
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(testUserID, result.ID)
@@ -799,34 +795,33 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationOAuthSuc
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationOIDCSuccess() {
-	suite.testFinishOIDCBasedAuth(idp.IDPTypeOIDC, suite.mockOIDCService)
+	sessionToken := suite.mockFederatedAuthnSuccess(idp.IDPTypeOIDC)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOIDC, sessionToken, true, "",
+		testAuthCode)
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(testUserID, result.ID)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationGoogleSuccess() {
-	suite.testFinishOIDCBasedAuth(idp.IDPTypeGoogle, suite.mockGoogleService)
+	sessionToken := suite.mockFederatedAuthnSuccess(idp.IDPTypeGoogle)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeGoogle, sessionToken, true, "", testAuthCode)
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(testUserID, result.ID)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationGitHubSuccess() {
-	userInfo := map[string]interface{}{
-		"sub": testUserID,
-	}
-	suite.testFinishOAuthBasedAuth(idp.IDPTypeGitHub, suite.mockGithubService, userInfo)
+	sessionToken := suite.mockFederatedAuthnSuccess(idp.IDPTypeGitHub)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeGitHub, sessionToken, true, "", testAuthCode)
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(testUserID, result.ID)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAssertion() {
-	testUser := &entityprovider.Entity{
-		ID:   testUserID,
-		Type: "person",
-		OUID: testOrgUnit,
-	}
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		TokenType:   "Bearer",
-	}
-	userInfo := map[string]interface{}{
-		"sub": testUserID,
-	}
-
 	testCases := []struct {
 		name              string
 		skipAssertion     bool
@@ -841,11 +836,17 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			setupMocks: func() {
 				sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-					Return(tokenResp, nil).Once()
-				suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).
-					Return(userInfo, nil).Once()
-				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
+				suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+					mock.MatchedBy(func(creds map[string]interface{}) bool {
+						_, ok := creds["federated"]
+						return ok
+					}), mock.Anything, mock.Anything, mock.Anything).
+					Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+						UserID:         testUserID,
+						UserType:       "person",
+						OUID:           testOrgUnit,
+						IsExistingUser: true,
+					}, nil).Once()
 				suite.mockAssertGenerator.On("GenerateAssertion", mock.Anything).Return(
 					&assert.AssertionResult{
 						Context: &assert.AssuranceContext{
@@ -869,11 +870,17 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 				existingAssertion := suite.createTestAssertion(testUserID)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 				suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-					Return(tokenResp, nil).Once()
-				suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).
-					Return(userInfo, nil).Once()
-				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
+				suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+					mock.MatchedBy(func(creds map[string]interface{}) bool {
+						_, ok := creds["federated"]
+						return ok
+					}), mock.Anything, mock.Anything, mock.Anything).
+					Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+						UserID:         testUserID,
+						UserType:       "person",
+						OUID:           testOrgUnit,
+						IsExistingUser: true,
+					}, nil).Once()
 				suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).Return(
 					&assert.AssertionResult{
 						Context: &assert.AssuranceContext{
@@ -883,7 +890,6 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 					}, nil).Once()
 				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
-						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
 					}), mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
@@ -964,20 +970,17 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationTypeMism
 	suite.Equal(common.ErrorInvalidIDPType.Code, err.Code)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationSubClaimNotFound() {
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		TokenType:   "Bearer",
-	}
-	userInfo := map[string]interface{}{
-		"name": "Test User",
-	}
-
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationUserNotFound() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: false,
+		}, nil).Once()
 
 	result, err := suite.service.FinishIDPAuthentication(
 		context.Background(), idp.IDPTypeOAuth, sessionToken, false, "",
@@ -985,14 +988,26 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationSubClaim
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)
+	suite.Equal(common.ErrorUserNotFound.Code, err.Code)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationSubClaimFallbackToID() {
-	userInfo := map[string]interface{}{
-		"id": testUserID,
-	}
-	suite.testFinishOAuthBasedAuth(idp.IDPTypeOAuth, suite.mockOAuthService, userInfo)
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationProviderAuthFailure() {
+	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
+	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, nil, &authnprovidermgr.ErrorAuthenticationFailed).Once()
+
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeOAuth, sessionToken, false, "",
+		testAuthCode)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorFederatedAuthenticationFailed.Code, err.Code)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeExactMatch() {
@@ -1018,52 +1033,6 @@ func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeMismatch() {
 	err := suite.service.validateIDPType(idp.IDPTypeGoogle, idp.IDPTypeGitHub, logger)
 	suite.NotNil(err)
 	suite.Equal(common.ErrorInvalidIDPType.Code, err.Code)
-}
-
-func (suite *AuthenticationServiceTestSuite) TestGetSubClaimFromSub() {
-	userClaims := map[string]interface{}{
-		"sub": testUserID,
-	}
-
-	result, err := suite.service.getSubClaim(userClaims, nil)
-
-	suite.Nil(err)
-	suite.Equal(testUserID, result)
-}
-
-func (suite *AuthenticationServiceTestSuite) TestGetSubClaimFromID() {
-	userClaims := map[string]interface{}{
-		"id": testUserID,
-	}
-
-	result, err := suite.service.getSubClaim(userClaims, nil)
-
-	suite.Nil(err)
-	suite.Equal(testUserID, result)
-}
-
-func (suite *AuthenticationServiceTestSuite) TestGetSubClaimFromIDNumeric() {
-	userClaims := map[string]interface{}{
-		"id": 12345,
-	}
-
-	result, err := suite.service.getSubClaim(userClaims, nil)
-
-	suite.Nil(err)
-	suite.Equal("12345", result)
-}
-
-func (suite *AuthenticationServiceTestSuite) TestGetSubClaimNotFound() {
-	logger := log.GetLogger()
-	userClaims := map[string]interface{}{
-		"name": "Test User",
-	}
-
-	result, err := suite.service.getSubClaim(userClaims, logger)
-
-	suite.Empty(result)
-	suite.NotNil(err)
-	suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestHandleIDPServiceErrorServerError() {
@@ -1142,144 +1111,22 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationBuildURLE
 	suite.Equal(svcErr.Code, err.Code)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestFinishOIDCAuthenticationFetchUserInfoError() {
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		IDToken:     "id_token_123",
-		TokenType:   "Bearer",
-	}
-	svcErr := &serviceerror.ServiceError{
-		Type:  serviceerror.ClientErrorType,
-		Code:  "FETCH_ERROR",
-		Error: core.I18nMessage{Key: "error.test.fetch_error", DefaultValue: "Fetch error"},
-		ErrorDescription: core.I18nMessage{
-			Key: "error.test.failed_to_fetch_id_token_claims", DefaultValue: "Failed to fetch ID token claims",
-		},
-	}
-
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationProviderServerError() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOIDC)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_123").Return(nil, svcErr)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, nil, &serviceerror.InternalServerError).Once()
 
 	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOIDC, sessionToken, true, "",
 		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(svcErr.Code, err.Code)
-}
-
-func (suite *AuthenticationServiceTestSuite) TestFinishGoogleAuthenticationGetInternalUserError() {
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		IDToken:     "id_token_123",
-		TokenType:   "Bearer",
-	}
-	claims := map[string]interface{}{
-		"sub": testUserID,
-	}
-	svcErr := &serviceerror.ServiceError{
-		Type:  serviceerror.ClientErrorType,
-		Code:  "USER_NOT_FOUND",
-		Error: core.I18nMessage{Key: "error.test.user_not_found", DefaultValue: "User not found"},
-		ErrorDescription: core.I18nMessage{
-			Key: "error.test.internal_user_not_found", DefaultValue: "Internal user not found",
-		},
-	}
-
-	sessionToken := suite.createSessionToken(idp.IDPTypeGoogle)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockGoogleService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-		Return(tokenResp, nil)
-	suite.mockGoogleService.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
-	suite.mockGoogleService.On("GetInternalUser", testUserID).Return(nil, svcErr)
-
-	result, err := suite.service.FinishIDPAuthentication(
-		context.Background(), idp.IDPTypeGoogle, sessionToken, true, "",
-		testAuthCode)
-
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(svcErr.Code, err.Code)
-}
-
-func (suite *AuthenticationServiceTestSuite) testFinishOIDCBasedAuth(
-	idpType idp.IDPType,
-	mockService interface{},
-) {
-	testUser := &entityprovider.Entity{
-		ID:   testUserID,
-		Type: "person",
-		OUID: testOrgUnit,
-	}
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		IDToken:     "id_token_123",
-		TokenType:   "Bearer",
-	}
-	claims := map[string]interface{}{
-		"sub": testUserID,
-	}
-
-	sessionToken := suite.createSessionToken(idpType)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-
-	switch service := mockService.(type) {
-	case *oidcmock.OIDCAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
-		service.On("GetInternalUser", testUserID).Return(testUser, nil)
-	case *googlemock.GoogleOIDCAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
-		service.On("GetInternalUser", testUserID).Return(testUser, nil)
-	}
-
-	result, err := suite.service.FinishIDPAuthentication(context.Background(), idpType, sessionToken, true, "",
-		testAuthCode)
-
-	suite.Nil(err)
-	suite.NotNil(result)
-	suite.Equal(testUserID, result.ID)
-}
-
-func (suite *AuthenticationServiceTestSuite) testFinishOAuthBasedAuth(
-	idpType idp.IDPType,
-	mockService interface{},
-	userInfo map[string]interface{},
-) {
-	testUser := &entityprovider.Entity{
-		ID:   testUserID,
-		Type: "person",
-		OUID: testOrgUnit,
-	}
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		TokenType:   "Bearer",
-	}
-
-	sessionToken := suite.createSessionToken(idpType)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-
-	switch service := mockService.(type) {
-	case *githubmock.GithubOAuthAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
-		service.On("GetInternalUser", testUserID).Return(testUser, nil)
-	case *oauthmock.OAuthAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
-		service.On("GetInternalUser", testUserID).Return(testUser, nil)
-	}
-
-	result, err := suite.service.FinishIDPAuthentication(context.Background(), idpType, sessionToken, true, "",
-		testAuthCode)
-
-	suite.Nil(err)
-	suite.NotNil(result)
-	suite.Equal(testUserID, result.ID)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
 func (suite *AuthenticationServiceTestSuite) createSessionToken(idpType idp.IDPType) string {
@@ -1336,26 +1183,19 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionE
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAssertionGenerationError() {
-	testUser := &entityprovider.Entity{
-		ID:   testUserID,
-		Type: "person",
-		OUID: testOrgUnit,
-	}
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: testToken,
-		TokenType:   "Bearer",
-	}
-	userInfo := map[string]interface{}{
-		"sub": testUserID,
-	}
-
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
-		Return(tokenResp, nil).Once()
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil).Once()
-	suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			UserID:         testUserID,
+			UserType:       "person",
+			OUID:           testOrgUnit,
+			IsExistingUser: true,
+		}, nil).Once()
 
 	// Create invalid existing assertion that will fail JWT verification
 	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).

--- a/backend/internal/authnprovider/common/model.go
+++ b/backend/internal/authnprovider/common/model.go
@@ -39,6 +39,13 @@ type AuthnResult struct {
 	Token                     string              `json:"token"`
 	IsAttributeValuesIncluded bool                `json:"isAttributeValuesIncluded"`
 	AttributesResponse        *AttributesResponse `json:"attributesResponse,omitempty"`
+
+	// Federated authentication fields. Set when the authentication flow is federated
+	// and no internal user was found (IsExistingUser = false).
+	ExternalSub     string                 `json:"externalSub,omitempty"`
+	ExternalClaims  map[string]interface{} `json:"externalClaims,omitempty"`
+	IsExistingUser  bool                   `json:"isExistingUser"`
+	IsAmbiguousUser bool                   `json:"isAmbiguousUser"`
 }
 
 // GetAttributesMetadata contains metadata for fetching attributes.

--- a/backend/internal/authnprovider/manager/init.go
+++ b/backend/internal/authnprovider/manager/init.go
@@ -19,15 +19,18 @@
 package manager
 
 import (
+	authncommon "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	"github.com/asgardeo/thunder/internal/authnprovider/provider"
 	"github.com/asgardeo/thunder/internal/entity"
+	"github.com/asgardeo/thunder/internal/idp"
 )
 
 // InitializeAuthnProviderManager initializes and returns an AuthnProviderManagerInterface.
 func InitializeAuthnProviderManager(entitySvc entity.EntityServiceInterface,
-	passkeySvc passkey.PasskeyServiceInterface, otpSvc otp.OTPAuthnServiceInterface) AuthnProviderManagerInterface {
-	p := provider.InitializeAuthnProvider(entitySvc, passkeySvc, otpSvc)
+	passkeySvc passkey.PasskeyServiceInterface, otpSvc otp.OTPAuthnServiceInterface,
+	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator) AuthnProviderManagerInterface {
+	p := provider.InitializeAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
 	return newAuthnProviderManager(p)
 }

--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -73,6 +73,14 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 			})
 		}
 	}
+	if !result.IsExistingUser {
+		return authUser, &AuthnBasicResult{
+			ExternalSub:     result.ExternalSub,
+			ExternalClaims:  result.ExternalClaims,
+			IsExistingUser:  false,
+			IsAmbiguousUser: result.IsAmbiguousUser,
+		}, nil
+	}
 	authUser.setIdentity(result.UserID, result.UserType, result.OUID)
 	authUser.setProviderData(defaultProvider, providerData{
 		token:                     result.Token,
@@ -80,9 +88,12 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 		isAttributeValuesIncluded: result.IsAttributeValuesIncluded,
 	})
 	return authUser, &AuthnBasicResult{
-		UserID:   result.UserID,
-		OUID:     result.OUID,
-		UserType: result.UserType,
+		UserID:         result.UserID,
+		OUID:           result.OUID,
+		UserType:       result.UserType,
+		IsExistingUser: true,
+		ExternalSub:    result.ExternalSub,
+		ExternalClaims: result.ExternalClaims,
 	}, nil
 }
 

--- a/backend/internal/authnprovider/manager/manager_test.go
+++ b/backend/internal/authnprovider/manager/manager_test.go
@@ -59,6 +59,7 @@ func (s *ManagerTestSuite) TestAuthenticateUser_Success() {
 			Token:                     "tok",
 			IsAttributeValuesIncluded: false,
 			AttributesResponse:        nil,
+			IsExistingUser:            true,
 		}, (*serviceerror.ServiceError)(nil))
 
 	returnedAuthUser, result, svcErr := s.mgr.AuthenticateUser(context.Background(), identifiers, credentials,
@@ -79,6 +80,34 @@ func (s *ManagerTestSuite) TestAuthenticateUser_Success() {
 	s.True(ok)
 	s.Equal("tok", pd.token)
 	s.False(pd.isAttributeValuesIncluded)
+}
+
+func (s *ManagerTestSuite) TestAuthenticateUser_FederatedNewUser() {
+	identifiers := map[string]interface{}{}
+	credentials := map[string]interface{}{"federated": "token"}
+	meta := &authnprovidercm.AuthnMetadata{}
+
+	s.mockProvider.On("Authenticate", context.Background(), identifiers, credentials, meta).
+		Return(&authnprovidercm.AuthnResult{
+			IsExistingUser:  false,
+			IsAmbiguousUser: false,
+			ExternalSub:     "ext-sub-123",
+			ExternalClaims:  map[string]interface{}{"email": "new@example.com"},
+		}, (*serviceerror.ServiceError)(nil))
+
+	returnedAuthUser, result, svcErr := s.mgr.AuthenticateUser(context.Background(), identifiers, credentials,
+		nil, meta, AuthUser{})
+
+	s.Nil(svcErr)
+	s.NotNil(result)
+	s.False(result.IsExistingUser)
+	s.False(result.IsAmbiguousUser)
+	s.Equal("ext-sub-123", result.ExternalSub)
+	s.Equal(map[string]interface{}{"email": "new@example.com"}, result.ExternalClaims)
+
+	s.False(returnedAuthUser.IsAuthenticated())
+	_, ok := returnedAuthUser.getProviderData(defaultProvider)
+	s.False(ok)
 }
 
 func (s *ManagerTestSuite) TestAuthenticateUser_ClientError() {
@@ -177,10 +206,10 @@ func (s *ManagerTestSuite) TestAuthenticateUser_ReAuth() {
 	meta := &authnprovidercm.AuthnMetadata{}
 
 	firstResult := &authnprovidercm.AuthnResult{
-		UserID: "user-1", UserType: "customer", OUID: "ou-1", Token: "tok-first",
+		UserID: "user-1", UserType: "customer", OUID: "ou-1", Token: "tok-first", IsExistingUser: true,
 	}
 	secondResult := &authnprovidercm.AuthnResult{
-		UserID: "user-1", UserType: "customer", OUID: "ou-1", Token: "tok-second",
+		UserID: "user-1", UserType: "customer", OUID: "ou-1", Token: "tok-second", IsExistingUser: true,
 	}
 
 	s.mockProvider.On("Authenticate", context.Background(), identifiers, credentials, meta).

--- a/backend/internal/authnprovider/manager/model.go
+++ b/backend/internal/authnprovider/manager/model.go
@@ -49,6 +49,13 @@ type AuthnBasicResult struct {
 	UserID   string
 	OUID     string
 	UserType string
+
+	// Federated authentication fields. Set when the authentication flow is federated
+	// and no internal user was found (IsExistingUser = false).
+	ExternalSub     string
+	ExternalClaims  map[string]interface{}
+	IsExistingUser  bool
+	IsAmbiguousUser bool
 }
 
 func (a *AuthUser) setIdentity(userID, userType, ouID string) {

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -24,10 +24,12 @@ import (
 	"encoding/json"
 	"errors"
 
+	authncommon "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
 	"github.com/asgardeo/thunder/internal/entity"
+	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -37,16 +39,19 @@ type defaultAuthnProvider struct {
 	entitySvc      entity.EntityServiceInterface
 	passkeyService passkey.PasskeyServiceInterface
 	otpService     otp.OTPAuthnServiceInterface
+	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator
 	logger         *log.Logger
 }
 
 // newDefaultAuthnProvider creates a new internal user authn provider.
 func newDefaultAuthnProvider(entitySvc entity.EntityServiceInterface,
-	passkeyService passkey.PasskeyServiceInterface, otpService otp.OTPAuthnServiceInterface) AuthnProviderInterface {
+	passkeyService passkey.PasskeyServiceInterface, otpService otp.OTPAuthnServiceInterface,
+	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator) AuthnProviderInterface {
 	return &defaultAuthnProvider{
 		entitySvc:      entitySvc,
 		passkeyService: passkeyService,
 		otpService:     otpService,
+		federatedAuths: federatedAuths,
 		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DefaultAuthnProvider")),
 	}
 }
@@ -62,89 +67,15 @@ func (p *defaultAuthnProvider) Authenticate(
 			"Credentials are required", "Credentials are required for authentication")
 	}
 
-	authenticatedEntityID := ""
-
-	if passkeyCredential, ok := credentials["passkey"]; ok {
-		passkeyCredential, ok := passkeyCredential.(*passkey.PasskeyAuthenticationFinishRequest)
-		if !ok || passkeyCredential == nil {
-			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-				"Invalid passkey payload", "The provided passkey credential is invalid")
-		}
-		authResponse, authErr := p.passkeyService.FinishAuthentication(ctx, passkeyCredential)
-		if authErr != nil {
-			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
-				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
-		}
-		authenticatedEntityID = authResponse.ID
-	} else if otpCredential, ok := credentials["otp"]; ok {
-		otpCredential, ok := otpCredential.(map[string]interface{})
-		if !ok {
-			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-				"Invalid OTP payload", "The provided OTP credential is invalid")
-		}
-		sessionToken, ok := otpCredential["sessionToken"].(string)
-		if !ok || sessionToken == "" {
-			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-				"Invalid OTP payload", "sessionToken is required")
-		}
-		otpValue, ok := otpCredential["otp"].(string)
-		if !ok || otpValue == "" {
-			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-				"Invalid OTP payload", "otp is required")
-		}
-		authResponse, authErr := p.otpService.Authenticate(ctx, sessionToken, otpValue)
-		if authErr != nil {
-			if authErr.Type == serviceerror.ClientErrorType {
-				if authErr.Code == otp.ErrorIncorrectOTP.Code {
-					return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
-						authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
-				}
-				return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-					authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
-			}
-			return nil, p.logAndReturnServerError("OTP authentication failed with server error",
-				log.String("error", authErr.Error.DefaultValue),
-				log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
-		}
-		authenticatedEntityID = authResponse.ID
-	} else if userID, ok := identifiers["userID"]; ok && userID != "" {
-		userIDStr, ok := userID.(string)
-		if !ok || userIDStr == "" {
-			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
-				"Invalid user ID", "The provided userID is invalid")
-		}
-		authResult, authErr := p.entitySvc.AuthenticateEntityByID(ctx, userIDStr, credentials)
-		if authErr != nil {
-			if errors.Is(authErr, entity.ErrEntityNotFound) {
-				return nil, newClientError(authnprovidercm.ErrorCodeUserNotFound,
-					"User not found", "The specified user does not exist")
-			}
-			if errors.Is(authErr, entity.ErrAuthenticationFailed) {
-				return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
-					"Authentication failed", "Invalid credentials provided")
-			}
-			return nil, p.logAndReturnServerError("Basic authentication by ID failed with server error",
-				log.String("error", authErr.Error()))
-		}
-		authenticatedEntityID = authResult.EntityID
-	} else {
-		authResult, authErr := p.entitySvc.AuthenticateEntity(ctx, identifiers, credentials)
-		if authErr != nil {
-			if errors.Is(authErr, entity.ErrEntityNotFound) {
-				return nil, newClientError(authnprovidercm.ErrorCodeUserNotFound,
-					"User not found", "The specified user does not exist")
-			}
-			if errors.Is(authErr, entity.ErrAuthenticationFailed) {
-				return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
-					"Authentication failed", "Invalid credentials provided")
-			}
-			return nil, p.logAndReturnServerError("Basic authentication failed with server error",
-				log.String("error", authErr.Error()))
-		}
-		authenticatedEntityID = authResult.EntityID
+	authOutcome, svcErr := p.resolveCredentials(ctx, identifiers, credentials)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+	if authOutcome.earlyReturn != nil {
+		return authOutcome.earlyReturn, nil
 	}
 
-	entityResult, getErr := p.entitySvc.GetEntity(ctx, authenticatedEntityID)
+	entityResult, getErr := p.entitySvc.GetEntity(ctx, authOutcome.entityID)
 	if getErr != nil {
 		if errors.Is(getErr, entity.ErrEntityNotFound) {
 			return nil, newClientError(authnprovidercm.ErrorCodeUserNotFound,
@@ -174,16 +105,181 @@ func (p *defaultAuthnProvider) Authenticate(
 	}
 
 	return &authnprovidercm.AuthnResult{
-		EntityID:                  authenticatedEntityID,
+		EntityID:                  authOutcome.entityID,
 		EntityCategory:            string(entityResult.Category),
 		EntityType:                entityResult.Type,
 		OUID:                      entityResult.OUID,
-		UserID:                    authenticatedEntityID,
-		Token:                     authenticatedEntityID,
+		UserID:                    authOutcome.entityID,
+		Token:                     authOutcome.entityID,
 		UserType:                  entityResult.Type,
 		IsAttributeValuesIncluded: false,
 		AttributesResponse:        attributesResponse,
+		IsExistingUser:            true,
+		ExternalSub:               authOutcome.externalSub,
+		ExternalClaims:            authOutcome.externalClaims,
 	}, nil
+}
+
+type credentialOutcome struct {
+	entityID       string
+	externalSub    string
+	externalClaims map[string]interface{}
+	earlyReturn    *authnprovidercm.AuthnResult
+}
+
+func (p *defaultAuthnProvider) resolveCredentials(
+	ctx context.Context,
+	identifiers, credentials map[string]interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	if passkeyCredential, ok := credentials["passkey"]; ok {
+		return p.authenticateWithPasskey(ctx, passkeyCredential)
+	}
+	if otpCredential, ok := credentials["otp"]; ok {
+		return p.authenticateWithOTP(ctx, otpCredential)
+	}
+	if fedCred, ok := credentials["federated"]; ok {
+		return p.authenticateWithFederated(ctx, fedCred)
+	}
+	if userID, ok := identifiers["userID"]; ok && userID != "" {
+		return p.authenticateByUserID(ctx, userID, credentials)
+	}
+	return p.authenticateByIdentifiers(ctx, identifiers, credentials)
+}
+
+func (p *defaultAuthnProvider) authenticateWithPasskey(
+	ctx context.Context, raw interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	cred, ok := raw.(*passkey.PasskeyAuthenticationFinishRequest)
+	if !ok || cred == nil {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid passkey payload", "The provided passkey credential is invalid")
+	}
+	authResponse, authErr := p.passkeyService.FinishAuthentication(ctx, cred)
+	if authErr != nil {
+		return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
+			authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
+	}
+	return &credentialOutcome{entityID: authResponse.ID}, nil
+}
+
+func (p *defaultAuthnProvider) authenticateWithOTP(
+	ctx context.Context, raw interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	otpCredential, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid OTP payload", "The provided OTP credential is invalid")
+	}
+	sessionToken, ok := otpCredential["sessionToken"].(string)
+	if !ok || sessionToken == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid OTP payload", "sessionToken is required")
+	}
+	otpValue, ok := otpCredential["otp"].(string)
+	if !ok || otpValue == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid OTP payload", "otp is required")
+	}
+	authResponse, authErr := p.otpService.Authenticate(ctx, sessionToken, otpValue)
+	if authErr != nil {
+		if authErr.Type == serviceerror.ClientErrorType {
+			if authErr.Code == otp.ErrorIncorrectOTP.Code {
+				return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
+					authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
+			}
+			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
+		}
+		return nil, p.logAndReturnServerError("OTP authentication failed with server error",
+			log.String("error", authErr.Error.DefaultValue),
+			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
+	}
+	return &credentialOutcome{entityID: authResponse.ID}, nil
+}
+
+func (p *defaultAuthnProvider) authenticateWithFederated(
+	ctx context.Context, raw interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	cred, ok := raw.(*authncommon.FederatedAuthCredential)
+	if !ok || cred == nil {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid federated credential payload", "The provided federated credential is invalid")
+	}
+	if cred.IDPID == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Missing IDP ID", "The federated credential must include a non-empty IDP ID")
+	}
+	if cred.Code == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Missing authorization code", "The federated credential must include a non-empty authorization code")
+	}
+	svc, ok := p.federatedAuths[cred.IDPType]
+	if !ok {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Unsupported IDP type", "The provided IDP type is not supported for federated authentication")
+	}
+	authResult, authErr := svc.Authenticate(ctx, cred.IDPID, cred.Code)
+	if authErr != nil {
+		if authErr.Type == serviceerror.ClientErrorType {
+			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
+				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
+		}
+		return nil, p.logAndReturnServerError("Federated authentication failed with server error",
+			log.String("error", authErr.Error.DefaultValue),
+			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
+	}
+	if authResult.InternalEntity == nil {
+		return &credentialOutcome{
+			earlyReturn: &authnprovidercm.AuthnResult{
+				ExternalSub:     authResult.Sub,
+				ExternalClaims:  authResult.Claims,
+				IsExistingUser:  false,
+				IsAmbiguousUser: authResult.IsAmbiguousUser,
+			},
+		}, nil
+	}
+	return &credentialOutcome{
+		entityID:       authResult.InternalEntity.ID,
+		externalSub:    authResult.Sub,
+		externalClaims: authResult.Claims,
+	}, nil
+}
+
+func (p *defaultAuthnProvider) authenticateByUserID(
+	ctx context.Context, userID interface{}, credentials map[string]interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	userIDStr, ok := userID.(string)
+	if !ok || userIDStr == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid user ID", "The provided userID is invalid")
+	}
+	authResult, authErr := p.entitySvc.AuthenticateEntityByID(ctx, userIDStr, credentials)
+	if authErr != nil {
+		return nil, p.handleEntityAuthError(authErr, "Basic authentication by ID failed with server error")
+	}
+	return &credentialOutcome{entityID: authResult.EntityID}, nil
+}
+
+func (p *defaultAuthnProvider) authenticateByIdentifiers(
+	ctx context.Context, identifiers, credentials map[string]interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	authResult, authErr := p.entitySvc.AuthenticateEntity(ctx, identifiers, credentials)
+	if authErr != nil {
+		return nil, p.handleEntityAuthError(authErr, "Basic authentication failed with server error")
+	}
+	return &credentialOutcome{entityID: authResult.EntityID}, nil
+}
+
+func (p *defaultAuthnProvider) handleEntityAuthError(err error, serverMsg string) *serviceerror.ServiceError {
+	if errors.Is(err, entity.ErrEntityNotFound) {
+		return newClientError(authnprovidercm.ErrorCodeUserNotFound,
+			"User not found", "The specified user does not exist")
+	}
+	if errors.Is(err, entity.ErrAuthenticationFailed) {
+		return newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
+			"Authentication failed", "Invalid credentials provided")
+	}
+	return p.logAndReturnServerError(serverMsg, log.String("error", err.Error()))
 }
 
 // GetAttributes retrieves the user attributes using the internal entity service.

--- a/backend/internal/authnprovider/provider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider_test.go
@@ -39,7 +39,7 @@ type DefaultAuthnProviderTestSuite struct {
 
 func (suite *DefaultAuthnProviderTestSuite) SetupTest() {
 	suite.mockService = entitymock.NewEntityServiceInterfaceMock(suite.T())
-	suite.provider = newDefaultAuthnProvider(suite.mockService, nil, nil)
+	suite.provider = newDefaultAuthnProvider(suite.mockService, nil, nil, nil)
 }
 
 func TestDefaultAuthnProviderTestSuite(t *testing.T) {

--- a/backend/internal/authnprovider/provider/init.go
+++ b/backend/internal/authnprovider/provider/init.go
@@ -21,9 +21,11 @@ package provider
 import (
 	"time"
 
+	authncommon "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	"github.com/asgardeo/thunder/internal/entity"
+	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/config"
 	systemhttp "github.com/asgardeo/thunder/internal/system/http"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -34,13 +36,14 @@ func InitializeAuthnProvider(
 	entitySvc entity.EntityServiceInterface,
 	passkeySvc passkey.PasskeyServiceInterface,
 	otpSvc otp.OTPAuthnServiceInterface,
+	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator,
 ) AuthnProviderInterface {
 	authnProviderConfig := config.GetThunderRuntime().Config.AuthnProvider
 	switch authnProviderConfig.Type {
 	case "rest":
 		return initializeRestAuthnProvider()
 	default:
-		return initializeDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc)
+		return initializeDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
 	}
 }
 
@@ -49,8 +52,9 @@ func initializeDefaultAuthnProvider(
 	entitySvc entity.EntityServiceInterface,
 	passkeySvc passkey.PasskeyServiceInterface,
 	otpSvc otp.OTPAuthnServiceInterface,
+	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator,
 ) AuthnProviderInterface {
-	return newDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc)
+	return newDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
 }
 
 // initializeRestAuthnProvider initializes the REST authentication provider.

--- a/backend/internal/flow/executor/github_auth_executor.go
+++ b/backend/internal/flow/executor/github_auth_executor.go
@@ -21,6 +21,7 @@ package executor
 import (
 	authngithub "github.com/asgardeo/thunder/internal/authn/github"
 	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
@@ -41,6 +42,7 @@ func newGithubOAuthExecutor(
 	idpService idp.IDPServiceInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
 	authService authngithub.GithubOAuthAuthnServiceInterface,
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
 ) oAuthExecutorInterface {
 	oauthSvcCast, ok := authService.(authnoauth.OAuthAuthnCoreServiceInterface)
 	if !ok {
@@ -48,7 +50,7 @@ func newGithubOAuthExecutor(
 	}
 
 	base := newOAuthExecutor(ExecutorNameGitHubAuth, []common.Input{}, []common.Input{},
-		flowFactory, idpService, userSchemaService, oauthSvcCast)
+		flowFactory, idpService, userSchemaService, oauthSvcCast, authnProvider, idp.IDPTypeGitHub)
 
 	return &githubOAuthExecutor{
 		oAuthExecutorInterface: base,

--- a/backend/internal/flow/executor/github_auth_executor_test.go
+++ b/backend/internal/flow/executor/github_auth_executor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/tests/mocks/authn/githubmock"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oauthmock"
+	"github.com/asgardeo/thunder/tests/mocks/authnprovider/managermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
@@ -39,6 +40,7 @@ type GithubAuthExecutorTestSuite struct {
 	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 	mockGithubService     *githubmock.GithubOAuthAuthnServiceInterfaceMock
 	mockOAuthService      *oauthmock.OAuthAuthnCoreServiceInterfaceMock
+	mockAuthnProvider     *managermock.AuthnProviderManagerInterfaceMock
 }
 
 func TestGithubAuthExecutorTestSuite(t *testing.T) {
@@ -51,6 +53,7 @@ func (suite *GithubAuthExecutorTestSuite) SetupTest() {
 	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	suite.mockGithubService = githubmock.NewGithubOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnCoreServiceInterfaceMock(suite.T())
+	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerInterfaceMock(suite.T())
 }
 
 func (suite *GithubAuthExecutorTestSuite) TestNewGithubOAuthExecutor_Success() {
@@ -72,7 +75,7 @@ func (suite *GithubAuthExecutorTestSuite) TestNewGithubOAuthExecutor_Success() {
 	}
 
 	executor := newGithubOAuthExecutor(suite.mockFlowFactory, suite.mockIDPService,
-		suite.mockUserSchemaService, mockGithubSvc)
+		suite.mockUserSchemaService, mockGithubSvc, suite.mockAuthnProvider)
 
 	suite.NotNil(executor)
 	githubExec, ok := executor.(*githubOAuthExecutor)

--- a/backend/internal/flow/executor/google_auth_executor.go
+++ b/backend/internal/flow/executor/google_auth_executor.go
@@ -21,6 +21,7 @@ package executor
 import (
 	authngoogle "github.com/asgardeo/thunder/internal/authn/google"
 	authnoidc "github.com/asgardeo/thunder/internal/authn/oidc"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
@@ -41,6 +42,7 @@ func newGoogleOIDCAuthExecutor(
 	idpService idp.IDPServiceInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
 	authService authngoogle.GoogleOIDCAuthnServiceInterface,
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
 ) oidcAuthExecutorInterface {
 	defaultInputs := []common.Input{
 		{
@@ -61,7 +63,7 @@ func newGoogleOIDCAuthExecutor(
 	}
 
 	base := newOIDCAuthExecutor(ExecutorNameGoogleAuth, defaultInputs, []common.Input{},
-		flowFactory, idpService, userSchemaService, oidcSvcCast)
+		flowFactory, idpService, userSchemaService, oidcSvcCast, authnProvider, idp.IDPTypeGoogle)
 
 	return &googleOIDCAuthExecutor{
 		oidcAuthExecutorInterface: base,

--- a/backend/internal/flow/executor/google_auth_executor_test.go
+++ b/backend/internal/flow/executor/google_auth_executor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/tests/mocks/authn/googlemock"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oidcmock"
+	"github.com/asgardeo/thunder/tests/mocks/authnprovider/managermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
@@ -39,6 +40,7 @@ type GoogleAuthExecutorTestSuite struct {
 	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 	mockGoogleService     *googlemock.GoogleOIDCAuthnServiceInterfaceMock
 	mockOIDCService       *oidcmock.OIDCAuthnCoreServiceInterfaceMock
+	mockAuthnProvider     *managermock.AuthnProviderManagerInterfaceMock
 }
 
 func TestGoogleAuthExecutorTestSuite(t *testing.T) {
@@ -51,6 +53,7 @@ func (suite *GoogleAuthExecutorTestSuite) SetupTest() {
 	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	suite.mockGoogleService = googlemock.NewGoogleOIDCAuthnServiceInterfaceMock(suite.T())
 	suite.mockOIDCService = oidcmock.NewOIDCAuthnCoreServiceInterfaceMock(suite.T())
+	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerInterfaceMock(suite.T())
 }
 
 func (suite *GoogleAuthExecutorTestSuite) TestNewGoogleOIDCAuthExecutor_Success() {
@@ -77,7 +80,7 @@ func (suite *GoogleAuthExecutorTestSuite) TestNewGoogleOIDCAuthExecutor_Success(
 	}
 
 	executor := newGoogleOIDCAuthExecutor(suite.mockFlowFactory, suite.mockIDPService,
-		suite.mockUserSchemaService, mockGoogleSvc)
+		suite.mockUserSchemaService, mockGoogleSvc, suite.mockAuthnProvider)
 
 	suite.NotNil(executor)
 	googleExec, ok := executor.(*googleOIDCAuthExecutor)

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -20,7 +20,12 @@ package executor
 
 import (
 	"github.com/asgardeo/thunder/internal/attributecache"
-	"github.com/asgardeo/thunder/internal/authn"
+	"github.com/asgardeo/thunder/internal/authn/assert"
+	"github.com/asgardeo/thunder/internal/authn/consent"
+	"github.com/asgardeo/thunder/internal/authn/github"
+	"github.com/asgardeo/thunder/internal/authn/google"
+	"github.com/asgardeo/thunder/internal/authn/oauth"
+	"github.com/asgardeo/thunder/internal/authn/oidc"
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/authn/passkey"
 	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
@@ -48,7 +53,8 @@ func Initialize(
 	idpService idp.IDPServiceInterface,
 	notifSenderSvc notification.NotificationSenderServiceInterface,
 	jwtService jwt.JWTServiceInterface,
-	authRegistry *authn.AuthServiceRegistry,
+	authAssertGen assert.AuthAssertGeneratorInterface,
+	consentEnforcer consent.ConsentEnforcerServiceInterface,
 	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
 	otpService otp.OTPAuthnServiceInterface,
 	passkeyService passkey.PasskeyServiceInterface,
@@ -61,6 +67,10 @@ func Initialize(
 	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	emailClient email.EmailClientInterface,
 	templateService template.TemplateServiceInterface,
+	oauthSvc oauth.OAuthAuthnServiceInterface,
+	oidcSvc oidc.OIDCAuthnServiceInterface,
+	githubSvc github.GithubOAuthAuthnServiceInterface,
+	googleSvc google.GoogleOIDCAuthnServiceInterface,
 ) ExecutorRegistryInterface {
 	reg := newExecutorRegistry()
 	reg.RegisterExecutor(ExecutorNameBasicAuth, newBasicAuthExecutor(
@@ -72,14 +82,14 @@ func Initialize(
 
 	reg.RegisterExecutor(ExecutorNameOAuth, newOAuthExecutor(
 		"", []common.Input{}, []common.Input{}, flowFactory, idpService, userSchemaService,
-		authRegistry.OAuthAuthnService))
+		oauthSvc, authnProvider, idp.IDPTypeOAuth))
 	reg.RegisterExecutor(ExecutorNameOIDCAuth, newOIDCAuthExecutor(
 		"", []common.Input{}, []common.Input{}, flowFactory, idpService, userSchemaService,
-		authRegistry.OIDCAuthnService))
+		oidcSvc, authnProvider, idp.IDPTypeOIDC))
 	reg.RegisterExecutor(ExecutorNameGitHubAuth, newGithubOAuthExecutor(
-		flowFactory, idpService, userSchemaService, authRegistry.GithubOAuthAuthnService))
+		flowFactory, idpService, userSchemaService, githubSvc, authnProvider))
 	reg.RegisterExecutor(ExecutorNameGoogleAuth, newGoogleOIDCAuthExecutor(
-		flowFactory, idpService, userSchemaService, authRegistry.GoogleOIDCAuthnService))
+		flowFactory, idpService, userSchemaService, googleSvc, authnProvider))
 
 	reg.RegisterExecutor(ExecutorNameProvisioning, newProvisioningExecutor(flowFactory,
 		groupService, roleService, entityProvider))
@@ -87,7 +97,7 @@ func Initialize(
 
 	reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(flowFactory, entityProvider))
 	reg.RegisterExecutor(ExecutorNameAuthAssert, newAuthAssertExecutor(flowFactory, jwtService,
-		ouService, authRegistry.AuthAssertGenerator, authnProvider, entityProvider,
+		ouService, authAssertGen, authnProvider, entityProvider,
 		attributeCacheSvc, roleService))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService, entityProvider))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory, ouService))
@@ -99,7 +109,7 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameIdentifying, newIdentifyingExecutor(
 		"", []common.Input{{Identifier: userAttributeUsername, Type: "string", Required: true}}, []common.Input{},
 		flowFactory, entityProvider))
-	reg.RegisterExecutor(ExecutorNameConsent, newConsentExecutor(flowFactory, authRegistry.ConsentEnforcerService))
+	reg.RegisterExecutor(ExecutorNameConsent, newConsentExecutor(flowFactory, consentEnforcer))
 	reg.RegisterExecutor(ExecutorNameOUResolver, newOUResolverExecutor(flowFactory, ouService))
 	reg.RegisterExecutor(ExecutorNameAttributeUniquenessValidator, newAttributeUniquenessValidator(
 		flowFactory, userSchemaService, entityProvider))

--- a/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
@@ -96,80 +96,6 @@ func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run f
 	return _c
 }
 
-// ExchangeCodeForToken provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*OAuthTokenResponse, error) {
-	ret := _mock.Called(ctx, execResp, code)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExchangeCodeForToken")
-	}
-
-	var r0 *OAuthTokenResponse
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (*OAuthTokenResponse, error)); ok {
-		return returnFunc(ctx, execResp, code)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) *OAuthTokenResponse); ok {
-		r0 = returnFunc(ctx, execResp, code)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*OAuthTokenResponse)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, code)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExchangeCodeForToken'
-type oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call struct {
-	*mock.Call
-}
-
-// ExchangeCodeForToken is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - code string
-func (_e *oAuthExecutorInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, execResp interface{}, code interface{}) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	return &oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, execResp, code)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string)) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Return(oAuthTokenResponse *OAuthTokenResponse, err error) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(oAuthTokenResponse, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*OAuthTokenResponse, error)) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Execute provides a mock function for the type oAuthExecutorInterfaceMock
 func (_mock *oAuthExecutorInterfaceMock) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	ret := _mock.Called(ctx)
@@ -387,74 +313,6 @@ func (_c *oAuthExecutorInterfaceMock_GetIdpID_Call) Return(s string, err error) 
 }
 
 func (_c *oAuthExecutorInterfaceMock_GetIdpID_Call) RunAndReturn(run func(ctx *core.NodeContext) (string, error)) *oAuthExecutorInterfaceMock_GetIdpID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInternalUser provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) GetInternalUser(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error) {
-	ret := _mock.Called(sub, execResp)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInternalUser")
-	}
-
-	var r0 *entityprovider.Entity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) (*entityprovider.Entity, error)); ok {
-		return returnFunc(sub, execResp)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) *entityprovider.Entity); ok {
-		r0 = returnFunc(sub, execResp)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, *common.ExecutorResponse) error); ok {
-		r1 = returnFunc(sub, execResp)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_GetInternalUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInternalUser'
-type oAuthExecutorInterfaceMock_GetInternalUser_Call struct {
-	*mock.Call
-}
-
-// GetInternalUser is a helper method to define mock.On call
-//   - sub string
-//   - execResp *common.ExecutorResponse
-func (_e *oAuthExecutorInterfaceMock_Expecter) GetInternalUser(sub interface{}, execResp interface{}) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	return &oAuthExecutorInterfaceMock_GetInternalUser_Call{Call: _e.mock.On("GetInternalUser", sub, execResp)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) Run(run func(sub string, execResp *common.ExecutorResponse)) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) Return(entity *entityprovider.Entity, err error) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Return(entity, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) RunAndReturn(run func(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error)) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -697,80 +555,6 @@ func (_c *oAuthExecutorInterfaceMock_GetUserIDFromContext_Call) RunAndReturn(run
 	return _c
 }
 
-// GetUserInfo provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error) {
-	ret := _mock.Called(ctx, execResp, accessToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserInfo")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, execResp, accessToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) map[string]string); ok {
-		r0 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_GetUserInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserInfo'
-type oAuthExecutorInterfaceMock_GetUserInfo_Call struct {
-	*mock.Call
-}
-
-// GetUserInfo is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - accessToken string
-func (_e *oAuthExecutorInterfaceMock_Expecter) GetUserInfo(ctx interface{}, execResp interface{}, accessToken interface{}) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	return &oAuthExecutorInterfaceMock_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo", ctx, execResp, accessToken)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string)) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) Return(stringToString map[string]string, err error) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(stringToString, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error)) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasRequiredInputs provides a mock function for the type oAuthExecutorInterfaceMock
 func (_mock *oAuthExecutorInterfaceMock) HasRequiredInputs(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
 	ret := _mock.Called(ctx, execResp)
@@ -886,8 +670,8 @@ func (_c *oAuthExecutorInterfaceMock_ProcessAuthFlowResponse_Call) RunAndReturn(
 }
 
 // ResolveContextUser provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error) {
-	ret := _mock.Called(ctx, execResp, sub, internalUser)
+func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error) {
+	ret := _mock.Called(ctx, execResp, sub, internalUser, isAmbiguous)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveContextUser")
@@ -895,18 +679,18 @@ func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContex
 
 	var r0 *common0.AuthenticatedUser
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) (*common0.AuthenticatedUser, error)); ok {
-		return returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) (*common0.AuthenticatedUser, error)); ok {
+		return returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) *common0.AuthenticatedUser); ok {
-		r0 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) *common0.AuthenticatedUser); ok {
+		r0 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common0.AuthenticatedUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) error); ok {
-		r1 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) error); ok {
+		r1 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -923,11 +707,12 @@ type oAuthExecutorInterfaceMock_ResolveContextUser_Call struct {
 //   - execResp *common.ExecutorResponse
 //   - sub string
 //   - internalUser *entityprovider.Entity
-func (_e *oAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
-	return &oAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser)}
+//   - isAmbiguous bool
+func (_e *oAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}, isAmbiguous interface{}) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+	return &oAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser, isAmbiguous)}
 }
 
-func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *core.NodeContext
 		if args[0] != nil {
@@ -945,11 +730,16 @@ func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *
 		if args[3] != nil {
 			arg3 = args[3].(*entityprovider.Entity)
 		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -960,7 +750,7 @@ func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Return(authenticat
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -26,6 +26,7 @@ import (
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
@@ -60,13 +61,8 @@ type oAuthExecutorInterface interface {
 	core.ExecutorInterface
 	BuildAuthorizeFlow(ctx *core.NodeContext, execResp *common.ExecutorResponse) error
 	ProcessAuthFlowResponse(ctx *core.NodeContext, execResp *common.ExecutorResponse) error
-	ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-		code string) (*OAuthTokenResponse, error)
-	GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-		accessToken string) (map[string]string, error)
-	GetInternalUser(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error)
 	ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-		sub string, internalUser *entityprovider.Entity) (*authncm.AuthenticatedUser, error)
+		sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*authncm.AuthenticatedUser, error)
 	GetIdpID(ctx *core.NodeContext) (string, error)
 }
 
@@ -74,6 +70,8 @@ type oAuthExecutorInterface interface {
 type oAuthExecutor struct {
 	core.ExecutorInterface
 	authService       authnoauth.OAuthAuthnCoreServiceInterface
+	authnProvider     authnprovidermgr.AuthnProviderManagerInterface
+	idpType           idp.IDPType
 	idpService        idp.IDPServiceInterface
 	userSchemaService userschema.UserSchemaServiceInterface
 	logger            *log.Logger
@@ -89,6 +87,8 @@ func newOAuthExecutor(
 	idpService idp.IDPServiceInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
 	authService authnoauth.OAuthAuthnCoreServiceInterface,
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
+	idpType idp.IDPType,
 ) oAuthExecutorInterface {
 	if name == "" {
 		name = ExecutorNameOAuth
@@ -111,6 +111,8 @@ func newOAuthExecutor(
 	return &oAuthExecutor{
 		ExecutorInterface: base,
 		authService:       authService,
+		authnProvider:     authnProvider,
+		idpType:           idpType,
 		idpService:        idpService,
 		userSchemaService: userSchemaService,
 		logger:            logger,
@@ -206,48 +208,51 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 
-	tokenResp, err := o.ExchangeCodeForToken(ctx, execResp, code)
+	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
 		return err
 	}
-	if execResp.Status == common.ExecFailure {
-		return nil
-	}
 
-	if tokenResp.Scope == "" {
-		logger.Error("Scopes are empty in the token response")
-		execResp.Status = common.ExecFailure
-		execResp.AuthenticatedUser = authncm.AuthenticatedUser{
-			IsAuthenticated: false,
+	credentials := map[string]interface{}{
+		"federated": &authncm.FederatedAuthCredential{
+			IDPID:   idpID,
+			IDPType: o.idpType,
+			Code:    code,
+		},
+	}
+	newAuthUser, basicResult, svcErr := o.authnProvider.AuthenticateUser(
+		ctx.Context, nil, credentials, nil, nil, ctx.AuthUser)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
+			return nil
 		}
-		return nil
+
+		logger.Error("Federated authentication failed", log.String("errorCode", svcErr.Code),
+			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
+		return errors.New("federated authentication failed")
 	}
 
-	userInfo, err := o.GetUserInfo(ctx, execResp, tokenResp.AccessToken)
-	if err != nil {
-		return err
-	}
-	if execResp.Status == common.ExecFailure {
-		return nil
+	sub := basicResult.ExternalSub
+
+	if basicResult.IsAmbiguousUser {
+		if execResp.RuntimeData == nil {
+			execResp.RuntimeData = make(map[string]string)
+		}
+		execResp.RuntimeData[common.RuntimeKeyUserAmbiguous] = dataValueTrue
 	}
 
-	// Extract sub claim from user info
-	sub, ok := userInfo[userAttributeSub]
-	if !ok || sub == "" {
-		execResp.Status = common.ExecFailure
-		execResp.FailureReason = "sub claim not found in the response."
-		return nil
+	var internalUser *entityprovider.Entity
+	if basicResult.IsExistingUser {
+		internalUser = &entityprovider.Entity{
+			ID:   basicResult.UserID,
+			OUID: basicResult.OUID,
+			Type: basicResult.UserType,
+		}
 	}
 
-	internalUser, err := o.GetInternalUser(sub, execResp)
-	if err != nil {
-		return err
-	}
-	if execResp.Status == common.ExecFailure {
-		return nil
-	}
-
-	contextUser, err := o.ResolveContextUser(ctx, execResp, sub, internalUser)
+	contextUser, err := o.ResolveContextUser(ctx, execResp, sub, internalUser, basicResult.IsAmbiguousUser)
 	if err != nil {
 		return err
 	}
@@ -259,8 +264,10 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return errors.New("unexpected error occurred while resolving user")
 	}
 
+	userInfo := systemutils.ConvertInterfaceMapToStringMap(basicResult.ExternalClaims)
 	contextUser.Attributes = o.getContextUserAttributes(execResp, userInfo)
 	execResp.AuthenticatedUser = *contextUser
+	execResp.AuthUser = newAuthUser
 
 	return nil
 }
@@ -273,67 +280,6 @@ func (o *oAuthExecutor) HasRequiredInputs(ctx *core.NodeContext, execResp *commo
 	}
 
 	return o.ExecutorInterface.HasRequiredInputs(ctx, execResp)
-}
-
-// ExchangeCodeForToken exchanges the authorization code for an access token.
-func (o *oAuthExecutor) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-	code string) (*OAuthTokenResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Exchanging authorization code for a token")
-
-	idpID, err := o.GetIdpID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	tokenResp, svcErr := o.authService.ExchangeCodeForToken(ctx.Context, idpID, code, true)
-	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
-			return nil, nil
-		}
-
-		logger.Error("Failed to exchange code for a token", log.String("errorCode", svcErr.Code),
-			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		return nil, errors.New("failed to exchange code for token")
-	}
-
-	return &OAuthTokenResponse{
-		AccessToken:  tokenResp.AccessToken,
-		TokenType:    tokenResp.TokenType,
-		Scope:        tokenResp.Scope,
-		RefreshToken: tokenResp.RefreshToken,
-		IDToken:      tokenResp.IDToken,
-		ExpiresIn:    tokenResp.ExpiresIn,
-	}, nil
-}
-
-// GetUserInfo fetches user information from the OAuth provider using the access token.
-func (o *oAuthExecutor) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-	accessToken string) (map[string]string, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Fetching user info from OAuth provider")
-
-	idpID, err := o.GetIdpID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	userInfo, svcErr := o.authService.FetchUserInfo(ctx.Context, idpID, accessToken)
-	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
-			return nil, nil
-		}
-
-		logger.Error("Failed to fetch user info", log.String("errorCode", svcErr.Code),
-			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		return nil, errors.New("failed to fetch user information")
-	}
-
-	return systemutils.ConvertInterfaceMapToStringMap(userInfo), nil
 }
 
 // GetIdpID retrieves the identity provider ID from the node properties.
@@ -367,59 +313,19 @@ func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, e
 	return idp.Name, nil
 }
 
-// GetInternalUser retrieves the internal user for the given sub claim. Returns the user if found,
-// nil if not found, or an error on failure.
-func (o *oAuthExecutor) GetInternalUser(
-	sub string, execResp *common.ExecutorResponse,
-) (*entityprovider.Entity, error) {
-	logger := o.logger
-	logger.Debug("Resolving internal user with the given sub claim")
-
-	user, svcErr := o.authService.GetInternalUser(sub)
-	if svcErr != nil {
-		if svcErr.Code == authncm.ErrorUserNotFound.Code {
-			return nil, nil
-		}
-		if svcErr.Code == authncm.ErrorAmbiguousUser.Code {
-			// Signal ambiguity via RuntimeData rather than a sentinel error. This follows the
-			// same pattern used for userEligibleForProvisioning and is consumed by
-			// getContextUserForAuthentication within the same executor call, so RuntimeData
-			// cannot be reset between the write and the read.
-			if execResp.RuntimeData == nil {
-				execResp.RuntimeData = make(map[string]string)
-			}
-			execResp.RuntimeData[common.RuntimeKeyUserAmbiguous] = dataValueTrue
-			return nil, nil
-		}
-		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
-			return nil, nil
-		}
-		logger.Error("Error while retrieving internal user", log.String("errorCode", svcErr.Code),
-			log.String("description", svcErr.ErrorDescription.DefaultValue))
-		return nil, errors.New("error while retrieving internal user")
-	}
-	if user == nil || user.ID == "" {
-		return nil, nil
-	}
-
-	return user, nil
-}
-
 // ResolveContextUser resolves the authenticated user in context with the attributes.
 func (o *oAuthExecutor) ResolveContextUser(ctx *core.NodeContext,
-	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (
+	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (
 	*authncm.AuthenticatedUser, error) {
 	if ctx.FlowType == common.FlowTypeAuthentication {
-		return o.getContextUserForAuthentication(ctx, execResp, sub, internalUser)
+		return o.getContextUserForAuthentication(ctx, execResp, sub, internalUser, isAmbiguous)
 	}
-	return o.getContextUserForRegistration(ctx, execResp, sub, internalUser)
+	return o.getContextUserForRegistration(ctx, execResp, sub, internalUser, isAmbiguous)
 }
 
 // getContextUserForAuthentication resolves the authenticated user in context for authentication flows.
 func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
-	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (
+	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (
 	*authncm.AuthenticatedUser, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
@@ -436,7 +342,6 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 			if execResp.RuntimeData == nil {
 				execResp.RuntimeData = make(map[string]string)
 			}
-			isAmbiguous := execResp.RuntimeData[common.RuntimeKeyUserAmbiguous] == dataValueTrue
 
 			if isAmbiguous {
 				// Ambiguous user: exists in multiple OUs. Set sub for downstream
@@ -496,9 +401,16 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 
 // getContextUserForRegistration resolves the authenticated user in context for registration flows.
 func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
-	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (
+	execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (
 	*authncm.AuthenticatedUser, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	if isAmbiguous {
+		logger.Debug("Ambiguous user detected in registration flow, cannot proceed with registration")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "User identity is ambiguous and cannot be registered."
+		return nil, nil
+	}
 
 	// If no local user is found, proceed with registration
 	if internalUser == nil {

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -28,8 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
-	authncm "github.com/asgardeo/thunder/internal/authn/common"
-	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
@@ -37,6 +36,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userschema"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oauthmock"
+	"github.com/asgardeo/thunder/tests/mocks/authnprovider/managermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
@@ -48,6 +48,7 @@ type OAuthExecutorTestSuite struct {
 	mockIDPService        *idpmock.IDPServiceInterfaceMock
 	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockAuthnProvider     *managermock.AuthnProviderManagerInterfaceMock
 	executor              oAuthExecutorInterface
 }
 
@@ -60,6 +61,7 @@ func (suite *OAuthExecutorTestSuite) SetupTest() {
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerInterfaceMock(suite.T())
 
 	defaultInputs := []common.Input{{Identifier: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOAuth)
@@ -67,7 +69,8 @@ func (suite *OAuthExecutorTestSuite) SetupTest() {
 		defaultInputs, []common.Input{}).Return(mockExec)
 
 	suite.executor = newOAuthExecutor(ExecutorNameOAuth, defaultInputs, []common.Input{},
-		suite.mockFlowFactory, suite.mockIDPService, suite.mockUserSchemaService, suite.mockOAuthService)
+		suite.mockFlowFactory, suite.mockIDPService, suite.mockUserSchemaService, suite.mockOAuthService,
+		suite.mockAuthnProvider, idp.IDPTypeOAuth)
 }
 
 func (suite *OAuthExecutorTestSuite) TestNewOAuthExecutor() {
@@ -114,31 +117,17 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 		},
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "user-sub-123",
-		"email": "test@example.com",
-		"name":  "Test User",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "user-sub-123").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-123", "email": "test@example.com", "name": "Test User"},
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -149,7 +138,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 	assert.Equal(suite.T(), "user-123", resp.AuthenticatedUser.UserID)
 	assert.Equal(suite.T(), "ou-123", resp.AuthenticatedUser.OUID)
 	assert.Equal(suite.T(), "test@example.com", resp.RuntimeData["email"])
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
@@ -259,200 +248,6 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 	suite.mockOAuthService.AssertExpectations(suite.T())
 }
 
-func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_Success() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken:  "access_token_123",
-		TokenType:    "Bearer",
-		Scope:        "openid profile",
-		RefreshToken: "refresh_token_123",
-		IDToken:      "id_token_123",
-		ExpiresIn:    3600,
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code", true).
-		Return(tokenResp, nil)
-
-	result, err := suite.executor.ExchangeCodeForToken(ctx, execResp, "auth_code")
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), "access_token_123", result.AccessToken)
-	assert.Equal(suite.T(), "Bearer", result.TokenType)
-	assert.Equal(suite.T(), "openid profile", result.Scope)
-	assert.Equal(suite.T(), 3600, result.ExpiresIn)
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
-func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ClientError() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "invalid_code", true).
-		Return(nil, &serviceerror.ServiceError{
-			Type: serviceerror.ClientErrorType,
-			ErrorDescription: i18ncore.I18nMessage{
-				Key: "error.test.invalid_authorization_code", DefaultValue: "Invalid authorization code",
-			},
-		})
-
-	result, err := suite.executor.ExchangeCodeForToken(ctx, execResp, "invalid_code")
-
-	assert.NoError(suite.T(), err)
-	assert.Nil(suite.T(), result)
-	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Equal(suite.T(), "Invalid authorization code", execResp.FailureReason)
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
-func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ServerError() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code", true).
-		Return(nil, &serviceerror.ServiceError{
-			Type: serviceerror.ServerErrorType,
-			Code: "OAUTH-5000",
-			ErrorDescription: i18ncore.I18nMessage{
-				Key: "error.test.token_exchange_failed", DefaultValue: "Token exchange failed",
-			},
-		})
-
-	result, err := suite.executor.ExchangeCodeForToken(ctx, execResp, "auth_code")
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "failed to exchange code for token")
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
-func (suite *OAuthExecutorTestSuite) TestGetUserInfo_Success() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "user-sub-123",
-		"email": "test@example.com",
-		"name":  "Test User",
-	}
-
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token").
-		Return(userInfo, nil)
-
-	result, err := suite.executor.GetUserInfo(ctx, execResp, "access_token")
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), "user-sub-123", result["sub"])
-	assert.Equal(suite.T(), "test@example.com", result["email"])
-	assert.Equal(suite.T(), "Test User", result["name"])
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
-func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ClientError() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "invalid_token").
-		Return(nil, &serviceerror.ServiceError{
-			Type: serviceerror.ClientErrorType,
-			ErrorDescription: i18ncore.I18nMessage{
-				Key: "error.test.invalid_access_token", DefaultValue: "Invalid access token",
-			},
-		})
-
-	result, err := suite.executor.GetUserInfo(ctx, execResp, "invalid_token")
-
-	assert.NoError(suite.T(), err)
-	assert.Nil(suite.T(), result)
-	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Equal(suite.T(), "Invalid access token", execResp.FailureReason)
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
-func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ServerError() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token").
-		Return(nil, &serviceerror.ServiceError{
-			Type: serviceerror.ServerErrorType,
-			Code: "OAUTH-5000",
-			ErrorDescription: i18ncore.I18nMessage{
-				Key: "error.test.failed_to_fetch_user_info", DefaultValue: "Failed to fetch user info",
-			},
-		})
-
-	result, err := suite.executor.GetUserInfo(ctx, execResp, "access_token")
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "failed to fetch user information")
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
 func (suite *OAuthExecutorTestSuite) TestGetIdpID_Success() {
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
@@ -499,28 +294,14 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub": "new-user-sub", "email": "newuser@example.com", "name": "New User"},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -529,7 +310,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 	assert.False(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
 	assert.NotNil(suite.T(), execResp.AuthenticatedUser.Attributes)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound() {
@@ -549,37 +330,22 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "unknown-user",
-		"email": "unknown@example.com",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "unknown-user").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "unknown-user",
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), "User not found", execResp.FailureReason)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() {
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -596,36 +362,21 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExis
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "existing-user-sub",
-		"email": "existing@example.com",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-456",
-		OUID: "ou-456",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "existing-user-sub",
+			IsExistingUser: true,
+			UserID:         "user-456",
+			OUID:           "ou-456",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Contains(suite.T(), execResp.FailureReason, "User already exists")
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided() {
@@ -649,7 +400,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided(
 	assert.False(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 }
 
-func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_ProviderClientError() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
@@ -666,25 +417,22 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "",
-		ExpiresIn:   3600,
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "Invalid authorization code"},
+		})
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.False(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	assert.Equal(suite.T(), "Invalid authorization code", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_ProviderServerError() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
@@ -701,29 +449,19 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"email": "test@example.com",
-		"name":  "Test User",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			Code:             "AUTH-5000",
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "Internal authentication error"},
+		})
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Contains(suite.T(), execResp.FailureReason, "sub claim not found")
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "federated authentication failed")
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestHasRequiredInputs_CodeProvided() {
@@ -861,28 +599,14 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub": "new-user-sub", "email": "newuser@example.com", "name": "New User"},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -892,7 +616,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
 	assert.Equal(suite.T(), "newuser@example.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "newuser@example.com", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestGetContextUserAttributes_WithEmail_NilRuntimeData() {
@@ -936,28 +660,14 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithou
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub": "new-user-sub", "email": "newuser@example.com", "name": "New User"},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(&userschema.UserSchema{
 			Name:                  "INTERNAL",
@@ -973,7 +683,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithou
 	assert.Equal(suite.T(), dataValueTrue, execResp.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning])
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
 	assert.NotNil(suite.T(), execResp.AuthenticatedUser.Attributes)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockUserSchemaService.AssertExpectations(suite.T())
 }
 
@@ -995,34 +705,19 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthWith
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "new-user-sub",
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), "User not found", execResp.FailureReason)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrationWithExistingUser() {
@@ -1043,31 +738,17 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrati
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "existing-user-sub",
-		"email": "existing@example.com",
-		"name":  "Existing User",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "existing-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub": "existing-user-sub", "email": "existing@example.com", "name": "Existing User"},
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -1076,10 +757,10 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrati
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "user-123", execResp.AuthenticatedUser.UserID)
 	assert.Equal(suite.T(), dataValueTrue, execResp.RuntimeData[common.RuntimeKeySkipProvisioning])
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistrationWithExistingUser() {
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistrationWithExistingUser() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -1097,37 +778,22 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistra
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		ExpiresIn:   3600,
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "existing-user-sub",
-		"email": "existing@example.com",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "existing-user-sub",
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), "User already exists with the provided sub claim.", execResp.FailureReason)
-	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning() {
@@ -1262,107 +928,6 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_GetU
 	suite.mockUserSchemaService.AssertExpectations(suite.T())
 }
 
-func (suite *OAuthExecutorTestSuite) TestGetInternalUser_Errors() {
-	tests := []struct {
-		name               string
-		sub                string
-		serviceError       *serviceerror.ServiceError
-		expectError        bool
-		expectedStatus     common.ExecutorStatus
-		expectedFailReason string
-		errorContains      string
-	}{
-		{
-			name: "UserNotFoundError",
-			sub:  "unknown-sub",
-			serviceError: &serviceerror.ServiceError{
-				Code: authncm.ErrorUserNotFound.Code,
-				Type: serviceerror.ClientErrorType,
-			},
-			expectError:    false,
-			expectedStatus: "", // Status should not be set to failure for user not found
-		},
-		{
-			name: "ClientError",
-			sub:  "invalid-sub",
-			serviceError: &serviceerror.ServiceError{
-				Type: serviceerror.ClientErrorType,
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.invalid_sub_claim", DefaultValue: "Invalid sub claim",
-				},
-			},
-			expectError:        false,
-			expectedStatus:     common.ExecFailure,
-			expectedFailReason: "Invalid sub claim",
-		},
-		{
-			name: "ServerError",
-			sub:  "some-sub",
-			serviceError: &serviceerror.ServiceError{
-				Type: serviceerror.ServerErrorType,
-				Code: "USER-5000",
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.internal_error", DefaultValue: "Internal error",
-				},
-			},
-			expectError:   true,
-			errorContains: "error while retrieving internal user",
-		},
-	}
-
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			execResp := &common.ExecutorResponse{
-				AdditionalData: make(map[string]string),
-				RuntimeData:    make(map[string]string),
-			}
-
-			suite.mockOAuthService.On("GetInternalUser", tt.sub).
-				Return(nil, tt.serviceError).Once()
-
-			result, err := suite.executor.GetInternalUser(tt.sub, execResp)
-
-			assert.Nil(suite.T(), result)
-			if tt.expectError {
-				assert.Error(suite.T(), err)
-				assert.Contains(suite.T(), err.Error(), tt.errorContains)
-			} else {
-				assert.NoError(suite.T(), err)
-				if tt.expectedStatus != "" {
-					assert.Equal(suite.T(), tt.expectedStatus, execResp.Status)
-					assert.Equal(suite.T(), tt.expectedFailReason, execResp.FailureReason)
-				} else {
-					assert.NotEqual(suite.T(), common.ExecFailure, execResp.Status)
-				}
-			}
-			suite.mockOAuthService.AssertExpectations(suite.T())
-		})
-	}
-}
-
-func (suite *OAuthExecutorTestSuite) TestGetInternalUser_Success() {
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	suite.mockOAuthService.On("GetInternalUser", "user-sub-123").
-		Return(existingUser, nil)
-
-	result, err := suite.executor.GetInternalUser("user-sub-123", execResp)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), "user-123", result.ID)
-	suite.mockOAuthService.AssertExpectations(suite.T())
-}
-
 func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExistingUser_SkipProvisioningFlag() {
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
@@ -1387,7 +952,7 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExist
 	}
 
 	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForRegistration(
-		ctx, execResp, "test-sub", existingUser)
+		ctx, execResp, "test-sub", existingUser, false)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), contextUser)
@@ -1395,6 +960,60 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExist
 	assert.Equal(suite.T(), "user-456", contextUser.UserID)
 	assert.Equal(suite.T(), dataValueTrue, execResp.RuntimeData[common.RuntimeKeySkipProvisioning])
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+}
+
+func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_NoLocalUser() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForRegistration(
+		ctx, execResp, "ambiguous-sub", nil, true)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), contextUser)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User identity is ambiguous and cannot be registered.", execResp.FailureReason)
+}
+
+func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_WithExistingUser() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		NodeProperties: map[string]interface{}{
+			"idpId":                             "idp-123",
+			"allowRegistrationWithExistingUser": true,
+			"allowCrossOUProvisioning":          true,
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	existingUser := &entityprovider.Entity{
+		ID:   "user-789",
+		OUID: "ou-789",
+		Type: "INTERNAL",
+	}
+
+	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForRegistration(
+		ctx, execResp, "ambiguous-sub", existingUser, true)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), contextUser)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User identity is ambiguous and cannot be registered.", execResp.FailureReason)
 }
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_FailureScenarios() {
@@ -1495,7 +1114,7 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForAuthentication_Without
 	}
 
 	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForAuthentication(
-		ctx, execResp, "test-sub", nil)
+		ctx, execResp, "test-sub", nil, false)
 
 	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), contextUser)

--- a/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
@@ -96,80 +96,6 @@ func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(ru
 	return _c
 }
 
-// ExchangeCodeForToken provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*OAuthTokenResponse, error) {
-	ret := _mock.Called(ctx, execResp, code)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExchangeCodeForToken")
-	}
-
-	var r0 *OAuthTokenResponse
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (*OAuthTokenResponse, error)); ok {
-		return returnFunc(ctx, execResp, code)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) *OAuthTokenResponse); ok {
-		r0 = returnFunc(ctx, execResp, code)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*OAuthTokenResponse)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, code)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExchangeCodeForToken'
-type oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call struct {
-	*mock.Call
-}
-
-// ExchangeCodeForToken is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - code string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, execResp interface{}, code interface{}) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	return &oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, execResp, code)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string)) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Return(oAuthTokenResponse *OAuthTokenResponse, err error) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(oAuthTokenResponse, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*OAuthTokenResponse, error)) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Execute provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	ret := _mock.Called(ctx)
@@ -331,74 +257,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetIDTokenClaims provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetIDTokenClaims(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error) {
-	ret := _mock.Called(execResp, idToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIDTokenClaims")
-	}
-
-	var r0 map[string]interface{}
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*common.ExecutorResponse, string) (map[string]interface{}, error)); ok {
-		return returnFunc(execResp, idToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*common.ExecutorResponse, string) map[string]interface{}); ok {
-		r0 = returnFunc(execResp, idToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]interface{})
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(execResp, idToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIDTokenClaims'
-type oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call struct {
-	*mock.Call
-}
-
-// GetIDTokenClaims is a helper method to define mock.On call
-//   - execResp *common.ExecutorResponse
-//   - idToken string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetIDTokenClaims(execResp interface{}, idToken interface{}) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	return &oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", execResp, idToken)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) Run(run func(execResp *common.ExecutorResponse, idToken string)) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *common.ExecutorResponse
-		if args[0] != nil {
-			arg0 = args[0].(*common.ExecutorResponse)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) Return(stringToIfaceVal map[string]interface{}, err error) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Return(stringToIfaceVal, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error)) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdpID provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) GetIdpID(ctx *core.NodeContext) (string, error) {
 	ret := _mock.Called(ctx)
@@ -455,74 +313,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetIdpID_Call) Return(s string, err erro
 }
 
 func (_c *oidcAuthExecutorInterfaceMock_GetIdpID_Call) RunAndReturn(run func(ctx *core.NodeContext) (string, error)) *oidcAuthExecutorInterfaceMock_GetIdpID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInternalUser provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetInternalUser(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error) {
-	ret := _mock.Called(sub, execResp)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInternalUser")
-	}
-
-	var r0 *entityprovider.Entity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) (*entityprovider.Entity, error)); ok {
-		return returnFunc(sub, execResp)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) *entityprovider.Entity); ok {
-		r0 = returnFunc(sub, execResp)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, *common.ExecutorResponse) error); ok {
-		r1 = returnFunc(sub, execResp)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetInternalUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInternalUser'
-type oidcAuthExecutorInterfaceMock_GetInternalUser_Call struct {
-	*mock.Call
-}
-
-// GetInternalUser is a helper method to define mock.On call
-//   - sub string
-//   - execResp *common.ExecutorResponse
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetInternalUser(sub interface{}, execResp interface{}) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	return &oidcAuthExecutorInterfaceMock_GetInternalUser_Call{Call: _e.mock.On("GetInternalUser", sub, execResp)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) Run(run func(sub string, execResp *common.ExecutorResponse)) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) Return(entity *entityprovider.Entity, err error) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Return(entity, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) RunAndReturn(run func(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error)) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -765,80 +555,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetUserIDFromContext_Call) RunAndReturn(
 	return _c
 }
 
-// GetUserInfo provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error) {
-	ret := _mock.Called(ctx, execResp, accessToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserInfo")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, execResp, accessToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) map[string]string); ok {
-		r0 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetUserInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserInfo'
-type oidcAuthExecutorInterfaceMock_GetUserInfo_Call struct {
-	*mock.Call
-}
-
-// GetUserInfo is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - accessToken string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetUserInfo(ctx interface{}, execResp interface{}, accessToken interface{}) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	return &oidcAuthExecutorInterfaceMock_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo", ctx, execResp, accessToken)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string)) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) Return(stringToString map[string]string, err error) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(stringToString, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error)) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasRequiredInputs provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) HasRequiredInputs(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
 	ret := _mock.Called(ctx, execResp)
@@ -954,8 +670,8 @@ func (_c *oidcAuthExecutorInterfaceMock_ProcessAuthFlowResponse_Call) RunAndRetu
 }
 
 // ResolveContextUser provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error) {
-	ret := _mock.Called(ctx, execResp, sub, internalUser)
+func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error) {
+	ret := _mock.Called(ctx, execResp, sub, internalUser, isAmbiguous)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveContextUser")
@@ -963,18 +679,18 @@ func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeCon
 
 	var r0 *common0.AuthenticatedUser
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) (*common0.AuthenticatedUser, error)); ok {
-		return returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) (*common0.AuthenticatedUser, error)); ok {
+		return returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) *common0.AuthenticatedUser); ok {
-		r0 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) *common0.AuthenticatedUser); ok {
+		r0 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common0.AuthenticatedUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) error); ok {
-		r1 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) error); ok {
+		r1 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -991,11 +707,12 @@ type oidcAuthExecutorInterfaceMock_ResolveContextUser_Call struct {
 //   - execResp *common.ExecutorResponse
 //   - sub string
 //   - internalUser *entityprovider.Entity
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
-	return &oidcAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser)}
+//   - isAmbiguous bool
+func (_e *oidcAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}, isAmbiguous interface{}) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+	return &oidcAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser, isAmbiguous)}
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *core.NodeContext
 		if args[0] != nil {
@@ -1013,11 +730,16 @@ func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ct
 		if args[3] != nil {
 			arg3 = args[3].(*entityprovider.Entity)
 		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -1028,7 +750,7 @@ func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Return(authenti
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -20,17 +20,19 @@ package executor
 
 import (
 	"errors"
-	"fmt"
 	"slices"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
 	authnoidc "github.com/asgardeo/thunder/internal/authn/oidc"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
+	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
+	systemutils "github.com/asgardeo/thunder/internal/system/utils"
 	"github.com/asgardeo/thunder/internal/userschema"
 )
 
@@ -44,14 +46,15 @@ var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "
 // oidcAuthExecutorInterface defines the interface for OIDC authentication executors.
 type oidcAuthExecutorInterface interface {
 	oAuthExecutorInterface
-	GetIDTokenClaims(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error)
 }
 
 // oidcAuthExecutor implements the OIDCAuthExecutorInterface for handling generic OIDC authentication flows.
 type oidcAuthExecutor struct {
 	oAuthExecutorInterface
-	authService authnoidc.OIDCAuthnCoreServiceInterface
-	logger      *log.Logger
+	authService   authnoidc.OIDCAuthnCoreServiceInterface
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface
+	idpType       idp.IDPType
+	logger        *log.Logger
 }
 
 var _ core.ExecutorInterface = (*oidcAuthExecutor)(nil)
@@ -64,6 +67,8 @@ func newOIDCAuthExecutor(
 	idpService idp.IDPServiceInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
 	authService authnoidc.OIDCAuthnCoreServiceInterface,
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
+	idpType idp.IDPType,
 ) oidcAuthExecutorInterface {
 	if name == "" {
 		name = ExecutorNameOIDCAuth
@@ -77,11 +82,13 @@ func newOIDCAuthExecutor(
 	}
 
 	base := newOAuthExecutor(name, defaultInputs, prerequisites,
-		flowFactory, idpService, userSchemaService, oauthSvcCast)
+		flowFactory, idpService, userSchemaService, oauthSvcCast, authnProvider, idpType)
 
 	return &oidcAuthExecutor{
 		oAuthExecutorInterface: base,
 		authService:            authService,
+		authnProvider:          authnProvider,
+		idpType:                idpType,
 		logger:                 logger,
 	}
 }
@@ -130,54 +137,66 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 
-	tokenResp, err := o.ExchangeCodeForToken(ctx, execResp, code)
+	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
 		return err
-	}
-	if execResp.Status == common.ExecFailure {
-		return nil
 	}
 
-	idTokenClaims, err := o.GetIDTokenClaims(execResp, tokenResp.IDToken)
-	if err != nil {
-		return err
+	credentials := map[string]interface{}{
+		"federated": &authncm.FederatedAuthCredential{
+			IDPID:   idpID,
+			IDPType: o.idpType,
+			Code:    code,
+		},
 	}
-	if execResp.Status == common.ExecFailure {
-		return nil
+	newAuthUser, basicResult, svcErr := o.authnProvider.AuthenticateUser(
+		ctx.Context, nil, credentials, nil, nil, ctx.AuthUser)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
+			return nil
+		}
+
+		logger.Error("OIDC authentication failed", log.String("errorCode", svcErr.Code),
+			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
+		return errors.New("OIDC authentication failed")
+	}
+
+	if basicResult == nil {
+		logger.Error("authnProvider.AuthenticateUser returned nil result")
+		return errors.New("OIDC authentication failed")
 	}
 
 	// Validate nonce if configured
 	if nonce, ok := ctx.UserInputs[userInputNonce]; ok && nonce != "" {
-		if idTokenClaims[userInputNonce] != nonce {
+		claimNonce := basicResult.ExternalClaims[userInputNonce]
+		if claimNonce != nonce {
 			execResp.Status = common.ExecFailure
 			execResp.FailureReason = "Nonce mismatch in ID token claims."
 			return nil
 		}
 	}
 
-	// Extract sub claim from the id token claims
-	parsedSub := ""
-	sub, ok := idTokenClaims[userAttributeSub]
-	if ok && sub != "" {
-		if subStr, ok := sub.(string); ok && subStr != "" {
-			parsedSub = subStr
+	sub := basicResult.ExternalSub
+
+	if basicResult.IsAmbiguousUser {
+		if execResp.RuntimeData == nil {
+			execResp.RuntimeData = make(map[string]string)
+		}
+		execResp.RuntimeData[common.RuntimeKeyUserAmbiguous] = dataValueTrue
+	}
+
+	var internalUser *entityprovider.Entity
+	if basicResult.IsExistingUser {
+		internalUser = &entityprovider.Entity{
+			ID:   basicResult.UserID,
+			OUID: basicResult.OUID,
+			Type: basicResult.UserType,
 		}
 	}
-	if parsedSub == "" {
-		execResp.Status = common.ExecFailure
-		execResp.FailureReason = "sub claim not found in the ID token."
-		return nil
-	}
 
-	internalUser, err := o.GetInternalUser(parsedSub, execResp)
-	if err != nil {
-		return err
-	}
-	if execResp.Status == common.ExecFailure {
-		return nil
-	}
-
-	contextUser, err := o.ResolveContextUser(ctx, execResp, parsedSub, internalUser)
+	contextUser, err := o.ResolveContextUser(ctx, execResp, sub, internalUser, basicResult.IsAmbiguousUser)
 	if err != nil {
 		return err
 	}
@@ -185,100 +204,27 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 	if contextUser == nil {
-		logger.Error("Failed to resolve context user after OAuth authentication")
+		logger.Error("Failed to resolve context user after OIDC authentication")
 		return errors.New("unexpected error occurred while resolving user")
 	}
 
-	attributes, err := o.getContextUserAttributes(ctx, execResp, idTokenClaims, tokenResp.AccessToken)
-	if err != nil {
-		return err
-	}
-	if execResp.Status == common.ExecFailure {
-		return nil
-	}
-
-	contextUser.Attributes = attributes
+	contextUser.Attributes = o.getContextUserAttributes(execResp, basicResult.ExternalClaims)
 	execResp.AuthenticatedUser = *contextUser
+	execResp.AuthUser = newAuthUser
 
 	return nil
 }
 
-// GetIDTokenClaims extracts the ID token claims from the provided ID token.
-func (o *oidcAuthExecutor) GetIDTokenClaims(execResp *common.ExecutorResponse,
-	idToken string) (map[string]interface{}, error) {
-	logger := o.logger
-	logger.Debug("Extracting claims from the ID token")
-
-	claims, svcErr := o.authService.GetIDTokenClaims(idToken)
-	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
-			return nil, nil
-		}
-
-		logger.Error("Failed to extract claims from the ID token", log.String("errorCode", svcErr.Code),
-			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		return nil, errors.New("failed to extract claims from the ID token")
-	}
-
-	return claims, nil
-}
-
-// getContextUserAttributes retrieves user attributes from the ID token claims and user info endpoint.
+// getContextUserAttributes extracts user-facing attributes from the external claims map.
 // TODO: Need to convert attributes as per the IDP to local attribute mapping when the support is implemented.
-func (o *oidcAuthExecutor) getContextUserAttributes(ctx *core.NodeContext, execResp *common.ExecutorResponse,
-	idTokenClaims map[string]interface{}, accessToken string) (map[string]interface{}, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+func (o *oidcAuthExecutor) getContextUserAttributes(execResp *common.ExecutorResponse,
+	claims map[string]interface{}) map[string]interface{} {
 	userClaims := make(map[string]interface{})
 
-	// Resolve and add ID token claims
-	if len(idTokenClaims) != 0 {
-		for attr, val := range idTokenClaims {
-			if !slices.Contains(idTokenNonUserAttributes, attr) {
-				userClaims[attr] = val
-			}
+	for attr, val := range claims {
+		if !slices.Contains(idTokenNonUserAttributes, attr) {
+			userClaims[attr] = systemutils.ConvertInterfaceValueToString(val)
 		}
-		logger.Debug("Extracted ID token claims", log.Int("noOfClaims", len(idTokenClaims)))
-	}
-
-	// Retrieve IDP and check for additional scopes
-	idpID, err := o.GetIdpID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	oauthConfigs, svcErr := o.authService.GetOAuthClientConfig(ctx.Context, idpID)
-	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = fmt.Sprintf("failed to retrieve OAuth client configuration: %s",
-				svcErr.ErrorDescription.DefaultValue)
-			return nil, nil
-		}
-
-		logger.Error("Failed to retrieve OAuth client configuration", log.String("errorCode", svcErr.Code),
-			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		return nil, errors.New("failed to retrieve OAuth client configuration")
-	}
-
-	// If additional scopes are configured, retrieve user info
-	if len(oauthConfigs.Scopes) > 1 {
-		userInfo, err := o.GetUserInfo(ctx, execResp, accessToken)
-		if err != nil {
-			return nil, err
-		}
-		if execResp.Status == common.ExecFailure {
-			return nil, nil
-		}
-
-		for key, value := range userInfo {
-			if !slices.Contains(userInfoSkipAttributes, key) {
-				userClaims[key] = value
-			}
-		}
-	} else {
-		logger.Debug("No additional scopes configured.")
 	}
 
 	// Append email to runtime data if available.
@@ -291,5 +237,5 @@ func (o *oidcAuthExecutor) getContextUserAttributes(ctx *core.NodeContext, execR
 		}
 	}
 
-	return userClaims, nil
+	return userClaims
 }

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -28,15 +28,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
-	authncm "github.com/asgardeo/thunder/internal/authn/common"
-	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
-	"github.com/asgardeo/thunder/internal/entityprovider"
+	authnprovidermgr "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userschema"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oidcmock"
+	"github.com/asgardeo/thunder/tests/mocks/authnprovider/managermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
@@ -48,6 +47,7 @@ type OIDCAuthExecutorTestSuite struct {
 	mockIDPService        *idpmock.IDPServiceInterfaceMock
 	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockAuthnProvider     *managermock.AuthnProviderManagerInterfaceMock
 	executor              oidcAuthExecutorInterface
 }
 
@@ -60,6 +60,7 @@ func (suite *OIDCAuthExecutorTestSuite) SetupTest() {
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerInterfaceMock(suite.T())
 
 	defaultInputs := []common.Input{{Identifier: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOIDCAuth)
@@ -67,7 +68,8 @@ func (suite *OIDCAuthExecutorTestSuite) SetupTest() {
 		defaultInputs, []common.Input{}).Return(mockExec)
 
 	suite.executor = newOIDCAuthExecutor(ExecutorNameOIDCAuth, defaultInputs, []common.Input{},
-		suite.mockFlowFactory, suite.mockIDPService, suite.mockUserSchemaService, suite.mockOIDCService)
+		suite.mockFlowFactory, suite.mockIDPService, suite.mockUserSchemaService, suite.mockOIDCService,
+		suite.mockAuthnProvider, idp.IDPTypeOIDC)
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestNewOIDCAuthExecutor() {
@@ -114,42 +116,20 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 		},
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		IDToken:     "id_token_jwt_123",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-123",
-		"email": "test@example.com",
-		"name":  "Test User",
-		"iss":   "https://oidc.provider.com",
-		"aud":   "client-id-123",
-		"exp":   1234567890,
-		"iat":   1234567800,
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt_123").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-123", "email": "test@example.com", "name": "Test User",
+				"iss": "https://oidc.provider.com", "aud": "client-id-123",
+				"exp": 1234567890, "iat": 1234567800,
+			},
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -160,7 +140,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 	assert.Equal(suite.T(), "user-123", resp.AuthenticatedUser.UserID)
 	assert.Equal(suite.T(), "ou-123", resp.AuthenticatedUser.OUID)
 	assert.Equal(suite.T(), "test@example.com", resp.RuntimeData["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken_Success() {
@@ -180,46 +160,26 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-456",
-		"email": "user@example.com",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-456",
-		OUID: "ou-456",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-456").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-456",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-456", "email": "user@example.com",
+				"iss": "https://provider.com", "aud": "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-456",
+			OUID:           "ou-456",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce() {
@@ -240,33 +200,26 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-123",
-		"nonce": "different_nonce_456",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-123",
+				"nonce": "different_nonce_456",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Contains(suite.T(), execResp.FailureReason, "Nonce mismatch")
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ProviderClientError() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
@@ -283,30 +236,19 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim()
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"email": "test@example.com",
-		"name":  "Test User",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "Invalid ID token"},
+		})
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Contains(suite.T(), execResp.FailureReason, "sub claim not found")
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	assert.Equal(suite.T(), "Invalid ID token", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_UserNotFound() {
@@ -326,35 +268,15 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub": "new-user-sub", "email": "newuser@example.com", "name": "New User",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -362,7 +284,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
 	assert.False(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound() {
@@ -382,37 +304,22 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_Use
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub": "unknown-user",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "unknown-user").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "unknown-user",
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, execResp.FailureReason)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() {
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -429,193 +336,21 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyE
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub": "existing-user-sub",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "existing-user-sub",
+			IsExistingUser: true,
+			UserID:         "user-789",
+			OUID:           "ou-789",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Contains(suite.T(), execResp.FailureReason, "User already exists")
-	suite.mockOIDCService.AssertExpectations(suite.T())
-}
-
-func (suite *OIDCAuthExecutorTestSuite) TestGetIDTokenClaims_Success() {
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	expectedClaims := map[string]interface{}{
-		"sub":   "user-sub-123",
-		"email": "test@example.com",
-		"name":  "Test User",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(expectedClaims, nil)
-
-	claims, err := suite.executor.GetIDTokenClaims(execResp, "id_token_jwt")
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), claims)
-	assert.Equal(suite.T(), "user-sub-123", claims["sub"])
-	assert.Equal(suite.T(), "test@example.com", claims["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
-}
-
-func (suite *OIDCAuthExecutorTestSuite) TestGetIDTokenClaims_Errors() {
-	tests := []struct {
-		name               string
-		token              string
-		serviceError       *serviceerror.ServiceError
-		expectError        bool
-		expectedStatus     common.ExecutorStatus
-		expectedFailReason string
-		errorContains      string
-	}{
-		{
-			name:  "ClientError",
-			token: "invalid_token",
-			serviceError: &serviceerror.ServiceError{
-				Type: serviceerror.ClientErrorType,
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.invalid_id_token", DefaultValue: "Invalid ID token",
-				},
-			},
-			expectError:        false,
-			expectedStatus:     common.ExecFailure,
-			expectedFailReason: "Invalid ID token",
-		},
-		{
-			name:  "ServerError",
-			token: "id_token",
-			serviceError: &serviceerror.ServiceError{
-				Type: serviceerror.ServerErrorType,
-				Code: "OIDC-5000",
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.failed_to_extract_claims", DefaultValue: "Failed to extract claims",
-				},
-			},
-			expectError:   true,
-			errorContains: "failed to extract claims from the ID token",
-		},
-	}
-
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			execResp := &common.ExecutorResponse{
-				AdditionalData: make(map[string]string),
-				RuntimeData:    make(map[string]string),
-			}
-
-			suite.mockOIDCService.On("GetIDTokenClaims", tt.token).
-				Return(nil, tt.serviceError).Once()
-
-			claims, err := suite.executor.GetIDTokenClaims(execResp, tt.token)
-
-			assert.Nil(suite.T(), claims)
-			if tt.expectError {
-				assert.Error(suite.T(), err)
-				assert.Contains(suite.T(), err.Error(), tt.errorContains)
-			} else {
-				assert.NoError(suite.T(), err)
-				assert.Equal(suite.T(), tt.expectedStatus, execResp.Status)
-				assert.Equal(suite.T(), tt.expectedFailReason, execResp.FailureReason)
-			}
-			suite.mockOIDCService.AssertExpectations(suite.T())
-		})
-	}
-}
-
-func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAdditionalScopes_FetchesUserInfo() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeAuthentication,
-		UserInputs: map[string]string{
-			"code": "auth_code_123",
-		},
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
-	execResp := &common.ExecutorResponse{
-		AdditionalData: make(map[string]string),
-		RuntimeData:    make(map[string]string),
-	}
-
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub": "user-sub-123",
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":     "user-sub-123",
-		"email":   "user@example.com",
-		"phone":   "+1234567890",
-		"address": "123 Main St",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid", "profile", "email"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
-	suite.mockOIDCService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
-
-	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
-
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
-	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
-	assert.Contains(suite.T(), execResp.AuthenticatedUser.Attributes, "email")
-	assert.Contains(suite.T(), execResp.AuthenticatedUser.Attributes, "phone")
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided() {
@@ -656,44 +391,21 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":     "user-sub-123",
-		"email":   "user@example.com",
-		"name":    "User Name",
-		"iss":     "https://provider.com",
-		"aud":     "client-id",
-		"exp":     1234567890,
-		"iat":     1234567800,
-		"at_hash": "hash_value",
-		"nonce":   "nonce_value",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-123", "email": "user@example.com", "name": "User Name",
+				"iss": "https://provider.com", "aud": "client-id",
+				"exp": 1234567890, "iat": 1234567800,
+				"at_hash": "hash_value", "nonce": "nonce_value",
+			},
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -708,7 +420,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 	assert.NotContains(suite.T(), execResp.AuthenticatedUser.Attributes, "at_hash")
 	assert.NotContains(suite.T(), execResp.AuthenticatedUser.Attributes, "nonce")
 	assert.NotContains(suite.T(), execResp.AuthenticatedUser.Attributes, "sub")
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDToken() {
@@ -728,39 +440,19 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-789",
-		"email": "user@test.com",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-789",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-789", "email": "user@test.com",
+				"iss": "https://provider.com", "aud": "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-789",
+			OUID:           "ou-789",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -769,7 +461,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "user@test.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "user@test.com", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDToken() {
@@ -789,39 +481,19 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDT
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":  "user-sub-789",
-		"name": "Test User",
-		"iss":  "https://provider.com",
-		"aud":  "client-id",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-789",
+			ExternalClaims: map[string]interface{}{
+				"sub": "user-sub-789", "name": "Test User",
+				"iss": "https://provider.com", "aud": "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-789",
+			OUID:           "ou-789",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -830,7 +502,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDT
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.NotContains(suite.T(), execResp.RuntimeData, "email")
 	assert.NotContains(suite.T(), execResp.AuthenticatedUser.Attributes, "email")
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailInIDToken() {
@@ -850,39 +522,21 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailIn
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-789",
-		"email": "",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-789",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-789",
+				"email": "",
+				"iss":   "https://provider.com",
+				"aud":   "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-789",
+			OUID:           "ou-789",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -891,7 +545,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailIn
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.NotContains(suite.T(), execResp.RuntimeData, "email")
 	assert.Equal(suite.T(), "", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_WithEmail() {
@@ -911,37 +565,19 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "new-user-sub",
+				"email": "newuser@example.com",
+				"name":  "New User",
+				"iss":   "https://provider.com",
+				"aud":   "client-id",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -951,7 +587,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
 	assert.Equal(suite.T(), "newuser@example.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "newuser@example.com", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUserInfo() {
@@ -971,47 +607,22 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUse
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":  "user-sub-789",
-		"name": "Test User",
-		"iss":  "https://provider.com",
-		"aud":  "client-id",
-	}
-
-	userInfo := map[string]interface{}{
-		"sub":   "user-sub-789",
-		"email": "fromUserInfo@example.com",
-		"name":  "Test User",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid", "profile", "email"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
-	suite.mockOIDCService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
-		Return(userInfo, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-789",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-789",
+				"name":  "Test User",
+				"email": "fromUserInfo@example.com",
+				"iss":   "https://provider.com",
+				"aud":   "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-789",
+			OUID:           "ou-789",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -1020,7 +631,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUse
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "fromUserInfo@example.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "fromUserInfo@example.com", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDToken_NilRuntimeData() {
@@ -1040,39 +651,21 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 		RuntimeData:    nil, // Explicitly nil
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "user-sub-999",
-		"email": "niltest@example.com",
-		"iss":   "https://provider.com",
-		"aud":   "client-id",
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-999",
-		OUID: "ou-999",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "user-sub-999").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-999",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-999",
+				"email": "niltest@example.com",
+				"iss":   "https://provider.com",
+				"aud":   "client-id",
+			},
+			IsExistingUser: true,
+			UserID:         "user-999",
+			OUID:           "ou-999",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -1082,7 +675,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 	assert.NotNil(suite.T(), execResp.RuntimeData, "RuntimeData should be initialized")
 	assert.Equal(suite.T(), "niltest@example.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "niltest@example.com", execResp.AuthenticatedUser.Attributes["email"])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithoutLocalUser() {
@@ -1106,45 +699,25 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "new-user-sub",
-		"email": "newuser@example.com",
-		"name":  "New User",
-		"iss":   "https://provider.com",
-		"aud":   "client-123",
-		"exp":   float64(1234567890),
-		"iat":   float64(1234567000),
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "new-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "new-user-sub",
+				"email": "newuser@example.com",
+				"name":  "New User",
+				"iss":   "https://provider.com",
+				"aud":   "client-123",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(&userschema.UserSchema{
 			Name:                  "INTERNAL",
 			AllowSelfRegistration: true,
 			OUID:                  "ou-123",
 		}, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -1154,7 +727,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 	assert.Equal(suite.T(), dataValueTrue, execResp.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning])
 	assert.Equal(suite.T(), "new-user-sub", execResp.RuntimeData["sub"])
 	assert.NotNil(suite.T(), execResp.AuthenticatedUser.Attributes)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockUserSchemaService.AssertExpectations(suite.T())
 }
 
@@ -1176,38 +749,19 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthW
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub": "new-user-sub",
-		"iss": "https://provider.com",
-		"aud": "client-123",
-		"exp": float64(1234567890),
-		"iat": float64(1234567000),
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
-		Return(nil, &serviceerror.ServiceError{
-			Code: authncm.ErrorUserNotFound.Code,
-			Type: serviceerror.ClientErrorType,
-		})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "new-user-sub",
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, execResp.FailureReason)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrationWithExistingUser() {
@@ -1228,42 +782,22 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistr
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile email",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub":   "existing-user-sub",
-		"email": "existing@example.com",
-		"name":  "Existing User",
-		"iss":   "https://provider.com",
-		"aud":   "client-123",
-		"exp":   float64(1234567890),
-		"iat":   float64(1234567000),
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "existing-user-sub",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "existing-user-sub",
+				"email": "existing@example.com",
+				"name":  "Existing User",
+				"iss":   "https://provider.com",
+				"aud":   "client-123",
+			},
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
@@ -1272,9 +806,10 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistr
 	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "user-123", execResp.AuthenticatedUser.UserID)
 	assert.Equal(suite.T(), dataValueTrue, execResp.RuntimeData[common.RuntimeKeySkipProvisioning])
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
+//nolint:dupl
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistrationWithExistingUser() {
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
@@ -1293,135 +828,62 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegis
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid profile",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	idTokenClaims := map[string]interface{}{
-		"sub": "existing-user-sub",
-		"iss": "https://provider.com",
-		"aud": "client-123",
-		"exp": float64(1234567890),
-		"iat": float64(1234567000),
-	}
-
-	existingUser := &entityprovider.Entity{
-		ID:   "user-123",
-		OUID: "ou-123",
-		Type: "INTERNAL",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
-	suite.mockOIDCService.On("GetInternalUser", "existing-user-sub").
-		Return(existingUser, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub:    "existing-user-sub",
+			IsExistingUser: true,
+			UserID:         "user-123",
+			OUID:           "ou-123",
+			UserType:       "INTERNAL",
+		}, (*serviceerror.ServiceError)(nil))
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), "User already exists with the provided sub claim.", execResp.FailureReason)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
-func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OAuthClientConfigErrors() {
-	tests := []struct {
-		name               string
-		serviceError       *serviceerror.ServiceError
-		idTokenClaims      map[string]interface{}
-		expectGoError      bool
-		expectedExecStatus common.ExecutorStatus
-		errorContains      string
-	}{
-		{
-			name: "ClientError",
-			serviceError: &serviceerror.ServiceError{
-				Code: "CONFIG_ERROR",
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.configuration_not_found", DefaultValue: "Configuration not found",
-				},
-				Type: serviceerror.ClientErrorType,
-			},
-			idTokenClaims: map[string]interface{}{
-				"sub":   "user-sub",
-				"email": "user@example.com",
-				"iss":   "https://provider.com",
-				"aud":   "client-123",
-			},
-			expectGoError:      false,
-			expectedExecStatus: common.ExecFailure,
-			errorContains:      "failed to retrieve OAuth client configuration",
-		},
-		{
-			name: "ServerError",
-			serviceError: &serviceerror.ServiceError{
-				Code: "SERVER_ERROR",
-				ErrorDescription: i18ncore.I18nMessage{
-					Key: "error.test.internal_server_error", DefaultValue: "Internal server error",
-				},
-				Type: serviceerror.ServerErrorType,
-			},
-			idTokenClaims: map[string]interface{}{
-				"sub": "user-sub",
-			},
-			expectGoError:      true,
-			expectedExecStatus: common.ExecutorStatus(""),
-			errorContains:      "failed to retrieve OAuth client configuration",
-		},
+func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_FiltersNonUserClaims() {
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
 	}
 
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			// Clear expectations before each test
-			suite.mockOIDCService.ExpectedCalls = nil
-
-			ctx := &core.NodeContext{
-				ExecutionID: "flow-123",
-				NodeProperties: map[string]interface{}{
-					"idpId": "idp-123",
-				},
-			}
-
-			execResp := &common.ExecutorResponse{
-				AdditionalData: make(map[string]string),
-				RuntimeData:    make(map[string]string),
-			}
-
-			suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-				Return(nil, tt.serviceError)
-
-			attributes, err := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(
-				ctx, execResp, tt.idTokenClaims, "access-token")
-
-			if tt.expectGoError {
-				assert.Error(suite.T(), err)
-				assert.Contains(suite.T(), err.Error(), tt.errorContains)
-			} else {
-				assert.NoError(suite.T(), err)
-				assert.Equal(suite.T(), tt.expectedExecStatus, execResp.Status)
-				assert.Contains(suite.T(), execResp.FailureReason, tt.errorContains)
-			}
-
-			assert.Nil(suite.T(), attributes)
-			suite.mockOIDCService.AssertExpectations(suite.T())
-		})
+	claims := map[string]interface{}{
+		"sub":        "user-sub",
+		"email":      "user@example.com",
+		"name":       "Test User",
+		"iss":        "https://provider.com",
+		"aud":        "client-123",
+		"exp":        float64(1234567890),
+		"iat":        float64(1234567000),
+		"at_hash":    "hash-value",
+		"azp":        "azp-value",
+		"nonce":      "nonce-value",
+		"given_name": "Test",
 	}
+
+	attributes := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(execResp, claims)
+
+	assert.NotNil(suite.T(), attributes)
+	assert.Equal(suite.T(), "user@example.com", attributes["email"])
+	assert.Equal(suite.T(), "Test User", attributes["name"])
+	assert.Equal(suite.T(), "Test", attributes["given_name"])
+	assert.NotContains(suite.T(), attributes, "sub")
+	assert.NotContains(suite.T(), attributes, "iss")
+	assert.NotContains(suite.T(), attributes, "aud")
+	assert.NotContains(suite.T(), attributes, "exp")
+	assert.NotContains(suite.T(), attributes, "iat")
+	assert.NotContains(suite.T(), attributes, "at_hash")
+	assert.NotContains(suite.T(), attributes, "azp")
+	assert.NotContains(suite.T(), attributes, "nonce")
+	assert.Equal(suite.T(), "user@example.com", execResp.RuntimeData["email"])
 }
 
-func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OnlyOpenIDScope_NoUserInfoCall() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		NodeProperties: map[string]interface{}{
-			"idpId": "idp-123",
-		},
-	}
-
+func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_EmailAddedToRuntimeData() {
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
 		RuntimeData:    make(map[string]string),
@@ -1438,36 +900,21 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OnlyOpenIDS
 		"given_name": "Test",
 	}
 
-	oauthConfig := &authnoauth.OAuthClientConfig{
-		Scopes: []string{"openid"},
-	}
+	attributes := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(execResp, idTokenClaims)
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
-		Return(oauthConfig, nil)
-
-	attributes, err := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(
-		ctx, execResp, idTokenClaims, "access-token")
-
-	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attributes)
-	// User attributes from ID token should be present
 	assert.Equal(suite.T(), "user@example.com", attributes["email"])
 	assert.Equal(suite.T(), "Test User", attributes["name"])
 	assert.Equal(suite.T(), "Test", attributes["given_name"])
-	// Non-user attributes should be filtered (including sub which is an identifier, not a user attribute)
 	assert.NotContains(suite.T(), attributes, "sub")
 	assert.NotContains(suite.T(), attributes, "iss")
 	assert.NotContains(suite.T(), attributes, "aud")
 	assert.NotContains(suite.T(), attributes, "exp")
 	assert.NotContains(suite.T(), attributes, "iat")
-	// Email should be added to runtime data
 	assert.Equal(suite.T(), "user@example.com", execResp.RuntimeData["email"])
-	// Verify GetUserInfo was NOT called since only openid scope is present
-	suite.mockOIDCService.AssertNotCalled(suite.T(), "GetUserInfo")
-	suite.mockOIDCService.AssertExpectations(suite.T())
 }
 
-func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NonStringSubClaim() {
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ServerError() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
@@ -1484,30 +931,17 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NonStringSub
 		RuntimeData:    make(map[string]string),
 	}
 
-	tokenResp := &authnoauth.TokenResponse{
-		AccessToken: "access_token_123",
-		TokenType:   "Bearer",
-		Scope:       "openid",
-		IDToken:     "id_token_jwt",
-		ExpiresIn:   3600,
-	}
-
-	// sub claim is not a string
-	idTokenClaims := map[string]interface{}{
-		"sub": 12345, // numeric sub instead of string
-		"iss": "https://provider.com",
-		"aud": "client-123",
-	}
-
-	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
-		Return(tokenResp, nil)
-	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
-		Return(idTokenClaims, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			Code:             "OIDC-5000",
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "Internal OIDC authentication error"},
+		})
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Equal(suite.T(), "sub claim not found in the ID token.", execResp.FailureReason)
-	suite.mockOIDCService.AssertExpectations(suite.T())
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "OIDC authentication failed")
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -171,6 +171,8 @@ var defaultMessages = map[string]string{
 	"error.authnservice.empty_session_token_description": "The provided session token is empty",
 	"error.authnservice.error_retrieving_idp": "Error retrieving identity provider",
 	"error.authnservice.error_retrieving_idp_description": "An error occurred while retrieving the identity provider",
+	"error.authnservice.federated_authentication_failed": "Federated authentication failed",
+	"error.authnservice.federated_authentication_failed_description": "The federated authentication attempt failed",
 	"error.authnservice.google.invalid_id_token_audience_description": "The ID token audience does not match the expected client ID",
 	"error.authnservice.google.invalid_id_token_exp_claim_description": "The ID token expiration claim is missing or invalid",
 	"error.authnservice.google.invalid_id_token_expired_description": "The ID token has expired",

--- a/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
@@ -7,6 +7,7 @@ package githubmock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type GithubOAuthAuthnServiceInterfaceMock_Expecter struct {
 
 func (_m *GithubOAuthAuthnServiceInterfaceMock) EXPECT() *GithubOAuthAuthnServiceInterfaceMock_Expecter {
 	return &GithubOAuthAuthnServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock

--- a/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
@@ -7,6 +7,7 @@ package googlemock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type GoogleOIDCAuthnServiceInterfaceMock_Expecter struct {
 
 func (_m *GoogleOIDCAuthnServiceInterfaceMock) EXPECT() *GoogleOIDCAuthnServiceInterfaceMock_Expecter {
 	return &GoogleOIDCAuthnServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
@@ -7,6 +7,7 @@ package oauthmock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type OAuthAuthnCoreServiceInterfaceMock_Expecter struct {
 
 func (_m *OAuthAuthnCoreServiceInterfaceMock) EXPECT() *OAuthAuthnCoreServiceInterfaceMock_Expecter {
 	return &OAuthAuthnCoreServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
@@ -7,6 +7,7 @@ package oauthmock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type OAuthAuthnServiceInterfaceMock_Expecter struct {
 
 func (_m *OAuthAuthnServiceInterfaceMock) EXPECT() *OAuthAuthnServiceInterfaceMock_Expecter {
 	return &OAuthAuthnServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type OAuthAuthnServiceInterfaceMock
+func (_mock *OAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OAuthAuthnServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type OAuthAuthnServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	return &OAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnServiceInterfaceMock

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
@@ -7,6 +7,7 @@ package oidcmock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type OIDCAuthnCoreServiceInterfaceMock_Expecter struct {
 
 func (_m *OIDCAuthnCoreServiceInterfaceMock) EXPECT() *OIDCAuthnCoreServiceInterfaceMock_Expecter {
 	return &OIDCAuthnCoreServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
@@ -7,6 +7,7 @@ package oidcmock
 import (
 	"context"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -38,6 +39,82 @@ type OIDCAuthnServiceInterfaceMock_Expecter struct {
 
 func (_m *OIDCAuthnServiceInterfaceMock) EXPECT() *OIDCAuthnServiceInterfaceMock_Expecter {
 	return &OIDCAuthnServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type OIDCAuthnServiceInterfaceMock
+func (_mock *OIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *common.FederatedAuthResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.FederatedAuthResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.FederatedAuthResult); ok {
+		r0 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.FederatedAuthResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OIDCAuthnServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type OIDCAuthnServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - code string
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	return &OIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Return(federatedAuthResult *common.FederatedAuthResult, serviceError *serviceerror.ServiceError) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(federatedAuthResult, serviceError)
+	return _c
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.FederatedAuthResult, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnServiceInterfaceMock

--- a/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
-	"github.com/asgardeo/thunder/internal/flow/executor"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -93,80 +92,6 @@ func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err error) 
 }
 
 func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse) error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ExchangeCodeForToken provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*executor.OAuthTokenResponse, error) {
-	ret := _mock.Called(ctx, execResp, code)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExchangeCodeForToken")
-	}
-
-	var r0 *executor.OAuthTokenResponse
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (*executor.OAuthTokenResponse, error)); ok {
-		return returnFunc(ctx, execResp, code)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) *executor.OAuthTokenResponse); ok {
-		r0 = returnFunc(ctx, execResp, code)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*executor.OAuthTokenResponse)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, code)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExchangeCodeForToken'
-type oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call struct {
-	*mock.Call
-}
-
-// ExchangeCodeForToken is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - code string
-func (_e *oAuthExecutorInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, execResp interface{}, code interface{}) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	return &oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, execResp, code)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string)) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Return(oAuthTokenResponse *executor.OAuthTokenResponse, err error) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(oAuthTokenResponse, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*executor.OAuthTokenResponse, error)) *oAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -388,74 +313,6 @@ func (_c *oAuthExecutorInterfaceMock_GetIdpID_Call) Return(s string, err error) 
 }
 
 func (_c *oAuthExecutorInterfaceMock_GetIdpID_Call) RunAndReturn(run func(ctx *core.NodeContext) (string, error)) *oAuthExecutorInterfaceMock_GetIdpID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInternalUser provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) GetInternalUser(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error) {
-	ret := _mock.Called(sub, execResp)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInternalUser")
-	}
-
-	var r0 *entityprovider.Entity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) (*entityprovider.Entity, error)); ok {
-		return returnFunc(sub, execResp)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) *entityprovider.Entity); ok {
-		r0 = returnFunc(sub, execResp)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, *common.ExecutorResponse) error); ok {
-		r1 = returnFunc(sub, execResp)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_GetInternalUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInternalUser'
-type oAuthExecutorInterfaceMock_GetInternalUser_Call struct {
-	*mock.Call
-}
-
-// GetInternalUser is a helper method to define mock.On call
-//   - sub string
-//   - execResp *common.ExecutorResponse
-func (_e *oAuthExecutorInterfaceMock_Expecter) GetInternalUser(sub interface{}, execResp interface{}) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	return &oAuthExecutorInterfaceMock_GetInternalUser_Call{Call: _e.mock.On("GetInternalUser", sub, execResp)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) Run(run func(sub string, execResp *common.ExecutorResponse)) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) Return(entity *entityprovider.Entity, err error) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Return(entity, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetInternalUser_Call) RunAndReturn(run func(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error)) *oAuthExecutorInterfaceMock_GetInternalUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -698,80 +555,6 @@ func (_c *oAuthExecutorInterfaceMock_GetUserIDFromContext_Call) RunAndReturn(run
 	return _c
 }
 
-// GetUserInfo provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error) {
-	ret := _mock.Called(ctx, execResp, accessToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserInfo")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, execResp, accessToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) map[string]string); ok {
-		r0 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oAuthExecutorInterfaceMock_GetUserInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserInfo'
-type oAuthExecutorInterfaceMock_GetUserInfo_Call struct {
-	*mock.Call
-}
-
-// GetUserInfo is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - accessToken string
-func (_e *oAuthExecutorInterfaceMock_Expecter) GetUserInfo(ctx interface{}, execResp interface{}, accessToken interface{}) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	return &oAuthExecutorInterfaceMock_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo", ctx, execResp, accessToken)}
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string)) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) Return(stringToString map[string]string, err error) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(stringToString, err)
-	return _c
-}
-
-func (_c *oAuthExecutorInterfaceMock_GetUserInfo_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error)) *oAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasRequiredInputs provides a mock function for the type oAuthExecutorInterfaceMock
 func (_mock *oAuthExecutorInterfaceMock) HasRequiredInputs(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
 	ret := _mock.Called(ctx, execResp)
@@ -887,8 +670,8 @@ func (_c *oAuthExecutorInterfaceMock_ProcessAuthFlowResponse_Call) RunAndReturn(
 }
 
 // ResolveContextUser provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error) {
-	ret := _mock.Called(ctx, execResp, sub, internalUser)
+func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error) {
+	ret := _mock.Called(ctx, execResp, sub, internalUser, isAmbiguous)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveContextUser")
@@ -896,18 +679,18 @@ func (_mock *oAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContex
 
 	var r0 *common0.AuthenticatedUser
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) (*common0.AuthenticatedUser, error)); ok {
-		return returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) (*common0.AuthenticatedUser, error)); ok {
+		return returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) *common0.AuthenticatedUser); ok {
-		r0 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) *common0.AuthenticatedUser); ok {
+		r0 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common0.AuthenticatedUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) error); ok {
-		r1 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) error); ok {
+		r1 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -924,11 +707,12 @@ type oAuthExecutorInterfaceMock_ResolveContextUser_Call struct {
 //   - execResp *common.ExecutorResponse
 //   - sub string
 //   - internalUser *entityprovider.Entity
-func (_e *oAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
-	return &oAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser)}
+//   - isAmbiguous bool
+func (_e *oAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}, isAmbiguous interface{}) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+	return &oAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser, isAmbiguous)}
 }
 
-func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *core.NodeContext
 		if args[0] != nil {
@@ -946,11 +730,16 @@ func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *
 		if args[3] != nil {
 			arg3 = args[3].(*entityprovider.Entity)
 		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -961,7 +750,7 @@ func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) Return(authenticat
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error)) *oAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
-	"github.com/asgardeo/thunder/internal/flow/executor"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -93,80 +92,6 @@ func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err erro
 }
 
 func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse) error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ExchangeCodeForToken provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*executor.OAuthTokenResponse, error) {
-	ret := _mock.Called(ctx, execResp, code)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExchangeCodeForToken")
-	}
-
-	var r0 *executor.OAuthTokenResponse
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (*executor.OAuthTokenResponse, error)); ok {
-		return returnFunc(ctx, execResp, code)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) *executor.OAuthTokenResponse); ok {
-		r0 = returnFunc(ctx, execResp, code)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*executor.OAuthTokenResponse)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, code)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExchangeCodeForToken'
-type oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call struct {
-	*mock.Call
-}
-
-// ExchangeCodeForToken is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - code string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, execResp interface{}, code interface{}) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	return &oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, execResp, code)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string)) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) Return(oAuthTokenResponse *executor.OAuthTokenResponse, err error) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
-	_c.Call.Return(oAuthTokenResponse, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, code string) (*executor.OAuthTokenResponse, error)) *oidcAuthExecutorInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -332,74 +257,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetExecutionPolicy_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetIDTokenClaims provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetIDTokenClaims(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error) {
-	ret := _mock.Called(execResp, idToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIDTokenClaims")
-	}
-
-	var r0 map[string]interface{}
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*common.ExecutorResponse, string) (map[string]interface{}, error)); ok {
-		return returnFunc(execResp, idToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*common.ExecutorResponse, string) map[string]interface{}); ok {
-		r0 = returnFunc(execResp, idToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]interface{})
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(execResp, idToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIDTokenClaims'
-type oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call struct {
-	*mock.Call
-}
-
-// GetIDTokenClaims is a helper method to define mock.On call
-//   - execResp *common.ExecutorResponse
-//   - idToken string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetIDTokenClaims(execResp interface{}, idToken interface{}) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	return &oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", execResp, idToken)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) Run(run func(execResp *common.ExecutorResponse, idToken string)) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *common.ExecutorResponse
-		if args[0] != nil {
-			arg0 = args[0].(*common.ExecutorResponse)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) Return(stringToIfaceVal map[string]interface{}, err error) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Return(stringToIfaceVal, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(execResp *common.ExecutorResponse, idToken string) (map[string]interface{}, error)) *oidcAuthExecutorInterfaceMock_GetIDTokenClaims_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdpID provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) GetIdpID(ctx *core.NodeContext) (string, error) {
 	ret := _mock.Called(ctx)
@@ -456,74 +313,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetIdpID_Call) Return(s string, err erro
 }
 
 func (_c *oidcAuthExecutorInterfaceMock_GetIdpID_Call) RunAndReturn(run func(ctx *core.NodeContext) (string, error)) *oidcAuthExecutorInterfaceMock_GetIdpID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInternalUser provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetInternalUser(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error) {
-	ret := _mock.Called(sub, execResp)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInternalUser")
-	}
-
-	var r0 *entityprovider.Entity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) (*entityprovider.Entity, error)); ok {
-		return returnFunc(sub, execResp)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, *common.ExecutorResponse) *entityprovider.Entity); ok {
-		r0 = returnFunc(sub, execResp)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, *common.ExecutorResponse) error); ok {
-		r1 = returnFunc(sub, execResp)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetInternalUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInternalUser'
-type oidcAuthExecutorInterfaceMock_GetInternalUser_Call struct {
-	*mock.Call
-}
-
-// GetInternalUser is a helper method to define mock.On call
-//   - sub string
-//   - execResp *common.ExecutorResponse
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetInternalUser(sub interface{}, execResp interface{}) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	return &oidcAuthExecutorInterfaceMock_GetInternalUser_Call{Call: _e.mock.On("GetInternalUser", sub, execResp)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) Run(run func(sub string, execResp *common.ExecutorResponse)) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) Return(entity *entityprovider.Entity, err error) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
-	_c.Call.Return(entity, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetInternalUser_Call) RunAndReturn(run func(sub string, execResp *common.ExecutorResponse) (*entityprovider.Entity, error)) *oidcAuthExecutorInterfaceMock_GetInternalUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -766,80 +555,6 @@ func (_c *oidcAuthExecutorInterfaceMock_GetUserIDFromContext_Call) RunAndReturn(
 	return _c
 }
 
-// GetUserInfo provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error) {
-	ret := _mock.Called(ctx, execResp, accessToken)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserInfo")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, execResp, accessToken)
-	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string) map[string]string); ok {
-		r0 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string) error); ok {
-		r1 = returnFunc(ctx, execResp, accessToken)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// oidcAuthExecutorInterfaceMock_GetUserInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserInfo'
-type oidcAuthExecutorInterfaceMock_GetUserInfo_Call struct {
-	*mock.Call
-}
-
-// GetUserInfo is a helper method to define mock.On call
-//   - ctx *core.NodeContext
-//   - execResp *common.ExecutorResponse
-//   - accessToken string
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) GetUserInfo(ctx interface{}, execResp interface{}, accessToken interface{}) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	return &oidcAuthExecutorInterfaceMock_GetUserInfo_Call{Call: _e.mock.On("GetUserInfo", ctx, execResp, accessToken)}
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string)) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *core.NodeContext
-		if args[0] != nil {
-			arg0 = args[0].(*core.NodeContext)
-		}
-		var arg1 *common.ExecutorResponse
-		if args[1] != nil {
-			arg1 = args[1].(*common.ExecutorResponse)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) Return(stringToString map[string]string, err error) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(stringToString, err)
-	return _c
-}
-
-func (_c *oidcAuthExecutorInterfaceMock_GetUserInfo_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, accessToken string) (map[string]string, error)) *oidcAuthExecutorInterfaceMock_GetUserInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasRequiredInputs provides a mock function for the type oidcAuthExecutorInterfaceMock
 func (_mock *oidcAuthExecutorInterfaceMock) HasRequiredInputs(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
 	ret := _mock.Called(ctx, execResp)
@@ -955,8 +670,8 @@ func (_c *oidcAuthExecutorInterfaceMock_ProcessAuthFlowResponse_Call) RunAndRetu
 }
 
 // ResolveContextUser provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error) {
-	ret := _mock.Called(ctx, execResp, sub, internalUser)
+func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error) {
+	ret := _mock.Called(ctx, execResp, sub, internalUser, isAmbiguous)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveContextUser")
@@ -964,18 +679,18 @@ func (_mock *oidcAuthExecutorInterfaceMock) ResolveContextUser(ctx *core.NodeCon
 
 	var r0 *common0.AuthenticatedUser
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) (*common0.AuthenticatedUser, error)); ok {
-		return returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) (*common0.AuthenticatedUser, error)); ok {
+		return returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) *common0.AuthenticatedUser); ok {
-		r0 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(0).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) *common0.AuthenticatedUser); ok {
+		r0 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common0.AuthenticatedUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity) error); ok {
-		r1 = returnFunc(ctx, execResp, sub, internalUser)
+	if returnFunc, ok := ret.Get(1).(func(*core.NodeContext, *common.ExecutorResponse, string, *entityprovider.Entity, bool) error); ok {
+		r1 = returnFunc(ctx, execResp, sub, internalUser, isAmbiguous)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -992,11 +707,12 @@ type oidcAuthExecutorInterfaceMock_ResolveContextUser_Call struct {
 //   - execResp *common.ExecutorResponse
 //   - sub string
 //   - internalUser *entityprovider.Entity
-func (_e *oidcAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
-	return &oidcAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser)}
+//   - isAmbiguous bool
+func (_e *oidcAuthExecutorInterfaceMock_Expecter) ResolveContextUser(ctx interface{}, execResp interface{}, sub interface{}, internalUser interface{}, isAmbiguous interface{}) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+	return &oidcAuthExecutorInterfaceMock_ResolveContextUser_Call{Call: _e.mock.On("ResolveContextUser", ctx, execResp, sub, internalUser, isAmbiguous)}
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *core.NodeContext
 		if args[0] != nil {
@@ -1014,11 +730,16 @@ func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Run(run func(ct
 		if args[3] != nil {
 			arg3 = args[3].(*entityprovider.Entity)
 		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -1029,7 +750,7 @@ func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) Return(authenti
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity) (*common0.AuthenticatedUser, error)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
+func (_c *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call) RunAndReturn(run func(ctx *core.NodeContext, execResp *common.ExecutorResponse, sub string, internalUser *entityprovider.Entity, isAmbiguous bool) (*common0.AuthenticatedUser, error)) *oidcAuthExecutorInterfaceMock_ResolveContextUser_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

Federated authenticators (OAuth, OIDC, Google, GitHub) were bypassing the authn provider manager and executing their own authentication logic directly inside the top-level authentication service. With the updated architecture supporting user-core pluggability, all authentication should route through the authn provider. This PR fixes that inconsistency.

### Approach

  - Introduced a FederatedAuthCredential struct and FederatedAuthenticator interface in authn/common.
  - Each federated authenticator (OAuth, OIDC, Google, GitHub) now implements FederatedAuthenticator, exposing a unified Authenticate(ctx, idpID, code) method.
  - defaultAuthnProvider is extended with a map[IDPType]FederatedAuthenticator, injected at startup. The credential resolution logic is refactored into a resolveCredentials dispatcher that routes to the appropriate authenticator — including the new federated branch.
  - authn/service.go:FinishIDPAuthentication no longer contains a type-switch or IDP-specific logic. It wraps the callback into a FederatedAuthCredential and delegates entirely to authnProvider.AuthenticateUser, consistent with how all other authentication methods are handled.

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2355

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified federated sign-in across OAuth/OIDC/Google/GitHub with explicit provider handling and propagation of external identity/claims.
  * New user-facing federated-authentication error messages.

* **Bug Fixes**
  * Consistent handling of ambiguous and non-existing federated users across flows; clearer failure reasons and more predictable registration/authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->