### PR TITLE
Implement cache-backed entity store for improved performance in entity lookups

### DIFF
--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package entity
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/asgardeo/thunder/internal/system/cache"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+// cacheBackedEntityStore wraps an entityStoreInterface with in-memory caching
+// for individual entity lookups by ID and identifier filter resolution.
+type cacheBackedEntityStore struct {
+	entityByIDCache cache.CacheInterface[*Entity]
+	store           entityStoreInterface
+	logger          *log.Logger
+}
+
+// newCacheBackedEntityStore creates a cache-backed wrapper around the given store.
+func newCacheBackedEntityStore(store entityStoreInterface) entityStoreInterface {
+	return &cacheBackedEntityStore{
+		entityByIDCache: cache.GetCache[*Entity]("EntityByIDCache"),
+		store:           store,
+		logger: log.GetLogger().With(
+			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
+	}
+}
+
+func (s *cacheBackedEntityStore) CreateEntity(ctx context.Context, entity Entity,
+	credentials json.RawMessage, systemCredentials json.RawMessage) error {
+	if err := s.store.CreateEntity(ctx, entity, credentials, systemCredentials); err != nil {
+		return err
+	}
+	s.cacheEntityByID(ctx, &entity)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) GetEntity(ctx context.Context, id string) (Entity, error) {
+	cacheKey := cache.CacheKey{Key: id}
+	if cached, ok := s.entityByIDCache.Get(ctx, cacheKey); ok {
+		return *cached, nil
+	}
+
+	entity, err := s.store.GetEntity(ctx, id)
+	if err != nil {
+		return entity, err
+	}
+
+	s.cacheEntityByID(ctx, &entity)
+	return entity, nil
+}
+
+func (s *cacheBackedEntityStore) GetEntityWithCredentials(ctx context.Context,
+	id string) (*entityWithCredentials, error) {
+	return s.store.GetEntityWithCredentials(ctx, id)
+}
+
+func (s *cacheBackedEntityStore) UpdateEntity(ctx context.Context, entity *Entity) error {
+	if err := s.store.UpdateEntity(ctx, entity); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, entity.ID)
+	s.cacheEntityByID(ctx, entity)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) UpdateAttributes(ctx context.Context,
+	entityID string, attributes json.RawMessage) error {
+	if err := s.store.UpdateAttributes(ctx, entityID, attributes); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, entityID)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) UpdateSystemAttributes(ctx context.Context,
+	entityID string, attrs json.RawMessage) error {
+	if err := s.store.UpdateSystemAttributes(ctx, entityID, attrs); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, entityID)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) UpdateCredentials(ctx context.Context,
+	entityID string, creds json.RawMessage) error {
+	if err := s.store.UpdateCredentials(ctx, entityID, creds); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, entityID)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) UpdateSystemCredentials(ctx context.Context,
+	entityID string, creds json.RawMessage) error {
+	if err := s.store.UpdateSystemCredentials(ctx, entityID, creds); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, entityID)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) DeleteEntity(ctx context.Context, id string) error {
+	if err := s.store.DeleteEntity(ctx, id); err != nil {
+		return err
+	}
+
+	s.invalidateEntityByID(ctx, id)
+	return nil
+}
+
+func (s *cacheBackedEntityStore) IdentifyEntity(ctx context.Context,
+	filters map[string]interface{}) (*string, error) {
+	entityID, err := s.store.IdentifyEntity(ctx, filters)
+	if err != nil || entityID == nil {
+		return entityID, err
+	}
+
+	return entityID, nil
+}
+
+// Pass-through methods.
+
+func (s *cacheBackedEntityStore) SearchEntities(ctx context.Context,
+	filters map[string]interface{}) ([]Entity, error) {
+	return s.store.SearchEntities(ctx, filters)
+}
+
+func (s *cacheBackedEntityStore) GetEntityListCount(ctx context.Context,
+	category string, filters map[string]interface{}) (int, error) {
+	return s.store.GetEntityListCount(ctx, category, filters)
+}
+
+func (s *cacheBackedEntityStore) GetEntityList(ctx context.Context,
+	category string, limit, offset int, filters map[string]interface{}) ([]Entity, error) {
+	return s.store.GetEntityList(ctx, category, limit, offset, filters)
+}
+
+func (s *cacheBackedEntityStore) GetEntityListCountByOUIDs(ctx context.Context,
+	category string, ouIDs []string, filters map[string]interface{}) (int, error) {
+	return s.store.GetEntityListCountByOUIDs(ctx, category, ouIDs, filters)
+}
+
+func (s *cacheBackedEntityStore) GetEntityListByOUIDs(ctx context.Context,
+	category string, ouIDs []string, limit, offset int,
+	filters map[string]interface{}) ([]Entity, error) {
+	return s.store.GetEntityListByOUIDs(ctx, category, ouIDs, limit, offset, filters)
+}
+
+func (s *cacheBackedEntityStore) ValidateEntityIDs(ctx context.Context,
+	entityIDs []string) ([]string, error) {
+	return s.store.ValidateEntityIDs(ctx, entityIDs)
+}
+
+func (s *cacheBackedEntityStore) GetEntitiesByIDs(ctx context.Context,
+	entityIDs []string) ([]Entity, error) {
+	return s.store.GetEntitiesByIDs(ctx, entityIDs)
+}
+
+func (s *cacheBackedEntityStore) ValidateEntityIDsInOUs(ctx context.Context,
+	entityIDs []string, ouIDs []string) ([]string, error) {
+	return s.store.ValidateEntityIDsInOUs(ctx, entityIDs, ouIDs)
+}
+
+func (s *cacheBackedEntityStore) GetGroupCountForEntity(ctx context.Context,
+	entityID string) (int, error) {
+	return s.store.GetGroupCountForEntity(ctx, entityID)
+}
+
+func (s *cacheBackedEntityStore) GetEntityGroups(ctx context.Context,
+	entityID string, limit, offset int) ([]EntityGroup, error) {
+	return s.store.GetEntityGroups(ctx, entityID, limit, offset)
+}
+
+func (s *cacheBackedEntityStore) GetTransitiveEntityGroups(ctx context.Context,
+	entityID string) ([]EntityGroup, error) {
+	return s.store.GetTransitiveEntityGroups(ctx, entityID)
+}
+
+func (s *cacheBackedEntityStore) IsEntityDeclarative(ctx context.Context, id string) (bool, error) {
+	return s.store.IsEntityDeclarative(ctx, id)
+}
+
+func (s *cacheBackedEntityStore) GetIndexedAttributes() map[string]bool {
+	return s.store.GetIndexedAttributes()
+}
+
+func (s *cacheBackedEntityStore) LoadIndexedAttributes(attributes []string) error {
+	return s.store.LoadIndexedAttributes(attributes)
+}
+
+// --- Cache helpers ---
+
+func (s *cacheBackedEntityStore) cacheEntityByID(ctx context.Context, entity *Entity) {
+	if entity == nil || entity.ID == "" {
+		return
+	}
+	if err := s.entityByIDCache.Set(ctx, cache.CacheKey{Key: entity.ID}, entity); err != nil {
+		s.logger.Error("Failed to cache entity by ID",
+			log.String("entityID", entity.ID), log.Error(err))
+	}
+}
+
+func (s *cacheBackedEntityStore) invalidateEntityByID(ctx context.Context, entityID string) {
+	if entityID == "" {
+		return
+	}
+	if err := s.entityByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
+		s.logger.Error("Failed to invalidate entity cache by ID",
+			log.String("entityID", entityID), log.Error(err))
+	}
+}

