### PR TITLE
Initiate new sign-in from SignUpBox component

### DIFF
--- a/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
@@ -27,19 +27,17 @@ import {Box, Button, Alert, Typography, AlertTitle, CircularProgress} from '@wso
 import type {JSX} from 'react';
 import {useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
-import {useNavigate, useSearchParams} from 'react-router';
+import {useNavigate} from 'react-router';
 import ROUTES from '../../constants/routes';
 
 export default function SignUpBox(): JSX.Element {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const {resolveFlowTemplateLiterals: resolve} = useAsgardeo();
   const {t} = useTranslation();
   const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);
 
-  const currentParams = searchParams.toString();
-  const signInUrl = currentParams ? `${ROUTES.AUTH.SIGN_IN}?${currentParams}` : ROUTES.AUTH.SIGN_IN;
+  const signInUrl = ROUTES.AUTH.SIGN_IN;
 
   const renderFlowContent = (
     components: EmbeddedFlowComponent[],


### PR DESCRIPTION
### Purpose
This pull request simplifies the `SignUpBox` component by removing the use of search parameters from the sign-in URL. This makes the code easier to maintain and reduces unnecessary complexity.

- **Code Simplification:**
  * Removed the import and usage of `useSearchParams` from `react-router` and the related logic that appended search parameters to the sign-in URL in `SignUpBox.tsx`. The sign-in URL is now always `ROUTES.AUTH.SIGN_IN`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
