### PR TITLE
Show organization unit handle in role responses and edit page

### DIFF
--- a/api/role.yaml
+++ b/api/role.yaml
@@ -47,10 +47,12 @@ paths:
                     name: "front-desk-agent"
                     description: "Front desk agent role with booking and customer management permissions"
                     ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                    ouHandle: "default"
                   - id: "257e528f-eb24-48b6-884d-20460e190957"
                     name: "hotel-manager"
                     description: "Hotel manager with full property access"
                     ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                    ouHandle: "default"
                 links:
                   - href: "roles?offset=2&limit=2"
                     rel: "next"
@@ -136,6 +138,7 @@ paths:
                 name: "front-desk-agent"
                 description: "Front desk agent role with booking and customer management permissions"
                 ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                ouHandle: "default"
                 permissions:
                   - resourceServerId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
                     permissions:
@@ -234,6 +237,7 @@ paths:
                 name: "front-desk-agent"
                 description: "Front desk agent role with booking and customer management permissions"
                 ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                ouHandle: "default"
                 permissions:
                   - "create_reservation"
                   - "view_reservation"
@@ -318,6 +322,7 @@ paths:
                 name: "senior-front-desk-agent"
                 description: "Senior front desk agent with additional permissions"
                 ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                ouHandle: "default"
                 permissions:
                   - resourceServerId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
                     permissions:
@@ -807,6 +812,10 @@ components:
           type: string
           format: uuid
           description: "ID of the organization unit this role belongs to"
+        ouHandle:
+          type: string
+          readOnly: true
+          description: "Handle of the organization unit this role belongs to"
 
     Role:
       type: object
@@ -827,6 +836,10 @@ components:
           type: string
           format: uuid
           description: "ID of the organization unit this role belongs to"
+        ouHandle:
+          type: string
+          readOnly: true
+          description: "Handle of the organization unit this role belongs to"
         permissions:
           type: array
           items:

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -465,6 +465,7 @@ func (rh *roleHandler) toHTTPCreateRoleResponse(role *RoleWithPermissionsAndAssi
 		Name:        role.Name,
 		Description: role.Description,
 		OUID:        role.OUID,
+		OUHandle:    role.OUHandle,
 		Permissions: role.Permissions,
 		Assignments: httpAssignments,
 	}

--- a/backend/internal/role/model.go
+++ b/backend/internal/role/model.go
@@ -67,6 +67,7 @@ type RoleSummaryResponse struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	OUID        string `json:"ouId"`
+	OUHandle    string `json:"ouHandle,omitempty"`
 	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
@@ -76,6 +77,7 @@ type RoleResponse struct {
 	Name        string                `json:"name"`
 	Description string                `json:"description,omitempty"`
 	OUID        string                `json:"ouId"`
+	OUHandle    string                `json:"ouHandle,omitempty"`
 	Permissions []ResourcePermissions `json:"permissions"`
 }
 
@@ -94,6 +96,7 @@ type CreateRoleResponse struct {
 	Name        string                `json:"name"`
 	Description string                `json:"description,omitempty"`
 	OUID        string                `json:"ouId"`
+	OUHandle    string                `json:"ouHandle,omitempty"`
 	Permissions []ResourcePermissions `json:"permissions"`
 	Assignments []AssignmentResponse  `json:"assignments,omitempty"`
 }
@@ -152,6 +155,7 @@ type RoleWithPermissionsAndAssignments struct {
 	Name        string
 	Description string
 	OUID        string
+	OUHandle    string
 	Permissions []ResourcePermissions
 	Assignments []RoleAssignment
 }
@@ -175,6 +179,7 @@ type Role struct {
 	Name        string
 	Description string
 	OUID        string
+	OUHandle    string
 	IsReadOnly  bool
 }
 
