### PR TITLE
Introduce runtime flow segmentation

### DIFF
--- a/backend/internal/flow/core/GraphInterface_mock_test.go
+++ b/backend/internal/flow/core/GraphInterface_mock_test.go
@@ -342,6 +342,158 @@ func (_c *GraphInterfaceMock_GetNodes_Call) RunAndReturn(run func() map[string]N
 	return _c
 }
 
+// GetSegmentByID provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegmentByID(segmentID string) *Segment {
+	ret := _mock.Called(segmentID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegmentByID")
+	}
+
+	var r0 *Segment
+	if returnFunc, ok := ret.Get(0).(func(string) *Segment); ok {
+		r0 = returnFunc(segmentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegmentByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegmentByID'
+type GraphInterfaceMock_GetSegmentByID_Call struct {
+	*mock.Call
+}
+
+// GetSegmentByID is a helper method to define mock.On call
+//   - segmentID string
+func (_e *GraphInterfaceMock_Expecter) GetSegmentByID(segmentID interface{}) *GraphInterfaceMock_GetSegmentByID_Call {
+	return &GraphInterfaceMock_GetSegmentByID_Call{Call: _e.mock.On("GetSegmentByID", segmentID)}
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) Run(run func(segmentID string)) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) Return(segment *Segment) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Return(segment)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) RunAndReturn(run func(segmentID string) *Segment) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSegmentByStartNode provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegmentByStartNode(nodeID string) *Segment {
+	ret := _mock.Called(nodeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegmentByStartNode")
+	}
+
+	var r0 *Segment
+	if returnFunc, ok := ret.Get(0).(func(string) *Segment); ok {
+		r0 = returnFunc(nodeID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegmentByStartNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegmentByStartNode'
+type GraphInterfaceMock_GetSegmentByStartNode_Call struct {
+	*mock.Call
+}
+
+// GetSegmentByStartNode is a helper method to define mock.On call
+//   - nodeID string
+func (_e *GraphInterfaceMock_Expecter) GetSegmentByStartNode(nodeID interface{}) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	return &GraphInterfaceMock_GetSegmentByStartNode_Call{Call: _e.mock.On("GetSegmentByStartNode", nodeID)}
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) Run(run func(nodeID string)) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) Return(segment *Segment) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Return(segment)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) RunAndReturn(run func(nodeID string) *Segment) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegments() []Segment {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegments")
+	}
+
+	var r0 []Segment
+	if returnFunc, ok := ret.Get(0).(func() []Segment); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegments'
+type GraphInterfaceMock_GetSegments_Call struct {
+	*mock.Call
+}
+
+// GetSegments is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) GetSegments() *GraphInterfaceMock_GetSegments_Call {
+	return &GraphInterfaceMock_GetSegments_Call{Call: _e.mock.On("GetSegments")}
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) Run(run func()) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) Return(segments []Segment) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Return(segments)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) RunAndReturn(run func() []Segment) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStartNode provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) GetStartNode() (NodeInterface, error) {
 	ret := _mock.Called()
@@ -485,6 +637,50 @@ func (_c *GraphInterfaceMock_GetType_Call) RunAndReturn(run func() common.FlowTy
 	return _c
 }
 
+// HasSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) HasSegments() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasSegments")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// GraphInterfaceMock_HasSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasSegments'
+type GraphInterfaceMock_HasSegments_Call struct {
+	*mock.Call
+}
+
+// HasSegments is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) HasSegments() *GraphInterfaceMock_HasSegments_Call {
+	return &GraphInterfaceMock_HasSegments_Call{Call: _e.mock.On("HasSegments")}
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) Run(run func()) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) Return(b bool) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) RunAndReturn(run func() bool) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveEdge provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) RemoveEdge(fromNodeID string, toNodeID string) error {
 	ret := _mock.Called(fromNodeID, toNodeID)
@@ -618,6 +814,46 @@ func (_c *GraphInterfaceMock_SetNodes_Call) Return() *GraphInterfaceMock_SetNode
 }
 
 func (_c *GraphInterfaceMock_SetNodes_Call) RunAndReturn(run func(nodes map[string]NodeInterface)) *GraphInterfaceMock_SetNodes_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) SetSegments(segments []Segment) {
+	_mock.Called(segments)
+	return
+}
+
+// GraphInterfaceMock_SetSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetSegments'
+type GraphInterfaceMock_SetSegments_Call struct {
+	*mock.Call
+}
+
+// SetSegments is a helper method to define mock.On call
+//   - segments []Segment
+func (_e *GraphInterfaceMock_Expecter) SetSegments(segments interface{}) *GraphInterfaceMock_SetSegments_Call {
+	return &GraphInterfaceMock_SetSegments_Call{Call: _e.mock.On("SetSegments", segments)}
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) Run(run func(segments []Segment)) *GraphInterfaceMock_SetSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []Segment
+		if args[0] != nil {
+			arg0 = args[0].([]Segment)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) Return() *GraphInterfaceMock_SetSegments_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) RunAndReturn(run func(segments []Segment)) *GraphInterfaceMock_SetSegments_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -41,6 +41,11 @@ type GraphInterface interface {
 	GetStartNode() (NodeInterface, error)
 	SetStartNode(startNodeID string) error
 	ToJSON() (string, error)
+	HasSegments() bool
+	GetSegments() []Segment
+	SetSegments(segments []Segment)
+	GetSegmentByID(segmentID string) *Segment
+	GetSegmentByStartNode(nodeID string) *Segment
 }
 
 // graph implements the GraphInterface for the flow execution
@@ -50,6 +55,7 @@ type graph struct {
 	nodes       map[string]NodeInterface
 	edges       map[string][]string
 	startNodeID string
+	segments    []Segment
 }
 
 // GetID returns the unique ID of the graph
