### PR TITLE
Update entity store constants order

### DIFF
--- a/backend/internal/entity/store_constants.go
+++ b/backend/internal/entity/store_constants.go
@@ -52,13 +52,13 @@ var (
 	}
 	// QuerySearchEntityList is the query to search entities across all categories.
 	QuerySearchEntityList = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-31",
+		ID: "ASQ-ENTITY_MGT-03",
 		Query: "SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES FROM ENTITY " +
 			"WHERE DEPLOYMENT_ID = $3 ORDER BY ID LIMIT $1 OFFSET $2",
 	}
 	// QueryCreateEntity is the query to create a new entity.
 	QueryCreateEntity = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-03",
+		ID: "ASQ-ENTITY_MGT-04",
 		Query: "INSERT INTO ENTITY " +
 			"(ID, DEPLOYMENT_ID, CATEGORY, TYPE, STATE, OU_ID, " +
 			"ATTRIBUTES, SYSTEM_ATTRIBUTES, CREDENTIALS, SYSTEM_CREDENTIALS) " +
@@ -66,56 +66,56 @@ var (
 	}
 	// QueryGetEntityByID is the query to get an entity by ID.
 	QueryGetEntityByID = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-04",
+		ID: "ASQ-ENTITY_MGT-05",
 		Query: "SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES " +
 			"FROM ENTITY WHERE ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// QueryUpdateEntity is the query to fully update an entity including system attributes.
 	QueryUpdateEntity = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-05",
+		ID: "ASQ-ENTITY_MGT-06",
 		Query: "UPDATE ENTITY SET OU_ID = $2, TYPE = $3, STATE = $4, ATTRIBUTES = $5, SYSTEM_ATTRIBUTES = $6 " +
 			"WHERE ID = $1 AND DEPLOYMENT_ID = $7",
 	}
 	// QueryUpdateAttributes is the query to update only the schema attributes of an entity.
 	QueryUpdateAttributes = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-29",
+		ID:    "ASQ-ENTITY_MGT-07",
 		Query: "UPDATE ENTITY SET ATTRIBUTES = $2 WHERE ID = $1 AND DEPLOYMENT_ID = $3",
 	}
 	// QueryUpdateSystemAttributes is the query to update system attributes.
 	QueryUpdateSystemAttributes = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-06",
+		ID:    "ASQ-ENTITY_MGT-08",
 		Query: "UPDATE ENTITY SET SYSTEM_ATTRIBUTES = $2 WHERE ID = $1 AND DEPLOYMENT_ID = $3",
 	}
 	// QueryUpdateCredentials is the query to update credentials.
 	QueryUpdateCredentials = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-07",
+		ID:    "ASQ-ENTITY_MGT-09",
 		Query: "UPDATE ENTITY SET CREDENTIALS = $2 WHERE ID = $1 AND DEPLOYMENT_ID = $3",
 	}
 	// QueryUpdateSystemCredentials is the query to update system credentials.
 	QueryUpdateSystemCredentials = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-08",
+		ID:    "ASQ-ENTITY_MGT-10",
 		Query: "UPDATE ENTITY SET SYSTEM_CREDENTIALS = $2 WHERE ID = $1 AND DEPLOYMENT_ID = $3",
 	}
 	// QueryDeleteEntity is the query to delete an entity.
 	QueryDeleteEntity = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-09",
+		ID:    "ASQ-ENTITY_MGT-11",
 		Query: "DELETE FROM ENTITY WHERE ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// QueryGetEntityWithCredentials is the query to get an entity with all credential columns.
 	QueryGetEntityWithCredentials = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-10",
+		ID: "ASQ-ENTITY_MGT-12",
 		Query: "SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, " +
 			"SYSTEM_ATTRIBUTES, CREDENTIALS, SYSTEM_CREDENTIALS " +
 			"FROM ENTITY WHERE ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// QueryGetGroupCountForEntity is the query to get the count of groups for a given entity.
 	QueryGetGroupCountForEntity = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-11",