@@ -184,6 +189,7 @@ type RoleWithPermissions struct {
 	Name        string
 	Description string
 	OUID        string
+	OUHandle    string
 	Permissions []ResourcePermissions
 }
 

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -120,6 +120,27 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		return nil, &serviceerror.InternalServerError
 	}
 
+	if len(roles) > 0 {
+		seen := make(map[string]struct{}, len(roles))
+		ouIDs := make([]string, 0, len(roles))
+		for _, r := range roles {
+			if r.OUID != "" {
+				if _, exists := seen[r.OUID]; !exists {
+					ouIDs = append(ouIDs, r.OUID)
+					seen[r.OUID] = struct{}{}
+				}
+			}
+		}
+		ouHandles, svcErr := rs.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
+		if svcErr != nil {
+			logger.Warn("Failed to resolve OU handles for roles, skipping", log.Any("error", svcErr))
+		} else {
+			for i := range roles {
+				roles[i].OUHandle = ouHandles[roles[i].OUID]
+			}
+		}
+	}
+
 	response := &RoleList{
 		TotalResults: totalCount,
 		Roles:        roles,
@@ -151,7 +172,7 @@ func (rs *roleService) CreateRole(
 	responseAssignments := role.Assignments
 
 	// Validate organization unit exists using OU service
-	_, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
+	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 			logger.Debug("Organization unit not found", log.String("ouID", role.OUID))
@@ -198,6 +219,7 @@ func (rs *roleService) CreateRole(
 		Name:        role.Name,
 		Description: role.Description,
 		OUID:        role.OUID,
+		OUHandle:    ou.Handle,
 		Permissions: role.Permissions,
 		Assignments: responseAssignments,
 	}
@@ -236,6 +258,14 @@ func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 		}
 		logger.Error("Failed to retrieve role", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
+	}
+
+	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
+	if svcErr != nil {
+		logger.Warn("Failed to resolve OU handle for role, skipping",
+			log.String("id", id), log.Any("error", svcErr))
+	} else {
+		role.OUHandle = ou.Handle
 	}
 
 	logger.Debug("Successfully retrieved role", log.String("id", role.ID), log.String("name", role.Name))
@@ -278,7 +308,7 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	}
 
 	// Validate organization unit exists using OU service
-	_, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
+	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 			logger.Debug("Organization unit not found", log.String("ouID", role.OUID))
@@ -315,6 +345,7 @@ func (rs *roleService) UpdateRoleWithPermissions(
 		Name:        role.Name,
 		Description: role.Description,
 		OUID:        role.OUID,
+		OUHandle:    ou.Handle,
 		Permissions: role.Permissions,
 	}, nil
 }

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -120,8 +120,9 @@ func (suite *RoleServiceTestSuite) TestGetRoleList_Success() {
 	}
 
 	suite.mockStore.On("GetRoleListCount", mock.Anything).Return(2, nil)
-	suite.mockStore.On("GetRoleList", mock.Anything,
-		10, 0).Return(expectedRoles, nil)
+	suite.mockStore.On("GetRoleList", mock.Anything, 10, 0).Return(expectedRoles, nil)
+	suite.mockOUService.On("GetOrganizationUnitHandlesByIDs", mock.Anything,
+		[]string{"ou1"}).Return(map[string]string{"ou1": "default"}, nil)
 
 	result, err := suite.service.GetRoleList(context.Background(), 10, 0)
 
@@ -133,8 +134,10 @@ func (suite *RoleServiceTestSuite) TestGetRoleList_Success() {
 	suite.Equal(2, len(result.Roles))
 	suite.Equal("role1", result.Roles[0].ID)
 	suite.Equal("Admin", result.Roles[0].Name)
+	suite.Equal("default", result.Roles[0].OUHandle)
 	suite.Equal("role2", result.Roles[1].ID)
 	suite.Equal("User", result.Roles[1].Name)
+	suite.Equal("default", result.Roles[1].OUHandle)
 }
 
 func (suite *RoleServiceTestSuite) TestGetRoleList_InvalidPagination() {
@@ -194,6 +197,25 @@ func (suite *RoleServiceTestSuite) TestGetRoleList_StoreErrors() {
 	}
 }
 