@@ -187,6 +193,41 @@ func (g *graph) SetStartNode(startNodeID string) error {
 	g.startNodeID = startNodeID
 	node.SetAsStartNode()
 
+	return nil
+}
+
+// HasSegments returns true if the graph has multiple segments (i.e., contains display-only prompt nodes).
+func (g *graph) HasSegments() bool {
+	return len(g.segments) > 1
+}
+
+// GetSegments returns all segments in the graph.
+func (g *graph) GetSegments() []Segment {
+	return g.segments
+}
+
+// SetSegments sets the segments for the graph.
+func (g *graph) SetSegments(segments []Segment) {
+	g.segments = segments
+}
+
+// GetSegmentByID retrieves a segment by its ID.
+func (g *graph) GetSegmentByID(segmentID string) *Segment {
+	for i := range g.segments {
+		if g.segments[i].ID == segmentID {
+			return &g.segments[i]
+		}
+	}
+	return nil
+}
+
+// GetSegmentByStartNode returns the segment whose start node matches the given node ID.
+func (g *graph) GetSegmentByStartNode(nodeID string) *Segment {
+	for i := range g.segments {
+		if g.segments[i].StartNodeID == nodeID {
+			return &g.segments[i]
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/flow/core/graph_test.go
+++ b/backend/internal/flow/core/graph_test.go
@@ -291,6 +291,89 @@ func (s *GraphTestSuite) TestGetStartNodeFailure() {
 	s.Contains(err.Error(), "start node not set for the graph")
 }
 
+func (s *GraphTestSuite) TestHasSegments_NoSegments() {
+	s.False(s.graph.HasSegments())
+}
+
+func (s *GraphTestSuite) TestHasSegments_OneSegmentIsNotMultiple() {
+	s.graph.SetSegments([]Segment{{ID: "seg-0", StartNodeID: "node-1"}})
+	s.False(s.graph.HasSegments())
+}
+
+func (s *GraphTestSuite) TestHasSegments_TwoSegments() {
+	s.graph.SetSegments([]Segment{
+		{ID: "seg-0", StartNodeID: "node-1"},
+		{ID: "seg-1", StartNodeID: "node-2"},
+	})
+	s.True(s.graph.HasSegments())
+}
+
+func (s *GraphTestSuite) TestGetSegments_Empty() {
+	segments := s.graph.GetSegments()
+	s.Empty(segments)
+}
+
+func (s *GraphTestSuite) TestSetAndGetSegments() {
+	input := []Segment{
+		{ID: "seg-0", StartNodeID: "node-a"},
+		{ID: "seg-1", StartNodeID: "node-b"},
+	}
+	s.graph.SetSegments(input)
+	segments := s.graph.GetSegments()
+	s.Len(segments, 2)
+	s.Equal("seg-0", segments[0].ID)
+	s.Equal("node-a", segments[0].StartNodeID)
+	s.Equal("seg-1", segments[1].ID)
+	s.Equal("node-b", segments[1].StartNodeID)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByID_Found() {
+	s.graph.SetSegments([]Segment{
+		{ID: "seg-0", StartNodeID: "node-a"},
+		{ID: "seg-1", StartNodeID: "node-b"},
+	})
+	seg := s.graph.GetSegmentByID("seg-1")
+	s.NotNil(seg)
+	s.Equal("seg-1", seg.ID)
+	s.Equal("node-b", seg.StartNodeID)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByID_NotFound() {
+	s.graph.SetSegments([]Segment{
+		{ID: "seg-0", StartNodeID: "node-a"},
+	})
+	seg := s.graph.GetSegmentByID("seg-99")
+	s.Nil(seg)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByID_EmptyList() {
+	seg := s.graph.GetSegmentByID("seg-0")
+	s.Nil(seg)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByStartNode_Found() {
+	s.graph.SetSegments([]Segment{
+		{ID: "seg-0", StartNodeID: "node-a"},
+		{ID: "seg-1", StartNodeID: "node-b"},
+	})
+	seg := s.graph.GetSegmentByStartNode("node-b")
+	s.NotNil(seg)
+	s.Equal("seg-1", seg.ID)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByStartNode_NotFound() {
+	s.graph.SetSegments([]Segment{
+		{ID: "seg-0", StartNodeID: "node-a"},
+	})
+	seg := s.graph.GetSegmentByStartNode("node-z")
+	s.Nil(seg)
+}
+
+func (s *GraphTestSuite) TestGetSegmentByStartNode_EmptyList() {
+	seg := s.graph.GetSegmentByStartNode("node-a")
+	s.Nil(seg)
+}
+
 func (s *GraphTestSuite) TestToJSON() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
 		map[string]interface{}{"key": "value"}, true, false)

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -60,7 +60,14 @@ type NodeCondition struct {
 	OnSkip string
 }
 
+// Segment represents a contiguous section of a flow graph bounded by display-only prompt nodes.
+type Segment struct {
+	ID          string
+	StartNodeID string
+}
+
 // ExecutionPolicy defines behavioral policies for node execution.
 type ExecutionPolicy struct {
 	SkipChallengeValidation bool
+	AllowSegmentRestart     bool
 }

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -64,6 +64,7 @@ func (e *inviteExecutor) GetExecutionPolicy(mode string) *core.ExecutionPolicy {
 	if mode == ExecutorModeVerify {
 		return &core.ExecutionPolicy{
 			SkipChallengeValidation: true,
+			AllowSegmentRestart:     true,
 		}
 	}
 	return nil

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -240,6 +240,12 @@ func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_VerifyMode_SkipsCha
 	assert.True(suite.T(), policy.SkipChallengeValidation)
 }
 
+func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_VerifyMode_AllowsSegmentRestart() {
+	policy := suite.executor.GetExecutionPolicy(ExecutorModeVerify)
+	assert.NotNil(suite.T(), policy)
+	assert.True(suite.T(), policy.AllowSegmentRestart)
+}
+
 func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_InvalidMode_ReturnsNil() {
 	policy := suite.executor.GetExecutionPolicy("invalid-mode")
 	assert.Nil(suite.T(), policy)

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -75,12 +75,14 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 		publishFlowStartedEvent(ctx, fe.observabilitySvc)
 	}
 
-	currentNode, err := fe.setCurrentExecutionNode(ctx, logger)
-	if err != nil {
+	if err := fe.setCurrentExecutionNode(ctx, logger); err != nil {
 		// Publish flow failed event before returning error
 		publishFlowFailedEvent(ctx, err, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
 		return flowStep, err
 	}
+
+	skipChallengeValidation := fe.validateSegmentResumePolicy(ctx, logger)
+	currentNode := ctx.CurrentNode
 
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
 	challengeTokenValidated := false
@@ -143,9 +145,11 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 		// policy against the executor
 		if !challengeTokenValidated {
 			challengeTokenValidated = true
-			if svcErr := fe.validateChallengeToken(ctx, currentNode); svcErr != nil {
-				publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
-				return flowStep, svcErr
+			if !skipChallengeValidation {
+				if svcErr := fe.validateChallengeToken(ctx, currentNode); svcErr != nil {
+					publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+					return flowStep, svcErr
+				}
 			}
 		}
 
@@ -214,13 +218,13 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	return flowStep, nil
 }
 
-// setCurrentExecutionNode sets the current execution node in the context and returns it.
-func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext, logger *log.Logger) (
-	core.NodeInterface, *serviceerror.ServiceError) {
+// setCurrentExecutionNode sets the current execution node in the context.
+func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext,
+	logger *log.Logger) *serviceerror.ServiceError {
 	graph := ctx.Graph
 	if graph == nil {
 		logger.Error("Flow graph is not initialized in the context")
-		return nil, &serviceerror.InternalServerError
+		return &serviceerror.InternalServerError
 	}
 
 	currentNode := ctx.CurrentNode
@@ -230,7 +234,7 @@ func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext, logger *log.Lo
 		currentNode, err = graph.GetStartNode()
 		if err != nil {
 			logger.Error("Start node not found in the flow graph", log.Error(err))
-			return nil, &serviceerror.InternalServerError
+			return &serviceerror.InternalServerError
 		}
 		ctx.CurrentNode = currentNode
 	}
@@ -240,7 +244,7 @@ func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext, logger *log.Lo
 		ctx.ExecutionHistory = make(map[string]*common.NodeExecutionRecord)
 	}
 
-	return currentNode, nil
+	return nil
 }
 
 // getNodeInputs extracts required inputs for a node.
@@ -534,10 +538,17 @@ func (fe *flowEngine) handleDisplayOnlyPromptResponse(ctx *EngineContext,
 		flowStep.Status = common.FlowStatusComplete
 		continueExecution = true
 	} else {
-		// Set current node to the next node so that the flow can resume from there in the next execution
+		// Set current node to the next node so that flow can be resumed from there in the next execution
 		ctx.CurrentNode = nextNode
 		flowStep.Status = common.FlowStatusIncomplete
 		flowStep.Type = common.StepTypeView
+
+		// Set current segment to the next node's segment if segments are defined in the graph
+		if ctx.Graph.HasSegments() {
+			if seg := ctx.Graph.GetSegmentByStartNode(nextNode.GetID()); seg != nil {
+				ctx.CurrentSegmentID = seg.ID
+			}
+		}
 	}
 
 	// Copy additional data from context
@@ -751,6 +762,38 @@ func (fe *flowEngine) resolveStepDetailsForPrompt(ctx *EngineContext, nodeResp *
 	flowStep.Status = common.FlowStatusIncomplete
 	flowStep.Type = common.StepTypeView
 	return nil
+}
+
+// validateSegmentResumePolicy checks whether the current flow is resuming inside a segment whose
+// start node allows segment restart. Returns true if challenge token validation should be skipped.
+func (fe *flowEngine) validateSegmentResumePolicy(ctx *EngineContext, logger *log.Logger) bool {
+	if !ctx.Graph.HasSegments() || ctx.CurrentSegmentID == "" {
+		return false
+	}
+
+	seg := ctx.Graph.GetSegmentByID(ctx.CurrentSegmentID)
+	if seg == nil {
+		return false
+	}
+
+	segStartNode, exists := ctx.Graph.GetNode(seg.StartNodeID)
+	if !exists {
+		return false
+	}
+
+	if svcErr := fe.setNodeExecutor(segStartNode, logger); svcErr != nil {
+		return false
+	}
+
+	policy := segStartNode.GetExecutionPolicy()
+	if policy == nil || !policy.AllowSegmentRestart {
+		return false
+	}
+
+	logger.Debug("Segment restart allowed; skipping challenge token validation for segment resume",
+		log.String("segmentID", seg.ID), log.String("segmentStartNodeID", seg.StartNodeID))
+
+	return true
 }
 
 // validateChallengeToken validates the incoming challenge token against the stored hash.

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -1440,6 +1440,7 @@ func (s *EngineTestSuite) TestHandleDisplayOnlyPromptResponse_ForwardToNextNode(
 
 	mockGraph := coremock.NewGraphInterfaceMock(t)
 	mockGraph.On("GetNode", "next-node").Return(mockNextNode, true)
+	mockGraph.On("HasSegments").Return(false)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
@@ -1761,4 +1762,206 @@ func (s *EngineTestSuite) TestValidateChallengeToken_SkipValidationWhenPolicyNil
 
 	svcErr := fe.validateChallengeToken(ctx, mockNode)
 	s.Nil(svcErr)
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_NoSegments() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(false)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_EmptySegmentID() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(true)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: ""}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_SegmentNotFound() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByID", "seg-1").Return((*core.Segment)(nil))
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_StartNodeNotFound() {
+	t := s.T()
+	seg := &core.Segment{ID: "seg-1", StartNodeID: "task-node"}
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByID", "seg-1").Return(seg)
+	mockGraph.On("GetNode", "task-node").Return(nil, false)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_SetNodeExecutorFails() {
+	// Node reports TaskExecution type but NodeInterfaceMock doesn't implement
+	// ExecutorBackedNodeInterface, so the type assertion in setNodeExecutor fails.
+	t := s.T()
+	seg := &core.Segment{ID: "seg-1", StartNodeID: "task-node"}
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetID").Return("task-node")
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByID", "seg-1").Return(seg)
+	mockGraph.On("GetNode", "task-node").Return(mockNode, true)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_NilPolicy() {
+	t := s.T()
+	seg := &core.Segment{ID: "seg-1", StartNodeID: "prompt-node"}
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypePrompt)
+	mockNode.On("GetExecutionPolicy").Return((*core.ExecutionPolicy)(nil))
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByID", "seg-1").Return(seg)
+	mockGraph.On("GetNode", "prompt-node").Return(mockNode, true)
+
+	fe := &flowEngine{
+		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+	ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+	s.False(fe.validateSegmentResumePolicy(ctx, fe.logger))
+}
+
+func (s *EngineTestSuite) TestValidateSegmentResumePolicy_PolicyAllowsRestartFlag() {
+	tests := []struct {
+		name          string
+		allowRestart  bool
+		expectAllowed bool
+	}{
+		{"policy disallows restart", false, false},
+		{"policy allows restart", true, true},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			t := s.T()
+			seg := &core.Segment{ID: "seg-1", StartNodeID: "task-node"}
+			policy := &core.ExecutionPolicy{SkipChallengeValidation: true, AllowSegmentRestart: tt.allowRestart}
+
+			mockNode := coremock.NewNodeInterfaceMock(t)
+			mockNode.On("GetType").Return(common.NodeTypePrompt)
+			mockNode.On("GetExecutionPolicy").Return(policy)
+
+			mockGraph := coremock.NewGraphInterfaceMock(t)
+			mockGraph.On("HasSegments").Return(true)
+			mockGraph.On("GetSegmentByID", "seg-1").Return(seg)
+			mockGraph.On("GetNode", "task-node").Return(mockNode, true)
+
+			fe := &flowEngine{
+				logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+			}
+			ctx := &EngineContext{Graph: mockGraph, CurrentSegmentID: "seg-1"}
+
+			s.Equal(tt.expectAllowed, fe.validateSegmentResumePolicy(ctx, fe.logger))
+		})
+	}
+}
+
+func (s *EngineTestSuite) TestHandleDisplayOnlyPromptResponse_ForwardToNextNode_SetsSegmentID() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(t)
+	mockPromptNode.On("GetNextNode").Return("next-node")
+
+	mockNextNode := coremock.NewNodeInterfaceMock(t)
+	mockNextNode.On("GetType").Return(common.NodeTypePrompt)
+	mockNextNode.On("GetID").Return("next-node")
+
+	seg := &core.Segment{ID: "seg-1", StartNodeID: "next-node"}
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", "next-node").Return(mockNextNode, true)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByStartNode", "next-node").Return(seg)
+
+	fe := &flowEngine{observabilitySvc: mockObservability}
+	ctx := &EngineContext{
+		CurrentNode: mockPromptNode,
+		Graph:       mockGraph,
+	}
+
+	_, complete, err := fe.handleDisplayOnlyPromptResponse(ctx, &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+	}, &FlowStep{Data: FlowData{}}, nil)
+
+	s.Nil(err)
+	s.False(complete)
+	s.Equal("seg-1", ctx.CurrentSegmentID)
+}
+
+func (s *EngineTestSuite) TestHandleDisplayOnlyPromptResponse_ForwardToNextNode_SegmentNotFound_KeepsEmptyID() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(t)
+	mockPromptNode.On("GetNextNode").Return("next-node")
+
+	mockNextNode := coremock.NewNodeInterfaceMock(t)
+	mockNextNode.On("GetType").Return(common.NodeTypePrompt)
+	mockNextNode.On("GetID").Return("next-node")
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", "next-node").Return(mockNextNode, true)
+	mockGraph.On("HasSegments").Return(true)
+	mockGraph.On("GetSegmentByStartNode", "next-node").Return((*core.Segment)(nil))
+
+	fe := &flowEngine{observabilitySvc: mockObservability}
+	ctx := &EngineContext{
+		CurrentNode: mockPromptNode,
+		Graph:       mockGraph,
+	}
+
+	_, complete, err := fe.handleDisplayOnlyPromptResponse(ctx, &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+	}, &FlowStep{Data: FlowData{}}, nil)
+
+	s.Nil(err)
+	s.False(complete)
+	s.Equal("", ctx.CurrentSegmentID)
 }

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -52,6 +52,7 @@ type EngineContext struct {
 	CurrentNode         core.NodeInterface
 	CurrentNodeResponse *common.NodeResponse
 	CurrentAction       string
+	CurrentSegmentID    string
 
 	Graph       core.GraphInterface
 	Application appmodel.Application
@@ -153,6 +154,7 @@ type flowContextContent struct {
 	Verbose             bool    `json:"verbose"`
 	CurrentNodeID       *string `json:"currentNodeId,omitempty"`
 	CurrentAction       *string `json:"currentAction,omitempty"`
+	CurrentSegmentID    *string `json:"currentSegmentId,omitempty"`
 	GraphID             string  `json:"graphId"`
 	RuntimeData         *string `json:"runtimeData,omitempty"`
 	ExecutionHistory    *string `json:"executionHistory,omitempty"`
@@ -290,6 +292,12 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context, graph core.GraphInt
 		currentAction = *content.CurrentAction
 	}
 
+	// Get current segment ID
+	currentSegmentID := ""
+	if content.CurrentSegmentID != nil {
+		currentSegmentID = *content.CurrentSegmentID
+	}
+
 	// Deserialize AuthUser if present
 	var authUser managerpkg.AuthUser
 	if content.AuthUser != nil {
@@ -315,6 +323,7 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context, graph core.GraphInt
 		RuntimeData:        runtimeData,
 		CurrentNode:        currentNode,
 		CurrentAction:      currentAction,
+		CurrentSegmentID:   currentSegmentID,
 		Graph:              graph,
 		AuthenticatedUser:  authenticatedUser,
 		AuthUser:           authUser,
@@ -364,6 +373,12 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 	var currentAction *string
 	if ctx.CurrentAction != "" {
 		currentAction = &ctx.CurrentAction
+	}
+
+	// Get current segment ID
+	var currentSegmentID *string
+	if ctx.CurrentSegmentID != "" {
+		currentSegmentID = &ctx.CurrentSegmentID
 	}
 
 	// Get authenticated user ID
@@ -428,6 +443,7 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		Verbose:             ctx.Verbose,
 		CurrentNodeID:       currentNodeID,
 		CurrentAction:       currentAction,
+		CurrentSegmentID:    currentSegmentID,
 		GraphID:             graphID,
 		RuntimeData:         &runtimeData,
 		ExecutionHistory:    &executionHistory,

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -948,3 +948,119 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 		})
 	}
 }
