### PR TITLE
Removes the redundant Thunder text in navbar

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -248,6 +248,10 @@ html[data-page='home'][data-theme='dark'] .navbar .navbar__github--link::before 
   font-weight: 500;
 }
 
+.navbar__brand .navbar__title {
+  display: none;
+}
+
 /* Right-side navbar items - add gap between nav links and icon buttons */
 .navbar__items--right {
   gap: 0.25rem;


### PR DESCRIPTION
### Purpose
Remove the duplicated brand text in the docs header so the top-left branding is clear and visually consistent (showing only one Thunder identity instead of [THUNDER] Thunder).

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Add a minimal CSS override.

<img width="1438" height="780" alt="Screenshot 2026-04-23 at 12 27 24" src="https://github.com/user-attachments/assets/728f616b-637c-4679-a312-420a9278ec5e" />

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2411

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