+		ID:    "ASQ-ENTITY_MGT-13",
 		Query: `SELECT COUNT(*) AS total FROM GROUP_MEMBER_REFERENCE WHERE MEMBER_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 	// QueryGetGroupsForEntity is the query to get groups for a given entity with pagination.
 	QueryGetGroupsForEntity = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-12",
+		ID: "ASQ-ENTITY_MGT-14",
 		Query: `SELECT G.ID, G.OU_ID, G.NAME FROM GROUP_MEMBER_REFERENCE GMR ` +
 			`INNER JOIN "GROUP" G ON GMR.GROUP_ID = G.ID AND GMR.DEPLOYMENT_ID = $4 AND G.DEPLOYMENT_ID = $4 ` +
 			`WHERE GMR.MEMBER_ID = $1 AND GMR.DEPLOYMENT_ID = $4 ` +
@@ -124,7 +124,7 @@ var (
 	// QueryGetTransitiveGroupsForEntity retrieves all groups an entity belongs to, including groups
 	// inherited through nested group membership, using a recursive CTE.
 	QueryGetTransitiveGroupsForEntity = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-30",
+		ID: "ASQ-ENTITY_MGT-15",
 		Query: `WITH RECURSIVE transitive_groups AS (
 			SELECT GMR.GROUP_ID
 			FROM GROUP_MEMBER_REFERENCE GMR
@@ -142,23 +142,23 @@ var (
 	}
 	// QueryBatchInsertIdentifiers is the base query for batch inserting entity identifiers.
 	QueryBatchInsertIdentifiers = model.DBQuery{
-		ID: "ASQ-ENTITY_MGT-13",
+		ID: "ASQ-ENTITY_MGT-16",
 		Query: "INSERT INTO ENTITY_IDENTIFIER " +
 			"(ENTITY_ID, NAME, VALUE, SOURCE, DEPLOYMENT_ID) VALUES ",
 	}
 	// QueryDeleteIdentifiersByEntity is the query to delete all identifiers for an entity.
 	QueryDeleteIdentifiersByEntity = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-14",
+		ID:    "ASQ-ENTITY_MGT-17",
 		Query: "DELETE FROM ENTITY_IDENTIFIER WHERE ENTITY_ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// QueryDeleteAttributeIdentifiersByEntity is the query to delete only attribute-sourced identifiers for an entity.
 	QueryDeleteAttributeIdentifiersByEntity = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-27",
+		ID:    "ASQ-ENTITY_MGT-18",
 		Query: "DELETE FROM ENTITY_IDENTIFIER WHERE ENTITY_ID = $1 AND DEPLOYMENT_ID = $2 AND SOURCE = 'attribute'",
 	}
 	// QueryDeleteSystemIdentifiersByEntity is the query to delete only system-sourced identifiers for an entity.
 	QueryDeleteSystemIdentifiersByEntity = model.DBQuery{
-		ID:    "ASQ-ENTITY_MGT-28",
+		ID:    "ASQ-ENTITY_MGT-19",
 		Query: "DELETE FROM ENTITY_IDENTIFIER WHERE ENTITY_ID = $1 AND DEPLOYMENT_ID = $2 AND SOURCE = 'system'",
 	}
 )