+
+func (s *ModelTestSuite) TestFromEngineContext_WithCurrentSegmentID() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id")
+
+	ctx := EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "test-exec-id",
+		FlowType:         common.FlowTypeAuthentication,
+		CurrentSegmentID: "seg-1",
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            mockGraph,
+	}
+
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+
+	content := s.getContextContent(dbModel)
+	s.NotNil(content.CurrentSegmentID)
+	s.Equal("seg-1", *content.CurrentSegmentID)
+}
+
+func (s *ModelTestSuite) TestFromEngineContext_EmptyCurrentSegmentID_OmitsField() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id")
+
+	ctx := EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "test-exec-id",
+		FlowType:         common.FlowTypeAuthentication,
+		CurrentSegmentID: "",
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            mockGraph,
+	}
+
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+
+	content := s.getContextContent(dbModel)
+	s.Nil(content.CurrentSegmentID)
+}
+
+func (s *ModelTestSuite) TestToEngineContext_WithCurrentSegmentID() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
+
+	segID := "seg-1"
+	content := flowContextContent{
+		GraphID:          "test-graph-id",
+		CurrentSegmentID: &segID,
+		UserInputs:       func() *string { v := `{}`; return &v }(),
+		RuntimeData:      func() *string { v := `{}`; return &v }(),
+		ExecutionHistory: func() *string { v := `{}`; return &v }(),
+	}
+	ctxJSON, _ := json.Marshal(content)
+	dbModel := &FlowContextDB{
+		ExecutionID: "test-exec-id",
+		Context:     string(ctxJSON),
+	}
+
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
+
+	s.NoError(err)
+	s.Equal("seg-1", resultCtx.CurrentSegmentID)
+}
+
+func (s *ModelTestSuite) TestToEngineContext_MissingCurrentSegmentID_IsEmpty() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
+
+	content := flowContextContent{
+		GraphID:          "test-graph-id",
+		CurrentSegmentID: nil,
+		UserInputs:       func() *string { v := `{}`; return &v }(),
+		RuntimeData:      func() *string { v := `{}`; return &v }(),
+		ExecutionHistory: func() *string { v := `{}`; return &v }(),
+	}
+	ctxJSON, _ := json.Marshal(content)
+	dbModel := &FlowContextDB{
+		ExecutionID: "test-exec-id",
+		Context:     string(ctxJSON),
+	}
+
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
+
+	s.NoError(err)
+	s.Equal("", resultCtx.CurrentSegmentID)
+}
+
+func (s *ModelTestSuite) TestCurrentSegmentID_RoundTrip() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id")
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
+
+	ctx := EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "test-exec-id",
+		FlowType:         common.FlowTypeAuthentication,
+		CurrentSegmentID: "seg-2",
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            mockGraph,
+	}
+
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+
+	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
+	s.NoError(err)
+	s.Equal("seg-2", resultCtx.CurrentSegmentID)
+}

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -117,8 +117,9 @@ func (b *graphBuilder) buildGraph(flow *CompleteFlowDefinition) (core.GraphInter
 
 	// Process all nodes and build the graph structure
 	edges := make(map[string][]string)
+	boundaries := make([]segmentBoundary, 0)
 	for i := range flow.Nodes {
-		if err := b.processNode(&flow.Nodes[i], flow.Nodes, graph, edges); err != nil {
+		if err := b.processNode(&flow.Nodes[i], flow.Nodes, graph, edges, &boundaries); err != nil {
 			return nil, fmt.Errorf("failed to process node %s: %w", flow.Nodes[i].ID, err)
 		}
 	}
@@ -131,12 +132,14 @@ func (b *graphBuilder) buildGraph(flow *CompleteFlowDefinition) (core.GraphInter
 		return nil, err
 	}
 
+	b.computeSegments(graph, boundaries)
+
 	return graph, nil
 }
 
 // processNode processes a single node definition and adds it to the graph.
 func (b *graphBuilder) processNode(nodeDef *NodeDefinition, allNodes []NodeDefinition,
-	graph core.GraphInterface, edges map[string][]string) error {
+	graph core.GraphInterface, edges map[string][]string, boundaries *[]segmentBoundary) error {
 	isFinalNode := nodeDef.OnSuccess == "" &&
 		nodeDef.OnFailure == "" &&
 		len(nodeDef.Prompts) == 0 &&
@@ -160,7 +163,7 @@ func (b *graphBuilder) processNode(nodeDef *NodeDefinition, allNodes []NodeDefin
 	if err := b.configureNodePrompts(nodeDef, node, edges); err != nil {
 		return err
 	}
-	if err := b.configureDisplayOnlyProperties(nodeDef, node, edges); err != nil {
+	if err := b.configureDisplayOnlyProperties(nodeDef, node, edges, boundaries); err != nil {
 		return err
 	}
 	if err := b.configureNodeExecutor(nodeDef, node); err != nil {
@@ -356,8 +359,9 @@ func (b *graphBuilder) configureNodePrompts(nodeDef *NodeDefinition, node core.N
 }
 
 // configureDisplayOnlyProperties configures the 'next' and 'message' fields for display-only prompt nodes.
+// It also records segment boundaries for later segment computation.
 func (b *graphBuilder) configureDisplayOnlyProperties(nodeDef *NodeDefinition, node core.NodeInterface,
-	edges map[string][]string) error {
+	edges map[string][]string, boundaries *[]segmentBoundary) error {
 	logger := b.logger.With(log.String("nodeID", nodeDef.ID))
 
 	if nodeDef.Next == "" {
@@ -387,7 +391,41 @@ func (b *graphBuilder) configureDisplayOnlyProperties(nodeDef *NodeDefinition, n
 	}
 	edges[nodeDef.ID] = append(edges[nodeDef.ID], nodeDef.Next)
 
+	if boundaries != nil {
+		*boundaries = append(*boundaries, segmentBoundary{
+			boundaryNodeID: nodeDef.ID,
+			nextNodeID:     nodeDef.Next,
+		})
+	}
+
 	return nil
+}
+
+// computeSegments builds the segments slice from detected display-only prompt boundaries.
+// Segment 0 starts at the graph start node; each boundary yields a subsequent segment
+// starting at the boundary's next node.
+func (b *graphBuilder) computeSegments(g core.GraphInterface, boundaries []segmentBoundary) {
+	if len(boundaries) == 0 {
+		return
+	}
+
+	startNode, err := g.GetStartNode()
+	if err != nil {
+		return
+	}
+
+	segments := make([]core.Segment, 0, len(boundaries)+1)
+	segments = append(segments, core.Segment{
+		ID:          "seg-0",
+		StartNodeID: startNode.GetID(),
+	})
+	for i, bnd := range boundaries {
+		segments = append(segments, core.Segment{
+			ID:          fmt.Sprintf("seg-%d", i+1),
+			StartNodeID: bnd.nextNodeID,
+		})
+	}
+	g.SetSegments(segments)
 }
 
 // configureNodeExecutor configures the executor for a node.

--- a/backend/internal/flow/mgt/graph_builder_test.go
+++ b/backend/internal/flow/mgt/graph_builder_test.go
@@ -1138,7 +1138,7 @@ func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_NoNextNodeDef
 
 	edges := map[string][]string{}
 
-	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges)
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, nil)
 
 	s.Nil(err)
 	// SetNextNode should not be called
@@ -1157,7 +1157,7 @@ func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_WithNextNode(
 
 	edges := map[string][]string{}
 
-	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges)
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, nil)
 
 	s.Nil(err)
 	// Verify edge is added
@@ -1180,7 +1180,7 @@ func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_WithMessage()
 
 	edges := map[string][]string{}
 
-	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges)
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, nil)
 
 	s.Nil(err)
 	s.Len(edges["prompt-1"], 1)
@@ -1199,7 +1199,7 @@ func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_OnNonPromptNo
 
 	edges := map[string][]string{}
 
-	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockTaskNode, edges)
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockTaskNode, edges, nil)
 
 	s.NotNil(err)
 	s.Contains(err.Error(), "'next' field is only valid on PROMPT nodes")