+func (suite *RoleServiceTestSuite) TestGetRoleList_OUHandlesError() {
+	expectedRoles := []Role{
+		{ID: "role1", Name: "Admin", OUID: "ou1"},
+	}
+
+	suite.mockStore.On("GetRoleListCount", mock.Anything).Return(1, nil)
+	suite.mockStore.On("GetRoleList", mock.Anything, 10, 0).Return(expectedRoles, nil)
+	suite.mockOUService.On("GetOrganizationUnitHandlesByIDs", mock.Anything,
+		[]string{"ou1"}).Return(nil, &serviceerror.ServiceError{Code: "INTERNAL_ERROR"})
+
+	result, err := suite.service.GetRoleList(context.Background(), 10, 0)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(1, result.Count)
+	suite.Equal("role1", result.Roles[0].ID)
+	suite.Equal("", result.Roles[0].OUHandle)
+}
+
 // CreateRole Tests
 func (suite *RoleServiceTestSuite) TestCreateRole_Success() {
 	request := RoleCreationDetail{
@@ -206,7 +228,7 @@ func (suite *RoleServiceTestSuite) TestCreateRole_Success() {
 		},
 	}
 
-	ou := oupkg.OrganizationUnit{ID: "ou1", Name: "Test OU"}
+	ou := oupkg.OrganizationUnit{ID: "ou1", Name: "Test OU", Handle: "default"}
 	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
 		"rs1", []string{"perm1", "perm2"}).Return([]string{}, nil)
 	suite.mockEntityService.On("GetEntitiesByIDs", mock.Anything,
@@ -225,6 +247,7 @@ func (suite *RoleServiceTestSuite) TestCreateRole_Success() {
 	suite.Equal("Test Role", result.Name)
 	suite.Equal("Test Description", result.Description)
 	suite.Equal("ou1", result.OUID)
+	suite.Equal("default", result.OUHandle)
 	suite.Equal(1, len(result.Permissions))
 	suite.Equal(2, len(result.Permissions[0].Permissions))
 	// Verify permission validation was called
@@ -620,8 +643,9 @@ func (suite *RoleServiceTestSuite) TestGetRole_Success() {
 		Permissions: []ResourcePermissions{{ResourceServerID: "rs1", Permissions: []string{"perm1", "perm2"}}},
 	}
 
-	suite.mockStore.On("GetRole", mock.Anything,
-		"role1").Return(expectedRole, nil)
+	suite.mockStore.On("GetRole", mock.Anything, "role1").Return(expectedRole, nil)
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything,
+		"ou1").Return(oupkg.OrganizationUnit{ID: "ou1", Handle: "default"}, nil)
 
 	result, err := suite.service.GetRoleWithPermissions(context.Background(), "role1")
 
@@ -629,6 +653,27 @@ func (suite *RoleServiceTestSuite) TestGetRole_Success() {
 	suite.NotNil(result)
 	suite.Equal(expectedRole.ID, result.ID)
 	suite.Equal(expectedRole.Name, result.Name)
+	suite.Equal("default", result.OUHandle)
+}
+
+func (suite *RoleServiceTestSuite) TestGetRole_OUHandleError() {
+	expectedRole := RoleWithPermissions{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+	}
+
+	suite.mockStore.On("GetRole", mock.Anything, "role1").Return(expectedRole, nil)
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything,
+		"ou1").Return(oupkg.OrganizationUnit{}, &serviceerror.ServiceError{Code: "INTERNAL_ERROR"})
+
+	result, err := suite.service.GetRoleWithPermissions(context.Background(), "role1")
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("role1", result.ID)
+	suite.Equal("Admin", result.Name)
+	suite.Equal("", result.OUHandle)
 }
 
 func (suite *RoleServiceTestSuite) TestGetRole_MissingID() {
@@ -812,7 +857,7 @@ func (suite *RoleServiceTestSuite) TestUpdateRole_Success() {
 		Permissions: []ResourcePermissions{{ResourceServerID: "rs1", Permissions: []string{"perm1", "perm2"}}},
 	}
 
-	ou := oupkg.OrganizationUnit{ID: "ou1"}
+	ou := oupkg.OrganizationUnit{ID: "ou1", Handle: "default"}
 	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
 		"rs1", []string{"perm1", "perm2"}).Return([]string{}, nil)
 	suite.mockStore.On("IsRoleExist", mock.Anything,
@@ -830,6 +875,7 @@ func (suite *RoleServiceTestSuite) TestUpdateRole_Success() {
 	suite.NotNil(result)
 	suite.Equal("New Name", result.Name)
 	suite.Equal("Updated description", result.Description)
+	suite.Equal("default", result.OUHandle)
 	// Verify permission validation was called
 	suite.mockResourceService.AssertCalled(suite.T(), "ValidatePermissions", mock.Anything,
 		"rs1", []string{"perm1", "perm2"})

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
@@ -72,6 +72,48 @@ export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSe
         description={t('roles:edit.general.sections.organizationUnit.description')}
       >
         <Stack spacing={2}>
+          {role.ouHandle && (
+            <FormControl fullWidth>
+              <FormLabel htmlFor="ou-handle-input">
+                {t('roles:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
+              </FormLabel>
+              <TextField
+                id="ou-handle-input"
+                value={role.ouHandle}
+                fullWidth
+                size="small"
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Tooltip
+                          title={
+                            copiedField === 'ouHandle'
+                              ? t('common:actions.copied')
+                              : t('roles:edit.general.sections.organizationUnit.copyHandle', 'Copy handle')
+                          }
+                        >
+                          <IconButton
+                            aria-label={t('roles:edit.general.sections.organizationUnit.copyHandle', 'Copy handle')}
+                            onClick={() => {
+                              handleCopyToClipboard(role.ouHandle!, 'ouHandle').catch(() => {
+                                /* noop */
+                              });
+                            }}
+                            edge="end"
+                          >
+                            {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+              />
+            </FormControl>
+          )}
           <FormControl fullWidth>
             <FormLabel htmlFor="ou-id-input">
               {t('roles:edit.general.sections.organizationUnit.idLabel', 'ID')}

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/__tests__/EditGeneralSettings.test.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/__tests__/EditGeneralSettings.test.tsx
@@ -35,11 +35,14 @@ vi.mock('@thunder/components', () => ({
 // Mock translations
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, fallback?: string) => {
       const translations: Record<string, string> = {
         'roles:edit.general.sections.organizationUnit.title': 'Organization Unit',
         'roles:edit.general.sections.organizationUnit.description': 'The organization unit this role belongs to.',
+        'roles:edit.general.sections.organizationUnit.idLabel': 'ID',
+        'roles:edit.general.sections.organizationUnit.handleLabel': 'Handle',
         'roles:edit.general.sections.organizationUnit.copyId': 'Copy Organization Unit ID',
+        'roles:edit.general.sections.organizationUnit.copyHandle': 'Copy handle',
         'roles:edit.general.sections.dangerZone.title': 'Danger Zone',
         'roles:edit.general.sections.dangerZone.description':
           'Actions in this section are irreversible. Proceed with caution.',
@@ -49,7 +52,7 @@ vi.mock('react-i18next', () => ({
         'common:actions.delete': 'Delete',
         'common:actions.copied': 'Copied',
       };
-      return translations[key] || key;
+      return translations[key] ?? fallback ?? key;
     },
   }),
 }));
@@ -126,5 +129,46 @@ describe('EditGeneralSettings', () => {
     render(<EditGeneralSettings {...defaultProps} />);
 
     expect(screen.getByText('Deleting this role is permanent and cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('should render Handle field and ID field when role has ouHandle', () => {
+    const roleWithHandle: Role = {...mockRole, ouHandle: 'default'};
+    render(<EditGeneralSettings role={roleWithHandle} onDeleteClick={mockOnDeleteClick} />);
+
+    expect(screen.getByDisplayValue('default')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('ou-test-123')).toBeInTheDocument();
+  });
+
+  it('should not render Handle field when role has no ouHandle', () => {
+    render(<EditGeneralSettings {...defaultProps} />);
+
+    expect(screen.queryByLabelText('Handle')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('ou-test-123')).toBeInTheDocument();
+  });
+
+  it('should copy ouHandle to clipboard when copy handle button is clicked', async () => {
+    const roleWithHandle: Role = {...mockRole, ouHandle: 'default'};
+    render(<EditGeneralSettings role={roleWithHandle} onDeleteClick={mockOnDeleteClick} />);
+
+    const copyButton = screen.getByRole('button', {name: 'Copy handle'});
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('default');
+    });
+  });
+
+  it('should not toggle ID copy icon when handle copy button is clicked', async () => {
+    const roleWithHandle: Role = {...mockRole, ouHandle: 'default'};
+    render(<EditGeneralSettings role={roleWithHandle} onDeleteClick={mockOnDeleteClick} />);
+
+    const copyHandleButton = screen.getByRole('button', {name: 'Copy handle'});
+    fireEvent.click(copyHandleButton);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('default');
+    });
+
+    expect(screen.getByRole('button', {name: 'Copy Organization Unit ID'})).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Purpose

Role API responses previously exposed only `ouId` (a UUID), so the Thunder Console had no way to display the human-readable organization unit handle. The Roles listing and Role edit page both showed UUIDs where a handle was expected.

This PR adds `ouHandle` to all role management API responses and surfaces the handle on the Role edit page.

**Before / After (Role edit page):**
Only the OU `ID` field was rendered. Now a read-only, copyable **Handle** field appears above it (rendered only when the backend returns a handle).

### Approach

**Backend** — `ouHandle` is now always included on role responses (list, get, create, update). It is resolved through the OU service because `ROLE` lives in the config DB and `ORGANIZATION_UNIT` lives in the user DB, so a SQL JOIN is not possible. The implementation mirrors the established pattern used by `groupService` / `userSchemaService`:
- `GetRoleList` batches lookups via `GetOrganizationUnitHandlesByIDs` with deduplicated OU IDs.
- `GetRoleWithPermissions` performs a single lookup.
- `CreateRole` / `UpdateRoleWithPermissions` reuse the OU object they already fetch for validation — no extra call.
- All read paths degrade gracefully: if the OU lookup fails, we log at Warn and return roles with an empty `OUHandle` instead of failing the request (the JSON tag is `omitempty`).

Request bodies are unchanged — `ouHandle` is response-only.

**Frontend** — `EditGeneralSettings.tsx` renders a new Handle field above the existing ID field, conditionally shown only when `role.ouHandle` is truthy. Same monospace + copy-button pattern as the ID field, with independent copy-state keying so the two icons toggle independently. The Roles listing page was not modified — it already rendered `ouHandle` with a UUID fallback, so it now naturally shows the handle.

**API spec** — `api/role.yaml` adds `ouHandle` (readOnly) to `RoleSummary` and `Role` schemas and updates inline examples.

### Related Issues
- Fixes #2360

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses and schemas now include an organization-unit handle (ouHandle) on role objects.
  * Role editor displays a read-only "Handle" field with copy-to-clipboard support when present.

* **Bug Fixes**
  * Role listing and detail responses now populate ouHandle reliably (best-effort, logs warnings on resolution failures).

* **Tests**
  * Tests added/updated for ouHandle resolution (success and failure), UI rendering, and clipboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->