--- a/backend/internal/entity/cache_backed_store_test.go
+++ b/backend/internal/entity/cache_backed_store_test.go
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package entity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/cache"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/tests/mocks/cachemock"
+)
+
+// CacheBackedEntityStoreTestSuite tests the cacheBackedEntityStore.
+type CacheBackedEntityStoreTestSuite struct {
+	suite.Suite
+	mockStore       *entityStoreInterfaceMock
+	entityByIDCache *cachemock.CacheInterfaceMock[*Entity]
+	cachedStore     *cacheBackedEntityStore
+	entityByIDData  map[string]*Entity
+}
+
+func TestCacheBackedEntityStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(CacheBackedEntityStoreTestSuite))
+}
+
+func (s *CacheBackedEntityStoreTestSuite) SetupTest() {
+	s.mockStore = newEntityStoreInterfaceMock(s.T())
+	s.entityByIDData = make(map[string]*Entity)
+
+	s.entityByIDCache = cachemock.NewCacheInterfaceMock[*Entity](s.T())
+
+	setupEntityCacheMock(s.entityByIDCache, s.entityByIDData)
+
+	s.entityByIDCache.EXPECT().IsEnabled().Return(true).Maybe()
+
+	s.cachedStore = &cacheBackedEntityStore{
+		entityByIDCache: s.entityByIDCache,
+		store:           s.mockStore,
+		logger: log.GetLogger().With(
+			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
+	}
+}
+
+func setupEntityCacheMock[T any](
+	mockCache *cachemock.CacheInterfaceMock[T],
+	data map[string]T,
+) {
+	mockCache.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, key cache.CacheKey, value T) error {
+			data[key.Key] = value
+			return nil
+		}).Maybe()
+
+	mockCache.EXPECT().Get(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, key cache.CacheKey) (T, bool) {
+			if val, ok := data[key.Key]; ok {
+				return val, true
+			}
+			var zero T
+			return zero, false
+		}).Maybe()
+
+	mockCache.EXPECT().Delete(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, key cache.CacheKey) error {
+			delete(data, key.Key)
+			return nil
+		}).Maybe()
+
+	mockCache.EXPECT().Clear(mock.Anything).
+		RunAndReturn(func(ctx context.Context) error {
+			for k := range data {
+				delete(data, k)
+			}
+			return nil
+		}).Maybe()
+
+	mockCache.EXPECT().GetName().Return("mockCache").Maybe()
+	mockCache.EXPECT().CleanupExpired().Maybe()
+}
+
+func (s *CacheBackedEntityStoreTestSuite) makeEntity(id, clientID string) Entity {
+	sysAttrs := map[string]interface{}{"clientId": clientID}
+	sysAttrsJSON, _ := json.Marshal(sysAttrs)
+	return Entity{
+		ID:               id,
+		Category:         EntityCategoryApp,
+		Type:             "application",
+		State:            EntityStateActive,
+		SystemAttributes: json.RawMessage(sysAttrsJSON),
+	}
+}
+
+const testEntityID = "entity-1"
+
+// GetEntity tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntity_CacheHit() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+
+	result, err := s.cachedStore.GetEntity(context.Background(), entity.ID)
+	s.Nil(err)
+	s.Equal(entity.ID, result.ID)
+	s.mockStore.AssertNotCalled(s.T(), "GetEntity")
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntity_CacheMiss() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.mockStore.On("GetEntity", mock.Anything, entity.ID).Return(entity, nil).Once()
+
+	result, err := s.cachedStore.GetEntity(context.Background(), entity.ID)
+	s.Nil(err)
+	s.Equal(entity.ID, result.ID)
+	s.mockStore.AssertExpectations(s.T())
+
+	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.True(ok)
+	s.Equal(entity.ID, cached.ID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntity_StoreError() {
+	storeErr := errors.New("db error")
+	s.mockStore.On("GetEntity", mock.Anything, "bad-id").Return(Entity{}, storeErr).Once()
+
+	_, err := s.cachedStore.GetEntity(context.Background(), "bad-id")
+	s.Equal(storeErr, err)
+
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: "bad-id"})
+	s.False(ok)
+}
+
+// IdentifyEntity tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_CallsStore() {
+	entityID := testEntityID
+	filters := map[string]interface{}{"clientId": "client-1"}
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(&entityID, nil).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Nil(err)
+	s.Equal(entityID, *result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_StoreError() {
+	filters := map[string]interface{}{"clientId": "bad-client"}
+	storeErr := errors.New("not found")
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(nil, storeErr).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Equal(storeErr, err)
+	s.Nil(result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// UpdateSystemAttributes tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateSystemAttributes_InvalidatesEntityCache() {
+	entity := s.makeEntity(testEntityID, "old-client")
+	s.entityByIDData[entity.ID] = &entity
+
+	newSysAttrs, _ := json.Marshal(map[string]interface{}{"clientId": "new-client"})
+	s.mockStore.On("UpdateSystemAttributes", mock.Anything, entity.ID,
+		json.RawMessage(newSysAttrs)).Return(nil).Once()
+
+	err := s.cachedStore.UpdateSystemAttributes(context.Background(), entity.ID, newSysAttrs)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
+}
+
+// DeleteEntity tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestDeleteEntity_InvalidatesEntityCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+
+	s.mockStore.On("DeleteEntity", mock.Anything, entity.ID).Return(nil).Once()
+
+	err := s.cachedStore.DeleteEntity(context.Background(), entity.ID)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestDeleteEntity_StoreError() {
+	entity := s.makeEntity("entity-2", "client-2")
+	s.entityByIDData[entity.ID] = &entity
+
+	storeErr := errors.New("delete error")
+	s.mockStore.On("DeleteEntity", mock.Anything, entity.ID).Return(storeErr).Once()
+
+	err := s.cachedStore.DeleteEntity(context.Background(), entity.ID)
+	s.Equal(storeErr, err)
+
+	// Cache should NOT be invalidated on error.
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.True(ok)
+}
+
+// CreateEntity tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_CachesEntityByID() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.mockStore.On("CreateEntity", mock.Anything, entity, json.RawMessage(nil),
+		json.RawMessage(nil)).Return(nil).Once()
+
+	err := s.cachedStore.CreateEntity(context.Background(), entity, nil, nil)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.True(ok)
+	s.Equal(entity.ID, cached.ID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_StoreError_DoesNotCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	storeErr := errors.New("create error")
+	s.mockStore.On("CreateEntity", mock.Anything, entity, json.RawMessage(nil),
+		json.RawMessage(nil)).Return(storeErr).Once()
+
+	err := s.cachedStore.CreateEntity(context.Background(), entity, nil, nil)
+	s.Equal(storeErr, err)
+
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
+}
+
+// UpdateEntity tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesAndRecachesEntity() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+
+	s.mockStore.On("UpdateEntity", mock.Anything, &entity).Return(nil).Once()
+
+	err := s.cachedStore.UpdateEntity(context.Background(), &entity)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	// Updated entity must be present in the by-ID cache.
+	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.True(ok)
+	s.Equal(entity.ID, cached.ID)
+}