@@ -1224,7 +1224,7 @@ func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_WithPromptsCo
 
 	edges := map[string][]string{}
 
-	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges)
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, nil)
 
 	s.NotNil(err)
 	s.Contains(err.Error(), "has both 'prompts' and 'next'; these are mutually exclusive")
@@ -1255,7 +1255,7 @@ func (s *GraphBuilderTestSuite) TestProcessNode_IsFinalNode_WithNextField() {
 	allNodes := []NodeDefinition{*nodeDef}
 	edges := map[string][]string{}
 
-	err := s.builder.processNode(nodeDef, allNodes, mockGraph, edges)
+	err := s.builder.processNode(nodeDef, allNodes, mockGraph, edges, nil)
 
 	s.Nil(err)
 }
@@ -1336,4 +1336,111 @@ func (s *GraphBuilderTestSuite) TestConfigureNodePrompts_WithMultipleActionsWith
 	err := s.builder.configureNodePrompts(nodeDef, mockPromptNode, edges)
 
 	s.Nil(err)
+}
+
+func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_RecordsBoundary() {
+	t := s.T()
+	nodeDef := &NodeDefinition{
+		ID:   "prompt-1",
+		Type: "PROMPT",
+		Next: "task-1",
+	}
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(t)
+	mockPromptNode.EXPECT().SetNextNode("task-1")
+
+	edges := map[string][]string{}
+	boundaries := make([]segmentBoundary, 0)
+
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, &boundaries)
+
+	s.Nil(err)
+	s.Len(boundaries, 1)
+	s.Equal("prompt-1", boundaries[0].boundaryNodeID)
+	s.Equal("task-1", boundaries[0].nextNodeID)
+}
+
+func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_RecordsMultipleBoundaries() {
+	t := s.T()
+	edges := map[string][]string{}
+	boundaries := make([]segmentBoundary, 0)
+
+	for _, tc := range []struct{ id, next string }{
+		{"prompt-1", "task-1"},
+		{"prompt-2", "task-2"},
+	} {
+		nodeDef := &NodeDefinition{ID: tc.id, Type: "PROMPT", Next: tc.next}
+		mockPN := coremock.NewPromptNodeInterfaceMock(t)
+		mockPN.EXPECT().SetNextNode(tc.next)
+		err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPN, edges, &boundaries)
+		s.Nil(err)
+	}
+
+	s.Len(boundaries, 2)
+	s.Equal("prompt-1", boundaries[0].boundaryNodeID)
+	s.Equal("prompt-2", boundaries[1].boundaryNodeID)
+}
+
+func (s *GraphBuilderTestSuite) TestConfigureDisplayOnlyProperties_NilBoundariesDoesNotPanic() {
+	t := s.T()
+	nodeDef := &NodeDefinition{ID: "prompt-1", Type: "PROMPT", Next: "task-1"}
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(t)
+	mockPromptNode.EXPECT().SetNextNode("task-1")
+
+	edges := map[string][]string{}
+
+	// nil boundaries must not panic
+	err := s.builder.configureDisplayOnlyProperties(nodeDef, mockPromptNode, edges, nil)
+	s.Nil(err)
+}
+
+func (s *GraphBuilderTestSuite) TestComputeSegments_NoBoundaries() {
+	// computeSegments returns early with no boundaries; SetSegments/GetStartNode must NOT be called
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+
+	s.builder.computeSegments(mockGraph, []segmentBoundary{})
+}
+
+func (s *GraphBuilderTestSuite) TestComputeSegments_OneBoundary() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockStartNode := coremock.NewNodeInterfaceMock(t)
+	mockStartNode.On("GetID").Return("node-start")
+	mockGraph.On("GetStartNode").Return(mockStartNode, nil)
+	mockGraph.On("SetSegments", []core.Segment{
+		{ID: "seg-0", StartNodeID: "node-start"},
+		{ID: "seg-1", StartNodeID: "node-task"},
+	}).Return()
+
+	s.builder.computeSegments(mockGraph, []segmentBoundary{
+		{boundaryNodeID: "node-prompt", nextNodeID: "node-task"},
+	})
+}
+
+func (s *GraphBuilderTestSuite) TestComputeSegments_TwoBoundaries() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockStartNode := coremock.NewNodeInterfaceMock(t)
+	mockStartNode.On("GetID").Return("node-start")
+	mockGraph.On("GetStartNode").Return(mockStartNode, nil)
+	mockGraph.On("SetSegments", []core.Segment{
+		{ID: "seg-0", StartNodeID: "node-start"},
+		{ID: "seg-1", StartNodeID: "node-task-1"},
+		{ID: "seg-2", StartNodeID: "node-task-2"},
+	}).Return()
+
+	s.builder.computeSegments(mockGraph, []segmentBoundary{
+		{boundaryNodeID: "node-prompt-1", nextNodeID: "node-task-1"},
+		{boundaryNodeID: "node-prompt-2", nextNodeID: "node-task-2"},
+	})
+}
+
+func (s *GraphBuilderTestSuite) TestComputeSegments_GetStartNodeFails() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetStartNode").Return(nil, errors.New("start node not set"))
+
+	// SetSegments must NOT be called when GetStartNode fails
+	s.builder.computeSegments(mockGraph, []segmentBoundary{
+		{boundaryNodeID: "prompt", nextNodeID: "task"},
+	})
 }

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -256,3 +256,11 @@ type updateFlowInput struct {
 	Name  string           `json:"name" jsonschema:"Display name for the flow. Required for PUT."`
 	Nodes []NodeDefinition `json:"nodes" jsonschema:"Array of nodes defining the flow steps. Required for PUT."`
 }
