### PR TITLE
Add private key jwt to application api

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -1126,7 +1126,7 @@ components:
           example: ["code"]
         tokenEndpointAuthMethod:
           type: string
-          enum: ["client_secret_basic", "client_secret_post", "none"]
+          enum: ["client_secret_basic", "client_secret_post", "private_key_jwt", "none"]
           description: The token endpoint authentication method for the OAuth application. Defaults to "client_secret_basic" if not specified.
           example: "client_secret_basic"
         pkceRequired:
@@ -1199,7 +1199,7 @@ components:
           example: ["code"]
         tokenEndpointAuthMethod:
           type: string
-          enum: ["client_secret_basic", "client_secret_post", "none"]
+          enum: ["client_secret_basic", "client_secret_post", "private_key_jwt", "none"]
           description: The token endpoint authentication method for the OAuth application. Defaults to "client_secret_basic" if not specified.
           example: "client_secret_basic"
         pkceRequired:


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth applications now support the private_key_jwt authentication method for token endpoint authentication, expanding configuration options alongside existing methods (client_secret_basic, client_secret_post, none). This change is limited to adding the new method option; no other configuration fields, request/response structures, or defaults were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->