### PR TITLE
Remove NONE cert in windows bootstrap

### DIFF
--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -261,10 +261,6 @@ $reactSdkAppData = @{
         validityPeriod = 3600
         userAttributes = $null
     }
-    certificate = @{
-        type = "NONE"
-        value = ""
-    }
     userAttributes = @("given_name","family_name","email","groups","name")
     allowedUserTypes = @("Customer")
     inboundAuthConfig = @(


### PR DESCRIPTION
This pull request makes a minor update to the sample resources bootstrap script by removing the unused `certificate` field from the `$reactSdkAppData` configuration. This helps clean up the configuration and avoids confusion.