+
+// segmentBoundary holds the parameters of a segment boundary, which is identified by a display-only prompt node.
+// It contains the ID of the display-only prompt node that serves as the boundary, and the ID of the next node
+// which is the start node of the next segment.
+type segmentBoundary struct {
+	boundaryNodeID string
+	nextNodeID     string
+}

--- a/backend/tests/mocks/flow/coremock/GraphInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/GraphInterface_mock.go
@@ -343,6 +343,158 @@ func (_c *GraphInterfaceMock_GetNodes_Call) RunAndReturn(run func() map[string]c
 	return _c
 }
 
+// GetSegmentByID provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegmentByID(segmentID string) *core.Segment {
+	ret := _mock.Called(segmentID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegmentByID")
+	}
+
+	var r0 *core.Segment
+	if returnFunc, ok := ret.Get(0).(func(string) *core.Segment); ok {
+		r0 = returnFunc(segmentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegmentByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegmentByID'
+type GraphInterfaceMock_GetSegmentByID_Call struct {
+	*mock.Call
+}
+
+// GetSegmentByID is a helper method to define mock.On call
+//   - segmentID string
+func (_e *GraphInterfaceMock_Expecter) GetSegmentByID(segmentID interface{}) *GraphInterfaceMock_GetSegmentByID_Call {
+	return &GraphInterfaceMock_GetSegmentByID_Call{Call: _e.mock.On("GetSegmentByID", segmentID)}
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) Run(run func(segmentID string)) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) Return(segment *core.Segment) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Return(segment)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByID_Call) RunAndReturn(run func(segmentID string) *core.Segment) *GraphInterfaceMock_GetSegmentByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSegmentByStartNode provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegmentByStartNode(nodeID string) *core.Segment {
+	ret := _mock.Called(nodeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegmentByStartNode")
+	}
+
+	var r0 *core.Segment
+	if returnFunc, ok := ret.Get(0).(func(string) *core.Segment); ok {
+		r0 = returnFunc(nodeID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegmentByStartNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegmentByStartNode'
+type GraphInterfaceMock_GetSegmentByStartNode_Call struct {
+	*mock.Call
+}
+
+// GetSegmentByStartNode is a helper method to define mock.On call
+//   - nodeID string
+func (_e *GraphInterfaceMock_Expecter) GetSegmentByStartNode(nodeID interface{}) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	return &GraphInterfaceMock_GetSegmentByStartNode_Call{Call: _e.mock.On("GetSegmentByStartNode", nodeID)}
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) Run(run func(nodeID string)) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) Return(segment *core.Segment) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Return(segment)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegmentByStartNode_Call) RunAndReturn(run func(nodeID string) *core.Segment) *GraphInterfaceMock_GetSegmentByStartNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetSegments() []core.Segment {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSegments")
+	}
+
+	var r0 []core.Segment
+	if returnFunc, ok := ret.Get(0).(func() []core.Segment); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core.Segment)
+		}
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSegments'
+type GraphInterfaceMock_GetSegments_Call struct {
+	*mock.Call
+}
+
+// GetSegments is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) GetSegments() *GraphInterfaceMock_GetSegments_Call {
+	return &GraphInterfaceMock_GetSegments_Call{Call: _e.mock.On("GetSegments")}
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) Run(run func()) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) Return(segments []core.Segment) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Return(segments)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetSegments_Call) RunAndReturn(run func() []core.Segment) *GraphInterfaceMock_GetSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStartNode provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) GetStartNode() (core.NodeInterface, error) {
 	ret := _mock.Called()
@@ -486,6 +638,50 @@ func (_c *GraphInterfaceMock_GetType_Call) RunAndReturn(run func() common.FlowTy
 	return _c
 }
 
+// HasSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) HasSegments() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasSegments")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// GraphInterfaceMock_HasSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasSegments'
+type GraphInterfaceMock_HasSegments_Call struct {
+	*mock.Call
+}
+
+// HasSegments is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) HasSegments() *GraphInterfaceMock_HasSegments_Call {
+	return &GraphInterfaceMock_HasSegments_Call{Call: _e.mock.On("HasSegments")}
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) Run(run func()) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) Return(b bool) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_HasSegments_Call) RunAndReturn(run func() bool) *GraphInterfaceMock_HasSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveEdge provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) RemoveEdge(fromNodeID string, toNodeID string) error {
 	ret := _mock.Called(fromNodeID, toNodeID)
@@ -619,6 +815,46 @@ func (_c *GraphInterfaceMock_SetNodes_Call) Return() *GraphInterfaceMock_SetNode
 }
 
 func (_c *GraphInterfaceMock_SetNodes_Call) RunAndReturn(run func(nodes map[string]core.NodeInterface)) *GraphInterfaceMock_SetNodes_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetSegments provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) SetSegments(segments []core.Segment) {
+	_mock.Called(segments)
+	return
+}
+
+// GraphInterfaceMock_SetSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetSegments'
+type GraphInterfaceMock_SetSegments_Call struct {
+	*mock.Call
+}
+
+// SetSegments is a helper method to define mock.On call
+//   - segments []core.Segment
+func (_e *GraphInterfaceMock_Expecter) SetSegments(segments interface{}) *GraphInterfaceMock_SetSegments_Call {
+	return &GraphInterfaceMock_SetSegments_Call{Call: _e.mock.On("SetSegments", segments)}
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) Run(run func(segments []core.Segment)) *GraphInterfaceMock_SetSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []core.Segment
+		if args[0] != nil {
+			arg0 = args[0].([]core.Segment)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) Return() *GraphInterfaceMock_SetSegments_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetSegments_Call) RunAndReturn(run func(segments []core.Segment)) *GraphInterfaceMock_SetSegments_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request introduces support for runtime flow graph segmentation, allowing a flow to be divided into multiple segments and enabling policies such as allowing segment restarts. The changes add a `Segment` type, extend the `GraphInterface` with segment-related methods, implement these methods in the `graph` struct, and update the flow execution engine to respect segment boundaries and policies. Comprehensive unit tests are included to verify the new segment logic.

This also fixes the invite flow retry issue where the challenge token improvement doesn't allow invite flow to be retried by clicking on the invite link again.

### Approach
**Graph Segmentation Support**

* Added a `Segment` struct to represent a section of a flow graph, and extended `GraphInterface` with methods for segment management: `HasSegments`, `GetSegments`, `SetSegments`, `GetSegmentByID`, and `GetSegmentByStartNode`.
* Implemented segment management methods in the `graph` struct, including logic for checking, retrieving, and setting segments.

**Flow Execution Engine Enhancements**

* Modified the flow execution engine to set and use the current segment, and to skip challenge token validation when resuming within a segment that allows restarts. This is controlled by the new `AllowSegmentRestart` field in `ExecutionPolicy`.
* Refactored `setCurrentExecutionNode` to simplify its return value and align with the new segment logic.

**Policy and Executor Updates**

* Added the `AllowSegmentRestart` field to `ExecutionPolicy` and updated the invite executor to set this policy in verify mode.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2383

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