@@ -206,7 +206,7 @@ func appendOUIDsINClause(
 func buildEntityCountQueryByOUIDs(
 	category string, ouIDs []string, filters map[string]interface{}, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
-	queryID := "ASQ-ENTITY_MGT-17"
+	queryID := "ASQ-ENTITY_MGT-20"
 	baseQuery := `SELECT COUNT(*) as total FROM ENTITY WHERE CATEGORY = $1`
 	args := []interface{}{category}
 
@@ -237,7 +237,7 @@ func buildEntityCountQueryByOUIDs(
 func buildEntityListQueryByOUIDs(
 	category string, ouIDs []string, filters map[string]interface{}, limit, offset int, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
-	queryID := "ASQ-ENTITY_MGT-18"
+	queryID := "ASQ-ENTITY_MGT-21"
 	baseQuery := `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES ` +
 		`FROM ENTITY WHERE CATEGORY = $1`
 	args := []interface{}{category}
@@ -315,7 +315,7 @@ func buildIdentifyQuery(filters map[string]interface{}, deploymentID string) (mo
 	args = append(args, deploymentID)
 
 	return model.DBQuery{
-		ID:            "ASQ-ENTITY_MGT-19",
+		ID:            "ASQ-ENTITY_MGT-22",
 		Query:         pgQuery,
 		PostgresQuery: pgQuery,
 		SQLiteQuery:   sqQuery,
@@ -359,7 +359,7 @@ func buildEntityINClauseQuery(
 // buildBulkEntityExistsQuery constructs a query to check which entity IDs exist from a list.
 func buildBulkEntityExistsQuery(entityIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
 	return buildEntityINClauseQuery(
-		"ASQ-ENTITY_MGT-20",
+		"ASQ-ENTITY_MGT-23",
 		"SELECT ID FROM ENTITY WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
 		entityIDs, deploymentID,
 	)
@@ -404,7 +404,7 @@ func buildBulkEntityExistsQueryInOUs(
 		strings.Join(sqliteOUPlaceholders, ","), strings.Join(sqliteIDPlaceholders, ","))
 
 	query := model.DBQuery{
-		ID:            "ASQ-ENTITY_MGT-21",
+		ID:            "ASQ-ENTITY_MGT-24",
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,
@@ -418,7 +418,7 @@ func buildEntityListQuery(
 	category string, filters map[string]interface{}, limit, offset int, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
 	baseQuery := "SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES FROM ENTITY"
-	queryID := "ASQ-ENTITY_MGT-22"
+	queryID := "ASQ-ENTITY_MGT-25"
 
 	if len(filters) > 0 {
 		var baseWithCategory string
@@ -469,7 +469,7 @@ func buildEntityCountQuery(
 	category string, filters map[string]interface{}, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
 	baseQuery := "SELECT COUNT(*) as total FROM ENTITY"
-	queryID := "ASQ-ENTITY_MGT-23"
+	queryID := "ASQ-ENTITY_MGT-26"
 
 	if len(filters) > 0 {
 		baseWithCategory := baseQuery + " WHERE CATEGORY = $1"
@@ -536,7 +536,7 @@ func buildIdentifyQueryFromIdentifiers(
 	args = append(args, deploymentID)
 
 	return model.DBQuery{
-		ID:            "ASQ-ENTITY_MGT-24",
+		ID:            "ASQ-ENTITY_MGT-27",
 		Query:         pgQueryString,
 		PostgresQuery: pgQueryString,
 		SQLiteQuery:   sqQueryString,
@@ -615,7 +615,7 @@ func buildIdentifyQueryHybrid(
 	args = append(args, deploymentID)
 
 	query := model.DBQuery{
-		ID:            "ASQ-ENTITY_MGT-25",
+		ID:            "ASQ-ENTITY_MGT-28",
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,
@@ -627,7 +627,7 @@ func buildIdentifyQueryHybrid(
 // buildGetEntitiesByIDsQuery constructs a query to fetch entities by a list of IDs.
 func buildGetEntitiesByIDsQuery(entityIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
 	return buildEntityINClauseQuery(
-		"ASQ-ENTITY_MGT-26",
+		"ASQ-ENTITY_MGT-29",
 		"SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES "+
 			"FROM ENTITY WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
 		entityIDs, deploymentID,


### PR DESCRIPTION
This pull request updates the internal query ID constants used throughout the `backend/internal/entity/store_constants.go` file. The main purpose is to reassign and renumber the `ASQ-ENTITY_MGT-XX` identifiers for various entity-related database queries, ensuring consistency and possibly aligning with a new or updated specification.

The most important changes are:

**Query ID Reassignments for Entity Operations:**

* Updated the `ID` fields for all major entity-related queries (e.g., search, create, update, delete, and credential operations) to new `ASQ-ENTITY_MGT-XX` values for improved organization and consistency.

**Query ID Reassignments for Group and Identifier Operations:**

* Renumbered query IDs for group membership and transitive group queries, as well as all identifier-related queries (insert, delete, etc.). [[1]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL127-R127) [[2]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL145-R161)

**Query ID Reassignments in Query Builder Functions:**

* Updated hardcoded query IDs in all query builder functions (such as `buildEntityCountQueryByOUIDs`, `buildEntityListQueryByOUIDs`, `buildIdentifyQuery`, etc.) to match the new numbering scheme. [[1]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL209-R209) [[2]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL240-R240) [[3]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL318-R318) [[4]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL362-R362) [[5]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL407-R407) [[6]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL421-R421) [[7]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL472-R472) [[8]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL539-R539) [[9]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL618-R618) [[10]](diffhunk://#diff-57e588cf9c55af932c42f5567bdb3b4cbc79bb9a85779e056b534f2f06137d2cL630-R630)

These changes are internal and do not affect the query logic, but they are important for keeping the codebase maintainable and aligned with any external documentation or tracking systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of database query identifiers to improve system organization. No functional changes or user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->