--- a/backend/internal/entity/init.go
+++ b/backend/internal/entity/init.go
@@ -50,5 +50,6 @@ func initializeStore() (entityStoreInterface, transaction.Transactioner, error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	return newEntityCompositeStore(fileStore, dbStore), transactioner, nil
+	cacheBackedEntityStore := newCacheBackedEntityStore(dbStore)
+	return newEntityCompositeStore(fileStore, cacheBackedEntityStore), transactioner, nil
 }


### PR DESCRIPTION
### Purpose
This pull request introduces a cache-backed wrapper for the entity store, improving the efficiency of entity lookup operations by caching entities in memory. It also adds comprehensive unit tests for the new caching layer and updates the store initialization logic to use the cache-backed store by default. Additionally, it ensures compatibility with existing code that needs access to the underlying file-based store. The most important changes are grouped below.

### Caching Layer Implementation

* Added a new `cacheBackedEntityStore` in `cache_backed_store.go` that wraps an `entityStoreInterface` and provides in-memory caching for entity lookups by ID, with cache invalidation on updates and deletes. This should reduce database/file store hits for frequently accessed entities.
* Updated the store initialization in `init.go` to return a `cacheBackedEntityStore` by default, so all entity operations now benefit from caching without requiring code changes elsewhere.

### Testing

* Added `cache_backed_store_test.go` with a comprehensive test suite for the cache-backed store, including cache hits, misses, invalidation, and error handling, ensuring correctness and reliability of the caching logic.

### Compatibility and Integration

* Modified `declarative_resource.go` to extract the underlying file-based store even when wrapped by the cache-backed store, maintaining compatibility with code that needs direct access to the file store.


### Related Issues
- https://github.com/asgardeo/thunder/issues/2370

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Introduced in-memory entity caching to improve retrieval performance by reducing database latency.

* **Tests**
  * Added comprehensive test coverage for entity caching functionality and cache invalidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->