### PR TITLE
Implement RuntimeCryptoProvider with Encrypt and Decrypt functions

### DIFF
--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -31,7 +31,8 @@ import (
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
-	"github.com/asgardeo/thunder/internal/system/crypto/config"
+	"github.com/asgardeo/thunder/internal/system/crypto"
+	"github.com/asgardeo/thunder/internal/system/crypto/runtime"
 )
 
 // EngineContext holds the overall context used by the flow engine during execution.
@@ -137,8 +138,8 @@ func (f *FlowContextDB) decrypt(ctx context.Context) error {
 	if !f.isEncrypted() {
 		return nil
 	}
-	encryptionService := config.GetEncryptionService()
-	decrypted, err := encryptionService.Decrypt(ctx, []byte(f.Context))
+	decrypted, err := runtime.GetRuntimeCryptoService().Decrypt(
+		ctx, crypto.KeyRef{}, crypto.AlgorithmAESGCM, []byte(f.Context))
 	if err != nil {
 		return err
 	}
@@ -173,8 +174,7 @@ func (c *flowContextContent) encrypt(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	encryptionService := config.GetEncryptionService()
-	encrypted, err := encryptionService.Encrypt(ctx, data)
+	encrypted, err := runtime.GetRuntimeCryptoService().Encrypt(ctx, crypto.KeyRef{}, crypto.AlgorithmAESGCM, data)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/system/crypto/model.go
+++ b/backend/internal/system/crypto/model.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package crypto
+
+import (
+	gocrypto "crypto"
+	"crypto/tls"
+)
+
+// KeyRef identifies a cryptographic key by its ID.
+type KeyRef struct {
+	KeyID string
+}
+
+// Algorithm represents a cryptographic algorithm identifier.
+type Algorithm string
+
+const (
+	// AlgorithmRS256 represents RSA PKCS1v15 signature with SHA-256 (JWA, RFC 7518).
+	AlgorithmRS256 Algorithm = "RS256"
+	// AlgorithmRS512 represents RSA PKCS1v15 signature with SHA-512 (JWA, RFC 7518).
+	AlgorithmRS512 Algorithm = "RS512"
+	// AlgorithmPS256 represents RSA-PSS signature with SHA-256 (JWA, RFC 7518).
+	AlgorithmPS256 Algorithm = "PS256"
+	// AlgorithmES256 represents ECDSA signature with SHA-256 (JWA, RFC 7518).
+	AlgorithmES256 Algorithm = "ES256"
+	// AlgorithmES384 represents ECDSA signature with SHA-384 (JWA, RFC 7518).
+	AlgorithmES384 Algorithm = "ES384"
+	// AlgorithmES512 represents ECDSA signature with SHA-512 (JWA, RFC 7518).
+	AlgorithmES512 Algorithm = "ES512"
+	// AlgorithmEdDSA represents EdDSA signature algorithm (JWA, RFC 7518).
+	AlgorithmEdDSA Algorithm = "EdDSA"
+	// AlgorithmRSAOAEP256 represents RSA-OAEP key encryption with SHA-256 (JWA, RFC 7518).
+	AlgorithmRSAOAEP256 Algorithm = "RSA-OAEP-256"
+	// AlgorithmAESGCM represents AES-GCM symmetric authenticated encryption.
+	AlgorithmAESGCM Algorithm = "AES-GCM"
+)
+
+// PublicKeyFilter specifies criteria for filtering public keys in GetPublicKeys.
+type PublicKeyFilter struct {
+	KeyID     string
+	Algorithm Algorithm
+}
+
+// PublicKeyInfo describes a public key returned by GetPublicKeys.
+type PublicKeyInfo struct {
+	KeyID      string
+	Algorithm  Algorithm
+	PublicKey  gocrypto.PublicKey
+	Thumbprint string
+}
+
+// TLSMaterial holds the TLS certificate material for a key reference.
+type TLSMaterial struct {
+	Certificate tls.Certificate
+}

--- a/backend/internal/system/crypto/provider.go
+++ b/backend/internal/system/crypto/provider.go
@@ -30,8 +30,10 @@ type ConfigCryptoProvider interface {
 
 // RuntimeCryptoProvider provides asymmetric cryptographic operations including
 // encryption, decryption, signing, and key discovery.
-// Implementation deferred to next phase.
 type RuntimeCryptoProvider interface {
-	// Placeholder for asymmetric operations.
-	// Will be implemented in subsequent phases.
+	Encrypt(ctx context.Context, keyRef KeyRef, algorithm Algorithm, content []byte) ([]byte, error)
+	Decrypt(ctx context.Context, keyRef KeyRef, algorithm Algorithm, content []byte) ([]byte, error)
+	Sign(ctx context.Context, keyRef KeyRef, algorithm Algorithm, content []byte) ([]byte, error)
+	GetPublicKeys(ctx context.Context, filter PublicKeyFilter) ([]PublicKeyInfo, error)
+	GetTLSMaterial(ctx context.Context, keyRef KeyRef) (*TLSMaterial, error)
 }

--- a/backend/internal/system/crypto/runtime/service.go
+++ b/backend/internal/system/crypto/runtime/service.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package runtime provides the RuntimeCryptoProvider implementation backed by PKI key material.
+package runtime
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/asgardeo/thunder/internal/system/crypto"
+	"github.com/asgardeo/thunder/internal/system/crypto/config"
+	"github.com/asgardeo/thunder/internal/system/crypto/pki"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+// runtimeCryptoService implements RuntimeCryptoProvider backed by PKI key material.
+type runtimeCryptoService struct {
+	pkiService pki.PKIServiceInterface
+	logger     *log.Logger
+}
+
+var (
+	runtimeInstance *runtimeCryptoService
+	runtimeOnce     sync.Once
+)
+
+// GetRuntimeCryptoService returns the singleton RuntimeCryptoProvider instance.
+func GetRuntimeCryptoService() crypto.RuntimeCryptoProvider {
+	runtimeOnce.Do(func() {
+		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RuntimeCryptoService"))
+		pkiSvc, err := pki.Initialize()
+		if err != nil {
+			logger.Warn("PKI service unavailable; RSA operations will fail", log.String("reason", err.Error()))
+		}
+		runtimeInstance = &runtimeCryptoService{
+			pkiService: pkiSvc,
+			logger:     logger,
+		}
+	})
+	return runtimeInstance
+}
+
+// Encrypt encrypts content using the algorithm specified. AlgorithmAESGCM delegates to the config
+// encryption service; AlgorithmRSAOAEP256 uses the PKI public key identified by keyRef.
+func (s *runtimeCryptoService) Encrypt(
+	ctx context.Context, keyRef crypto.KeyRef, algorithm crypto.Algorithm, content []byte,
+) ([]byte, error) {
+	switch algorithm {
+	case crypto.AlgorithmAESGCM:
+		return config.GetEncryptionService().Encrypt(ctx, content)
+	case crypto.AlgorithmRSAOAEP256:
+		if s.pkiService == nil {
+			return nil, errors.New("PKI service not initialized")
+		}
+		cert, svcErr := s.pkiService.GetX509Certificate(keyRef.KeyID)
+		if svcErr != nil {
+			return nil, fmt.Errorf("key not found for id %s: [%s] %s",
+				keyRef.KeyID, svcErr.Code, svcErr.Error.DefaultValue)
+		}
+		rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			return nil, errors.New("key is not an RSA public key")
+		}
+		return rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, content, nil)
+	default:
+		return nil, fmt.Errorf("unsupported algorithm: %s", algorithm)
+	}
+}
+
+// Decrypt decrypts content using the algorithm specified. AlgorithmAESGCM delegates to the config
+// encryption service; AlgorithmRSAOAEP256 uses the PKI private key identified by keyRef.
+func (s *runtimeCryptoService) Decrypt(
+	ctx context.Context, keyRef crypto.KeyRef, algorithm crypto.Algorithm, content []byte,
+) ([]byte, error) {
+	switch algorithm {
+	case crypto.AlgorithmAESGCM:
+		return config.GetEncryptionService().Decrypt(ctx, content)
+	case crypto.AlgorithmRSAOAEP256:
+		if s.pkiService == nil {
+			return nil, errors.New("PKI service not initialized")
+		}
+		privKey, svcErr := s.pkiService.GetPrivateKey(keyRef.KeyID)
+		if svcErr != nil {
+			return nil, fmt.Errorf("key not found for id %s: [%s] %s",
+				keyRef.KeyID, svcErr.Code, svcErr.Error.DefaultValue)
+		}
+		rsaPriv, ok := privKey.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("key is not an RSA private key")
+		}
+		// #nosec G776 -- rand.Reader is used as the random source; label parameter is nil per RFC 8017
+		return rsa.DecryptOAEP(sha256.New(), rand.Reader, rsaPriv, content, nil)
+	default:
+		return nil, fmt.Errorf("unsupported algorithm: %s", algorithm)
+	}
+}
+
+// Sign is not yet implemented.
+func (s *runtimeCryptoService) Sign(_ context.Context, _ crypto.KeyRef, _ crypto.Algorithm, _ []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// GetPublicKeys is not yet implemented.
+func (s *runtimeCryptoService) GetPublicKeys(
+	_ context.Context, _ crypto.PublicKeyFilter,
+) ([]crypto.PublicKeyInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+// GetTLSMaterial is not yet implemented.
+func (s *runtimeCryptoService) GetTLSMaterial(_ context.Context, _ crypto.KeyRef) (*crypto.TLSMaterial, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
### Purpose

Implements the `RuntimeCryptoProvider` interface and its PKI-backed service, and migrates flow context encryption/decryption to use it.

Previously, `RuntimeCryptoProvider` was a placeholder interface with no implementation. Flow context encryption was wired directly to the config-scoped AES-GCM encryption service. This change introduces a proper runtime crypto service backed by PKI key material that supports both symmetric (AES-GCM) and asymmetric (RSA-OAEP-256) operations, and routes flow context encryption through it.

### Approach

- Defined `KeyRef`, `Algorithm`, `PublicKeyFilter`, `PublicKeyInfo`, and `TLSMaterial` types in `internal/system/crypto/model.go` to support the full provider contract.
- Fleshed out the `RuntimeCryptoProvider` interface in `provider.go` with `Encrypt`, `Decrypt`, `Sign`, `GetPublicKeys`, and `GetTLSMaterial` methods.
- Implemented `runtimeCryptoService` in `internal/system/crypto/runtime/service.go` as a singleton backed by the existing `PKIService`. AES-GCM operations delegate to the config encryption service; RSA-OAEP-256 operations use the PKI key material.
- Migrated `flowexec` context encryption/decryption from `config.GetEncryptionService()` to `runtime.GetRuntimeCryptoService()` with `AlgorithmAESGCM`

### Related Issues
- https://github.com/asgardeo/thunder/issues/2347

### Related PRs
- https://github.com/asgardeo/thunder/pull/2364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader cryptography support: multiple signature algorithms and AES-GCM / RSA-OAEP encryption methods.
  * Public key discovery and filtering for selecting keys.
  * Runtime crypto provider with PKI-backed key usage and TLS certificate material support.

* **Bug Fixes**
  * More robust handling and clearer errors when cryptographic keys or algorithms are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->