### PR TITLE
Fix labeled events cancelling in-progress PR builds

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -14,7 +14,7 @@ on:
 # Avoid running multiple PR builders for the same PR on subsequent pushes.
 concurrency:
   group: pr-builder-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'labeled' }}
 
 env:
   GOFLAGS: "-mod=readonly"
@@ -29,7 +29,7 @@ jobs:
 
   security-audit:
     name: 🔒 Security Audit
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -113,7 +113,7 @@ jobs:
 
   dependency-review:
     name: 🔎 Dependency Review
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,7 +133,7 @@ jobs:
 
   verify-mocks:
     name: 🔍 Verify Mock Files
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -169,7 +169,7 @@ jobs:
   lint:
     name: 🧹 Lint Code
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && ((github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && ((github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -227,7 +227,7 @@ jobs:
   build:
     name: 🛠️ Build Product
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -318,7 +318,7 @@ jobs:
   test-frontend:
     name: 🧪 Frontend Tests (shard ${{ matrix.shard }}/4)
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -437,7 +437,7 @@ jobs:
   build_samples:
     name: 🛠️ Build Sample Apps
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -789,7 +789,7 @@ jobs:
 
   detect-powershell-changes:
     name: 🔍 Detect PowerShell Changes
-    if: (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.filter.outputs.powershell }}
@@ -813,7 +813,7 @@ jobs:
 
   detect-docs-changes:
     name: 🔍 Detect Documentation Changes
-    if: (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.filter.outputs.docs }}


### PR DESCRIPTION
### Purpose

Adding a label to a PR while a CI build is running triggers a `labeled` event that cancels the in-progress build via `cancel-in-progress: true` in the concurrency group. The replacement run then skips all jobs (except dependency-guard) because every job condition excludes labeled events with `github.event.action != 'labeled'`. This leaves PRs stuck with no CI results — only dependency-guard shows as passed.

**Affected PRs:** #2403, #2401 (and temporarily #2406 before a subsequent push fixed it).

**Root cause timeline (e.g. PR #2403):**
1. Push at `04:30:52` → `synchronize` event → full build starts
2. Label `Type/New Feature` added at `04:31:45` → `labeled` event → new run in same concurrency group
3. `cancel-in-progress: true` cancels the in-progress build
4. New run starts, all jobs skip (except dependency-guard)

Additionally, the `dependencies-approved` label bypass for the dependency guard was broken — even when the guard was bypassed via the label, all other jobs still skipped because of the blanket `!= 'labeled'` condition.

### Approach

**Two changes:**

1. **Conditional `cancel-in-progress`**: Changed from `true` to `${{ github.event.action != 'labeled' }}` so that label events queue behind in-progress builds instead of cancelling them, while push/sync events still cancel stale runs.

2. **Allow `dependencies-approved` label**: Updated all job conditions from `github.event.action != 'labeled'` to `(github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')` so that adding the `dependencies-approved` label triggers a full build with the dependency guard bypassed.

**Behavior matrix:**

| Event | cancel-in-progress | dependency-guard | other jobs |
|---|---|---|---|
| Push (`synchronize`) | `true` | runs | run |
| `dependencies-approved` label | `false` | skips (bypassed) | run (full build) |
| Any other label | `false` | runs | skip (quick no-op) |
| `merge_group` | `true` | runs | run |
| `workflow_dispatch` | `true` | skips | run (build/test/samples only) |

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request workflow concurrency handling to prevent unnecessary job cancellations when PRs are labeled.
  * Enhanced workflow logic to allow dependency-related checks to run for pull requests labeled with "dependencies-approved".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->