### PR TITLE
Remove debounce from resource property panel updates

### DIFF
--- a/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
@@ -19,7 +19,6 @@
 import {Stack, Typography} from '@wso2/oxygen-ui';
 import {useReactFlow, type Node as FlowNode} from '@xyflow/react';
 import cloneDeep from 'lodash-es/cloneDeep';
-import debounce from 'lodash-es/debounce';
 import isEmpty from 'lodash-es/isEmpty';
 import merge from 'lodash-es/merge';
 import set from 'lodash-es/set';
@@ -60,6 +59,35 @@ export interface CommonResourcePropertiesPropsInterface {
 }
 
 /**
+ * Recursively updates a property on a specific element within a component tree.
+ */
+function updateComponentProperty(
+  components: Element[],
+  elementId: string,
+  propertyKey: string,
+  newValue: string | boolean | object,
+): Element[] {
+  return components.map((component: Element) => {
+    if (component.id === elementId) {
+      const updated = {...component};
+
+      set(updated, propertyKey, newValue);
+
+      return updated;
+    }
+
+    if (component.components) {
+      return {
+        ...component,
+        components: updateComponentProperty(component.components, elementId, propertyKey, newValue),
+      };
+    }
+
+    return component;
+  });
+}
+
+/**
  * Component to generate the properties panel for the selected resource.
  *
  * @param props - Props injected to the component.
@@ -70,7 +98,7 @@ function ResourceProperties(): ReactElement {
   const {lastInteractedResource, setLastInteractedResource, lastInteractedStepId} = useInteractionState();
   const {ResourceProperties: ResourcePropertiesComponent} = useFlowConfig();
 
-  // Use a ref to track the current resource ID for debounced functions
+  // Use a ref to track the current resource ID for async property change handlers
   const lastInteractedResourceIdRef = useRef<string>(lastInteractedResource?.id);
 
   const lastInteractedResourceRef = useRef(lastInteractedResource);
@@ -217,134 +245,102 @@ function ResourceProperties(): ReactElement {
     });
   }, []);
 
-  /**
-   * Create debounced handler using a ref initialized in an effect to avoid
-   * accessing refs during render.
-   */
-  const handlePropertyChangeDebouncedRef = useRef<
-    ((propertyKey: string, newValue: string | boolean | object, element: Element) => Promise<void> | undefined) | null
-  >(null);
+  const applyNodeUpdate = useCallback(
+    (currentStepId: string, propertyKey: string, newValue: string | boolean | object, element: Element): void => {
+      updateNodeDataRef.current(currentStepId, (node: FlowNode<StepData>) => {
+        const data: StepData = node?.data ?? {};
 
-  useEffect(() => {
-    const debouncedFn = debounce(
-      async (propertyKey: string, newValue: string | boolean | object, element: Element): Promise<void> => {
-        const currentStepId = lastInteractedStepIdRef.current;
-        const currentResource = lastInteractedResourceRef.current;
-
-        // Execute plugins for ON_PROPERTY_CHANGE event.
-        const pluginResult = await PluginRegistry.getInstance().executeAsync(
-          FlowEventTypes.ON_PROPERTY_CHANGE,
-          propertyKey,
-          newValue,
-          element,
-          currentStepId,
-        );
-
-        // If plugin handled the change (returned false), still update the resource to trigger re-render
-        // This ensures properties panel updates after plugin modifications (e.g., adding confirm password field)
-        if (!pluginResult) {
-          if (element.id === lastInteractedResourceIdRef.current && currentResource) {
-            const updatedResource: Resource = cloneDeep(currentResource);
-            set(updatedResource as unknown as Record<string, unknown>, propertyKey, newValue);
-            setLastInteractedResourceRef.current(updatedResource);
-          }
-          return;
+        if (!isEmpty(node?.data?.components)) {
+          data.components = updateComponentProperty(
+            cloneDeep(node?.data?.components) ?? [],
+            element.id,
+            propertyKey,
+            newValue,
+          );
+        } else if (propertyKey === 'data') {
+          return {...(newValue as StepData)};
+        } else {
+          const actualKey = propertyKey.startsWith('data.') ? propertyKey.slice(5) : propertyKey;
+          set(data as Record<string, unknown>, actualKey, newValue);
         }
 
-        const updateComponent = (components: Element[]): Element[] =>
-          components.map((component: Element) => {
-            if (component.id === element.id) {
-              const updated = {...component};
+        return {...data};
+      });
+    },
+    [],
+  );
 
-              set(updated, propertyKey, newValue);
+  const applyResourceUpdate = useCallback(
+    (propertyKey: string, newValue: string | boolean | object, element: Element): void => {
+      const currentResource = lastInteractedResourceRef.current;
 
-              return updated;
-            }
+      if (propertyKey === 'action' || element.id !== lastInteractedResourceIdRef.current || !currentResource) {
+        return;
+      }
 
-            if (component.components) {
-              return {
-                ...component,
-                components: updateComponent(component.components),
-              };
-            }
+      const updatedResource: Resource = cloneDeep(currentResource);
+      const topLevelEditableProps = [
+        'label',
+        'hint',
+        'placeholder',
+        'required',
+        'src',
+        'alt',
+        'width',
+        'height',
+        'startIcon',
+        'endIcon',
+        'eventType',
+        'items',
+        'direction',
+        'gap',
+        'align',
+        'justify',
+        'name',
+        'size',
+        'color',
+      ];
 
-            return component;
-          });
+      if (propertyKey === 'data') {
+        updatedResource.data = newValue as StepData;
+      } else if (propertyKey === 'id' || topLevelEditableProps.includes(propertyKey)) {
+        set(updatedResource as unknown as Record<string, unknown>, propertyKey, newValue);
+      } else if (propertyKey.startsWith('config.') || propertyKey.startsWith('data.')) {
+        set(updatedResource, propertyKey, newValue);
+      } else {
+        set(updatedResource.data as Record<string, unknown>, propertyKey, newValue);
+      }
 
-        updateNodeDataRef.current(currentStepId, (node: FlowNode<StepData>) => {
-          const data: StepData = node?.data ?? {};
-
-          if (!isEmpty(node?.data?.components)) {
-            data.components = updateComponent(cloneDeep(node?.data?.components) ?? []);
-          } else if (propertyKey === 'data') {
-            // When propertyKey is exactly 'data', replace the entire data object
-            return {...(newValue as StepData)};
-          } else {
-            // Strip 'data.' prefix if present since we're already setting on the data object
-            const actualKey = propertyKey.startsWith('data.') ? propertyKey.slice(5) : propertyKey;
-            set(data as Record<string, unknown>, actualKey, newValue);
-          }
-
-          return {...data};
-        });
-
-        // Only update lastInteractedResource if the element being changed is still the currently selected one.
-        // This prevents stale updates from overwriting the heading when user switches to a different element.
-        // Use the ref to get the current resource ID at execution time (not from the stale closure).
-        if (propertyKey !== 'action' && element.id === lastInteractedResourceIdRef.current && currentResource) {
-          const updatedResource: Resource = cloneDeep(currentResource);
-
-          // Top-level editable properties are set directly on the resource
-          const topLevelEditableProps = [
-            'label',
-            'hint',
-            'placeholder',
-            'required',
-            'src',
-            'alt',
-            'width',
-            'height',
-            'startIcon',
-            'endIcon',
-            'eventType',
-            'items',
-            'direction',
-            'gap',
-            'align',
-            'justify',
-            'name',
-            'size',
-            'color',
-          ];
-          if (propertyKey === 'data') {
-            // When propertyKey is exactly 'data', replace the entire data object
-            updatedResource.data = newValue as StepData;
-          } else if (propertyKey === 'id' || topLevelEditableProps.includes(propertyKey)) {
-            set(updatedResource as unknown as Record<string, unknown>, propertyKey, newValue);
-          } else if (propertyKey.startsWith('config.') || propertyKey.startsWith('data.')) {
-            // Properties starting with 'config.' or 'data.' should be set on the resource directly
-            set(updatedResource, propertyKey, newValue);
-          } else {
-            set(updatedResource.data as Record<string, unknown>, propertyKey, newValue);
-          }
-          setLastInteractedResourceRef.current(updatedResource);
-        }
-      },
-      300,
-    );
-
-    handlePropertyChangeDebouncedRef.current = debouncedFn;
-
-    return () => {
-      debouncedFn.cancel();
-    };
-  }, []);
+      setLastInteractedResourceRef.current(updatedResource);
+    },
+    [],
+  );
 
   const handlePropertyChange = useCallback(
     (propertyKey: string, newValue: string | boolean | object, element: Element) => {
-      void handlePropertyChangeDebouncedRef.current?.(propertyKey, newValue, element);
+      const currentStepId = lastInteractedStepIdRef.current;
+
+      // Apply node and resource updates immediately for responsive UI
+      applyNodeUpdate(currentStepId, propertyKey, newValue, element);
+      applyResourceUpdate(propertyKey, newValue, element);
+
+      // Run plugins asynchronously — if a plugin intercepts (returns false),
+      // it will apply its own modifications to the node data
+      void PluginRegistry.getInstance()
+        .executeAsync(FlowEventTypes.ON_PROPERTY_CHANGE, propertyKey, newValue, element, currentStepId)
+        .then((pluginResult) => {
+          if (!pluginResult) {
+            // Plugin handled the change — refresh the resource to pick up plugin modifications
+            const currentResource = lastInteractedResourceRef.current;
+            if (element.id === lastInteractedResourceIdRef.current && currentResource) {
+              const refreshedResource: Resource = cloneDeep(currentResource);
+              set(refreshedResource as unknown as Record<string, unknown>, propertyKey, newValue);
+              setLastInteractedResourceRef.current(refreshedResource);
+            }
+          }
+        });
     },
-    [],
+    [applyNodeUpdate, applyResourceUpdate],
   );
 
   if (!lastInteractedResource) {

--- a/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -1612,15 +1612,14 @@ describe('ResourceProperties', () => {
       const changeButton = screen.getByText('Change Label (Plugin Handles)');
       changeButton.click();
 
-      // Wait for debounced function to execute
+      // Wait for async plugin execution
       await new Promise((resolve) => {
-        setTimeout(resolve, 400);
+        setTimeout(resolve, 50);
       });
 
-      // When plugin returns false, setLastInteractedResource should be called to update the resource
+      // Node update happens immediately (before plugin), resource is refreshed after plugin
+      expect(mockUpdateNodeData).toHaveBeenCalled();
       expect(mockSetLastInteractedResource).toHaveBeenCalled();
-      // updateNodeData should NOT be called since we return early
-      expect(mockUpdateNodeData).not.toHaveBeenCalled();
     });
 
     it('should not update resource when element.id differs from lastInteractedResourceId and plugin returns false', async () => {

--- a/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
+++ b/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
@@ -17,7 +17,7 @@
  */
 
 import {Divider, FormHelperText, FormLabel, MenuItem, Select, Stack, TextField} from '@wso2/oxygen-ui';
-import {useState, type ReactNode, type ChangeEvent} from 'react';
+import {type ReactNode, type ChangeEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/ResourceProperties';
 import type {Element} from '@/features/flows/models/elements';
@@ -38,39 +38,10 @@ export type ButtonExtendedPropertiesPropsInterface = CommonResourcePropertiesPro
 function ButtonExtendedProperties({resource, onChange}: ButtonExtendedPropertiesPropsInterface): ReactNode {
   const {t} = useTranslation();
 
-  const eventTypeValue = (resource as Element & {eventType?: string})?.eventType ?? ActionEventTypes.Trigger;
-
-  // Use local state for text inputs — provides immediate keystroke feedback while onChange is debounced
-  const [startIconValue, setStartIconValue] = useState(() => {
-    const element = resource as Element & {startIcon?: string};
-    return element?.startIcon ?? '';
-  });
-
-  const [endIconValue, setEndIconValue] = useState(() => {
-    const element = resource as Element & {endIcon?: string};
-    return element?.endIcon ?? '';
-  });
-
-  // Sync local state when resource changes (e.g., switching to a different button)
-  const [prevResource, setPrevResource] = useState(resource);
-  if (resource !== prevResource) {
-    setPrevResource(resource);
-    const element = resource as Element & {startIcon?: string; endIcon?: string};
-    setStartIconValue(element?.startIcon ?? '');
-    setEndIconValue(element?.endIcon ?? '');
-  }
-
-  // Handle startIcon change - update local state immediately, propagate via onChange (debounced)
-  const handleStartIconChange = (value: string): void => {
-    setStartIconValue(value);
-    onChange('startIcon', value, resource);
-  };
-
-  // Handle endIcon change - update local state immediately, propagate via onChange (debounced)
-  const handleEndIconChange = (value: string): void => {
-    setEndIconValue(value);
-    onChange('endIcon', value, resource);
-  };
+  const element = resource as Element & {eventType?: string; startIcon?: string; endIcon?: string};
+  const eventTypeValue = element?.eventType ?? ActionEventTypes.Trigger;
+  const startIconValue = element?.startIcon ?? '';
+  const endIconValue = element?.endIcon ?? '';
 
   return (
     <Stack gap={2}>
@@ -95,7 +66,7 @@ function ButtonExtendedProperties({resource, onChange}: ButtonExtendedProperties
         <TextField
           id="start-icon-input"
           value={startIconValue}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => handleStartIconChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange('startIcon', e.target.value, resource)}
           placeholder={t('flows:core.buttonExtendedProperties.startIcon.placeholder')}
           fullWidth
           size="small"
@@ -108,7 +79,7 @@ function ButtonExtendedProperties({resource, onChange}: ButtonExtendedProperties
         <TextField
           id="end-icon-input"
           value={endIconValue}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => handleEndIconChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange('endIcon', e.target.value, resource)}
           placeholder={t('flows:core.buttonExtendedProperties.endIcon.placeholder')}
           fullWidth
           size="small"

--- a/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
+++ b/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
@@ -227,8 +227,7 @@ function ExecutionExtendedProperties({resource, onChange}: ExecutionExtendedProp
     // Update the display label based on the selected mode
     const modeConfig = SMS_OTP_MODES.find((mode) => mode.value === selectedMode);
 
-    // Build the updated data object with both mode and display label
-    // This avoids the debounce issue where multiple rapid onChange calls would drop intermediate values
+    // Build the updated data object with both mode and display label in a single update
     const updatedData = {
       ...((resource?.data as StepData) ?? {}),
       action: {

--- a/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/FieldExtendedProperties.tsx
+++ b/frontend/apps/thunder-console/src/features/login-flow/components/resource-property-panel/extended-properties/FieldExtendedProperties.tsx
@@ -24,7 +24,7 @@ import {
   TextField,
   type AutocompleteRenderInputParams,
 } from '@wso2/oxygen-ui';
-import {useMemo, useState, type ReactNode, type SyntheticEvent} from 'react';
+import {useMemo, type ReactNode, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/ResourceProperties';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
@@ -48,18 +48,7 @@ function FieldExtendedProperties({resource, onChange}: FieldExtendedPropertiesPr
   const attributes: string[] = useMemo(() => ['email', 'username', 'given_name'], []);
   const credentialAttributes: string[] = useMemo(() => ['password', 'pin', 'secret'], []);
 
-  const resourceRef = (resource as Element & {ref?: string})?.ref;
-
-  // Use local state to track the selected value immediately (avoids revert on blur due to debounced updates)
-  // Initialize with the resourceRef value directly (supports free-solo values not in the predefined list)
-  const [localSelectedValue, setLocalSelectedValue] = useState<string | null>(() => resourceRef ?? null);
-
-  // Sync local state when resource changes (e.g., when switching to a different element)
-  const [prevResourceRef, setPrevResourceRef] = useState(resourceRef);
-  if (resourceRef !== prevResourceRef) {
-    setPrevResourceRef(resourceRef);
-    setLocalSelectedValue(resourceRef ?? null);
-  }
+  const resourceRef = (resource as Element & {ref?: string})?.ref ?? null;
 
   /**
    * Get the error message for the ref field.
@@ -94,15 +83,12 @@ function FieldExtendedProperties({resource, onChange}: FieldExtendedPropertiesPr
             />
           </>
         )}
-        value={localSelectedValue}
+        value={resourceRef}
         onChange={(_: SyntheticEvent, attribute: string | null) => {
-          setLocalSelectedValue(attribute);
           onChange('ref', attribute ?? '', resource);
         }}
         onInputChange={(_: SyntheticEvent, value: string, reason: string) => {
-          // Handle free-form input (when user types a custom value)
           if (reason === 'input') {
-            setLocalSelectedValue(value);
             onChange('ref', value, resource);
           }
         }}


### PR DESCRIPTION
### Purpose

Remove the debounced `handlePropertyChange` in `ResourceProperties` and apply property updates immediately. The debounce was causing input lag, dropped intermediate values during rapid edits, and required local state workarounds in child components (`ButtonExtendedProperties`, `FieldExtendedProperties`).

### Approach

- Replace the debounced handler with immediate calls to `applyNodeUpdate` and `applyResourceUpdate`, keeping the UI responsive.
- Extract the recursive component-tree update into a standalone `updateComponentProperty` helper.
- Run `PluginRegistry.executeAsync` asynchronously *after* the immediate update so plugins can still intercept changes without blocking the UI.
- Remove local state (`useState`) from `ButtonExtendedProperties` (icon inputs) and `FieldExtendedProperties` (ref autocomplete) since the parent now updates synchronously.
- Update tests to reflect the new timing (no 300ms debounce wait).

### Related Issues
- https://github.com/asgardeo/thunder/issues/2382

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.