### PR TITLE
Drive provisioning inputs from user schema

### DIFF
--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
@@ -162,97 +162,7 @@
             "executor": {
                 "name": "BasicAuthExecutor"
             },
-            "onSuccess": "prompt_user_info"
-        },
-        {
-            "id": "prompt_user_info",
-            "type": "PROMPT",
-            "meta": {
-                "components": [
-                    {
-                        "alt": "{{ t(signup:images.app_logo.alt) }}",
-                        "category": "DISPLAY",
-                        "height": "60",
-                        "id": "image",
-                        "resourceType": "ELEMENT",
-                        "src": "{{ meta(application.logoUrl) }}",
-                        "type": "IMAGE",
-                        "width": ""
-                    },
-                    {
-                        "align": "center",
-                        "type": "TEXT",
-                        "id": "heading_user_info",
-                        "label": "{{ t(signup:forms.user_info.title) }}",
-                        "variant": "HEADING_1"
-                    },
-                    {
-                        "type": "BLOCK",
-                        "id": "block_user_info",
-                        "components": [
-                            {
-                                "type": "TEXT_INPUT",
-                                "id": "input_given_name",
-                                "ref": "given_name",
-                                "label": "{{ t(signup:forms.user_info.fields.first_name.label) }}",
-                                "placeholder": "{{ t(signup:forms.user_info.fields.first_name.placeholder) }}",
-                                "required": true
-                            },
-                            {
-                                "type": "TEXT_INPUT",
-                                "id": "input_family_name",
-                                "ref": "family_name",
-                                "label": "{{ t(signup:forms.user_info.fields.last_name.label) }}",
-                                "placeholder": "{{ t(signup:forms.user_info.fields.last_name.placeholder) }}",
-                                "required": true
-                            },
-                            {
-                                "type": "EMAIL_INPUT",
-                                "id": "input_email",
-                                "ref": "email",
-                                "label": "{{ t(signup:forms.user_info.fields.email_address.label) }}",
-                                "placeholder": "{{ t(signup:forms.user_info.fields.email_address.placeholder) }}",
-                                "required": true
-                            },
-                            {
-                                "type": "ACTION",
-                                "id": "action_user_info",
-                                "label": "{{ t(signup:forms.user_info.actions.submit.label) }}",
-                                "variant": "PRIMARY",
-                                "eventType": "SUBMIT"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "prompts": [
-                {
-                    "inputs": [
-                        {
-                            "ref": "input_given_name",
-                            "identifier": "given_name",
-                            "type": "TEXT_INPUT",
-                            "required": true
-                        },
-                        {
-                            "ref": "input_family_name",
-                            "identifier": "family_name",
-                            "type": "TEXT_INPUT",
-                            "required": true
-                        },
-                        {
-                            "ref": "input_email",
-                            "identifier": "email",
-                            "type": "EMAIL_INPUT",
-                            "required": true
-                        }
-                    ],
-                    "action": {
-                        "ref": "action_user_info",
-                        "nextNode": "provisioning"
-                    }
-                }
-            ]
+            "onSuccess": "provisioning"
         },
         {
             "id": "provisioning",
@@ -271,28 +181,62 @@
                         "identifier": "password",
                         "type": "PASSWORD_INPUT",
                         "required": true
-                    },
-                    {
-                        "ref": "input_003",
-                        "identifier": "given_name",
-                        "type": "TEXT_INPUT",
-                        "required": true
-                    },
-                    {
-                        "ref": "input_004",
-                        "identifier": "family_name",
-                        "type": "TEXT_INPUT",
-                        "required": true
-                    },
-                    {
-                        "ref": "input_005",
-                        "identifier": "email",
-                        "type": "EMAIL_INPUT",
-                        "required": true
                     }
                 ]
             },
-            "onSuccess": "auth_assert"
+            "onSuccess": "auth_assert",
+            "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+            "id": "prompt_schema_attrs",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "alt": "{{ t(signup:images.app_logo.alt) }}",
+                        "category": "DISPLAY",
+                        "height": "60",
+                        "id": "image",
+                        "resourceType": "ELEMENT",
+                        "src": "{{ meta(application.logoUrl) }}",
+                        "type": "IMAGE",
+                        "width": ""
+                    },
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "heading_schema_attrs",
+                        "label": "{{ t(signup:forms.user_info.title) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_dynamic_user_inputs",
+                        "components": [
+                            {
+                                "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                                "id": "dynamic_inputs"
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_schema_attrs",
+                                "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [],
+                    "action": {
+                        "ref": "action_schema_attrs",
+                        "nextNode": "provisioning"
+                    }
+                }
+            ]
         },
         {
             "id": "auth_assert",

--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -147,6 +147,7 @@
       "forms.user_info.fields.email_address.label": "Email Address",
       "forms.user_info.fields.email_address.placeholder": "Enter your email address",
       "forms.user_info.actions.submit.label": "Sign Up",
+      "forms.user_info.actions.continue.label": "Continue",
       "forms.registration.title": "Sign Up",
       "forms.registration.fields.username.label": "Username",
       "forms.registration.fields.username.placeholder": "Enter your username",

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -215,12 +215,25 @@ const (
 	InputTypePhone = "PHONE_INPUT"
 	// InputTypeConsent represents a consent decisions input type.
 	InputTypeConsent = "CONSENT_INPUT"
+	// InputTypeSelect represents a select (dropdown) input type.
+	InputTypeSelect = "SELECT"
 
 	// TODO: Add support for other sensitive input types:
 	// - Passkey credential fields (credentialId, clientDataJSON, authenticatorData, signature, userHandle)
 	// - OAuth/OIDC authorization codes
 	// - OIDC nonce
 	// - Invite tokens
+)
+
+// MetaComponentType constants define known component types used in flow meta definitions.
+const (
+	// MetaComponentTypeBlock represents a block container component.
+	MetaComponentTypeBlock = "BLOCK"
+	// MetaComponentTypeAction represents an action (button) component.
+	MetaComponentTypeAction = "ACTION"
+	// MetaComponentTypeDynamicInputPlaceholder marks the insertion point for dynamically
+	// derived input components. The renderer replaces this component with the resolved inputs.
+	MetaComponentTypeDynamicInputPlaceholder = "DYNAMIC_INPUT_PLACEHOLDER"
 )
 
 // Attribute name constants for well-known user attributes used across flow executors.

--- a/backend/internal/flow/common/model.go
+++ b/backend/internal/flow/common/model.go
@@ -27,11 +27,12 @@ import (
 
 // Input represents the inputs required for a node
 type Input struct {
-	Ref        string   `json:"ref,omitempty"`
-	Identifier string   `json:"identifier"`
-	Type       string   `json:"type"`
-	Required   bool     `json:"required"`
-	Options    []string `json:"options,omitempty"`
+	Ref         string   `json:"ref,omitempty"`
+	Identifier  string   `json:"identifier"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Options     []string `json:"options,omitempty"`
+	DisplayName string   `json:"-"`
 }
 
 // IsSensitive checks whether this input's type is considered sensitive.

--- a/backend/internal/flow/common/model_test.go
+++ b/backend/internal/flow/common/model_test.go
@@ -75,6 +75,30 @@ func (s *ModelTestSuite) TestInput_IsSensitive() {
 	}
 }
 
+func (s *ModelTestSuite) TestInput_DisplayName_ExcludedFromJSON() {
+	input := Input{
+		Ref:         "ref_email",
+		Identifier:  "email",
+		Type:        InputTypeText,
+		Required:    true,
+		DisplayName: "Email Address",
+	}
+
+	data, err := json.Marshal(input)
+	s.Require().NoError(err)
+
+	jsonStr := string(data)
+	s.NotContains(jsonStr, "DisplayName", "DisplayName field name must not appear in JSON")
+	s.NotContains(jsonStr, "displayName", "displayName key must not appear in JSON")
+	s.NotContains(jsonStr, "Email Address", "DisplayName value must not appear in JSON")
+	s.Contains(jsonStr, "email", "Identifier must still be serialized")
+
+	var decoded Input
+	s.Require().NoError(json.Unmarshal(data, &decoded))
+	s.Equal("", decoded.DisplayName, "DisplayName must remain empty after unmarshalling")
+	s.Equal("email", decoded.Identifier)
+}
+
 func (s *ModelTestSuite) TestExecutionAttempt_GetDuration() {
 	tests := []struct {
 		name      string

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -294,7 +294,13 @@ func (g *graph) ToJSON() (string, error) {
 			if len(inputs) > 0 {
 				jsonNode.Inputs = make([]JSONInputs, len(inputs))
 				for i, input := range inputs {
-					jsonNode.Inputs[i] = JSONInputs(input)
+					jsonNode.Inputs[i] = JSONInputs{
+						Ref:        input.Ref,
+						Identifier: input.Identifier,
+						Type:       input.Type,
+						Required:   input.Required,
+						Options:    input.Options,
+					}
 				}
 			}
 		}

--- a/backend/internal/flow/core/graph_test.go
+++ b/backend/internal/flow/core/graph_test.go
@@ -382,7 +382,10 @@ func (s *GraphTestSuite) TestToJSON() {
 
 	if execNode, ok := node1.(ExecutorBackedNodeInterface); ok {
 		execNode.SetExecutorName("test-executor")
-		execNode.SetInputs([]common.Input{{Identifier: "username", Type: "string", Required: true}})
+		execNode.SetInputs([]common.Input{
+			{Identifier: "username", Type: "string", Required: true,
+				DisplayName: "User Name"},
+		})
 	}
 
 	_ = s.graph.AddNode(node1)
@@ -399,4 +402,6 @@ func (s *GraphTestSuite) TestToJSON() {
 	s.Contains(jsonStr, "node-2")
 	s.Contains(jsonStr, "test-executor")
 	s.Contains(jsonStr, "username")
+	s.NotContains(jsonStr, "displayName", "DisplayName must not appear in serialized graph JSON")
+	s.NotContains(jsonStr, "User Name", "DisplayName value must not appear in serialized graph JSON")
 }

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -146,7 +146,8 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 
 	// Include meta in the response if verbose mode is enabled
 	if ctx.Verbose && n.GetMeta() != nil {
-		nodeResp.Meta = n.trimMetaToRequestedInputs(nodeResp.Inputs, nodeResp.Actions)
+		trimmed := n.trimMetaToRequestedInputs(nodeResp.Inputs, nodeResp.Actions)
+		nodeResp.Meta = n.appendSyntheticMetaComponents(trimmed, nodeResp.Inputs)
 	}
 
 	nodeResp.Status = common.NodeStatusIncomplete
@@ -208,8 +209,13 @@ func (n *promptNode) resolvePromptInputs(ctx *NodeContext, nodeResp *common.Node
 	// Check for required inputs and collect missing ones
 	hasAllInputs := n.hasRequiredInputs(ctx, nodeResp)
 
-	// Enrich inputs from ForwardedData
+	// Enrich inputs from ForwardedData — may append dynamically derived inputs not in node prompts.
+	// If any new inputs are added they are unsatisfied by definition, so the node is incomplete.
+	prevCount := len(nodeResp.Inputs)
 	n.enrichInputsFromForwardedData(ctx, nodeResp)
+	if len(nodeResp.Inputs) > prevCount {
+		hasAllInputs = false
+	}
 
 	// Check for action selection
 	hasAction := n.hasSelectedAction(ctx, nodeResp)
@@ -285,43 +291,66 @@ func (n *promptNode) appendMissingInputs(ctx *NodeContext, nodeResp *common.Node
 }
 
 // enrichInputsFromForwardedData enriches the inputs in the node response with dynamic data
-// from ForwardedData. Currently only enriches Options for inputs that match by Identifier.
+// from ForwardedData. Inputs present in ForwardedData but absent from the node response are
+// appended (dynamically derived inputs). Options are propagated for all matched inputs.
 func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *common.NodeResponse) {
-	if ctx.ForwardedData == nil || len(nodeResp.Inputs) == 0 {
+	if ctx.ForwardedData == nil {
 		return
 	}
 
-	// Check if ForwardedData contains inputs
+	// Check if ForwardedData contains inputs.
 	forwardedInputsData, ok := ctx.ForwardedData[common.ForwardedDataKeyInputs]
 	if !ok {
 		return
 	}
 
-	// Type assert to []common.Input
+	// Type assert to []common.Input.
 	forwardedInputs, ok := forwardedInputsData.([]common.Input)
 	if !ok {
 		n.logger.Debug("ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
 		return
 	}
 
-	// Build a map of forwarded inputs by Identifier for quick lookup
-	forwardedInputMap := make(map[string]common.Input)
-	for _, fwdInput := range forwardedInputs {
-		forwardedInputMap[fwdInput.Identifier] = fwdInput
+	// Build an index map of identifiers already in the response for O(1) lookup and in-place update.
+	existingIndexMap := make(map[string]int, len(nodeResp.Inputs))
+	for i, inp := range nodeResp.Inputs {
+		existingIndexMap[inp.Identifier] = i
 	}
 
-	// Enrich each prompt input with data from matching forwarded input
-	for i := range nodeResp.Inputs {
-		if fwdInput, found := forwardedInputMap[nodeResp.Inputs[i].Identifier]; found {
-			// Only enrich Options for SELECT-type inputs to avoid leaking
-			// candidate attribute values in free-text input responses.
-			if len(fwdInput.Options) > 0 && nodeResp.Inputs[i].Type == "SELECT" {
-				nodeResp.Inputs[i].Options = fwdInput.Options
+	// Single pass: upsert forwarded inputs — replace existing entries (updating required/options)
+	// or append dynamically derived inputs not yet satisfied by the user.
+	for _, fwdInput := range forwardedInputs {
+		if idx, exists := existingIndexMap[fwdInput.Identifier]; exists {
+			if fwdInput.Required && !nodeResp.Inputs[idx].Required {
+				nodeResp.Inputs[idx].Required = true
+				n.logger.Debug("Updated input required flag from ForwardedData",
+					log.String("identifier", fwdInput.Identifier))
+			}
+			if fwdInput.Type == common.InputTypeSelect &&
+				nodeResp.Inputs[idx].Type == common.InputTypeSelect &&
+				len(fwdInput.Options) > 0 {
+				nodeResp.Inputs[idx].Options = fwdInput.Options
 				n.logger.Debug("Enriched input with options from ForwardedData",
-					log.String("identifier", nodeResp.Inputs[i].Identifier),
+					log.String("identifier", fwdInput.Identifier),
 					log.Int("optionsCount", len(fwdInput.Options)))
 			}
+			continue
 		}
+		if _, ok := ctx.UserInputs[fwdInput.Identifier]; ok {
+			continue
+		}
+		if _, ok := ctx.RuntimeData[fwdInput.Identifier]; ok {
+			continue
+		}
+		if value, ok := ctx.ForwardedData[fwdInput.Identifier]; ok {
+			if _, isString := value.(string); isString {
+				continue
+			}
+		}
+		nodeResp.Inputs = append(nodeResp.Inputs, fwdInput)
+		existingIndexMap[fwdInput.Identifier] = len(nodeResp.Inputs) - 1
+		n.logger.Debug("Added dynamically-derived input from ForwardedData",
+			log.String("identifier", fwdInput.Identifier))
 	}
 }
 
@@ -498,4 +527,182 @@ func filterMetaComponents(comps []interface{}, allowedRefs, knownInputActionRefs
 		result = append(result, comp)
 	}
 	return result
+}
+
+// appendSyntheticMetaComponents ensures every input in the list has a corresponding meta
+// component. For inputs whose component already exists (matched by ref or id), the required
+// field is updated in-place if the input marks it required. For inputs with no existing
+// component, a minimal synthetic component is created and inserted into the first BLOCK
+// before any ACTION. If no BLOCK exists, a new one is appended.
+// The label uses DisplayName when set, falling back to Identifier.
+func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inputs []common.Input) interface{} {
+	metaMap, ok := trimmedMeta.(map[string]interface{})
+	if !ok {
+		return trimmedMeta
+	}
+
+	// Build a set of refs/ids from the node's own configured prompt inputs —
+	// used to suppress synthesis for node-defined inputs with no meta component.
+	nodeInputRefs := make(map[string]struct{})
+	for _, inp := range n.getAllInputs() {
+		if inp.Ref != "" {
+			nodeInputRefs[inp.Ref] = struct{}{}
+		}
+		nodeInputRefs[inp.Identifier] = struct{}{}
+	}
+
+	// Build ref/id → component map for O(1) lookup and in-place required update.
+	metaCompByRef := make(map[string]map[string]interface{})
+	collectMetaComponentMap(metaMap["components"], metaCompByRef)
+
+	// Single pass: update required on existing components; collect synthetic for missing ones.
+	// For each input, try to find its meta component by Identifier first, then by Ref.
+	// Node-configured inputs with no meta component are skipped (no synthesis).
+	synthetic := make([]interface{}, 0, len(inputs))
+	for _, input := range inputs {
+		comp, inMeta := metaCompByRef[input.Identifier]
+		if !inMeta && input.Ref != "" {
+			comp, inMeta = metaCompByRef[input.Ref]
+		}
+		if inMeta {
+			if input.Required {
+				comp["required"] = true
+			}
+			continue
+		}
+		if _, isNodeInput := nodeInputRefs[input.Identifier]; isNodeInput {
+			continue
+		}
+		label := input.DisplayName
+		if label == "" {
+			label = input.Identifier
+		}
+		inputType := input.Type
+		if inputType == "" {
+			inputType = common.InputTypeText
+		}
+		synthetic = append(synthetic, map[string]interface{}{
+			"id":       input.Identifier,
+			"ref":      input.Identifier,
+			"type":     inputType,
+			"label":    label,
+			"required": input.Required,
+		})
+	}
+
+	// Walk the meta tree and either replace a DYNAMIC_INPUT_PLACEHOLDER with synthetic
+	// inputs (preferred — exact insertion point), or insert before the first ACTION in
+	// the first BLOCK (fallback). The placeholder is always stripped even when there are
+	// no synthetic inputs, so it never leaks to the client.
+	// Input components are only rendered inside a BLOCK by the UI renderer.
+	result := make(map[string]interface{}, len(metaMap))
+	for k, v := range metaMap {
+		result[k] = v
+	}
+	existing, _ := metaMap["components"].([]interface{})
+	updatedComponents := make([]interface{}, len(existing))
+	copy(updatedComponents, existing)
+
+	placeholderStripped := false
+	inserted := false
+	for i, comp := range updatedComponents {
+		compMap, ok := comp.(map[string]interface{})
+		if !ok || compMap["type"] != common.MetaComponentTypeBlock {
+			continue
+		}
+		children, _ := compMap["components"].([]interface{})
+
+		// Preferred path: find and replace DYNAMIC_INPUT_PLACEHOLDER.
+		// Always strip it, inserting synthetic inputs in its place (may be empty).
+		for j, child := range children {
+			childMap, ok := child.(map[string]interface{})
+			if !ok || childMap["type"] != common.MetaComponentTypeDynamicInputPlaceholder {
+				continue
+			}
+			newChildren := make([]interface{}, 0, len(children)-1+len(synthetic))
+			newChildren = append(newChildren, children[:j]...)
+			newChildren = append(newChildren, synthetic...)
+			newChildren = append(newChildren, children[j+1:]...)
+			newBlock := make(map[string]interface{}, len(compMap))
+			for k, v := range compMap {
+				newBlock[k] = v
+			}
+			newBlock["components"] = newChildren
+			updatedComponents[i] = newBlock
+			placeholderStripped = true
+			inserted = true
+			break
+		}
+		if placeholderStripped {
+			break
+		}
+
+		// Fallback (no placeholder): insert before the first ACTION, only when there
+		// are synthetic inputs to add.
+		if len(synthetic) == 0 {
+			break
+		}
+		insertIdx := len(children)
+		for j, child := range children {
+			childMap, ok := child.(map[string]interface{})
+			if ok && childMap["type"] == common.MetaComponentTypeAction {
+				insertIdx = j
+				break
+			}
+		}
+		newChildren := make([]interface{}, 0, len(children)+len(synthetic))
+		newChildren = append(newChildren, children[:insertIdx]...)
+		newChildren = append(newChildren, synthetic...)
+		newChildren = append(newChildren, children[insertIdx:]...)
+		newBlock := make(map[string]interface{}, len(compMap))
+		for k, v := range compMap {
+			newBlock[k] = v
+		}
+		newBlock["components"] = newChildren
+		updatedComponents[i] = newBlock
+		inserted = true
+		break
+	}
+
+	if len(synthetic) == 0 && !placeholderStripped {
+		return trimmedMeta
+	}
+
+	if !inserted && len(synthetic) > 0 {
+		// No BLOCK found — wrap synthetic inputs in a new BLOCK so the UI renderer
+		// can display them (input components are only supported inside a BLOCK).
+		updatedComponents = append(updatedComponents, map[string]interface{}{
+			"id":         "block_schema_dynamic",
+			"type":       common.MetaComponentTypeBlock,
+			"components": synthetic,
+		})
+	}
+
+	result["components"] = updatedComponents
+	return result
+}
+
+// collectMetaComponentMap recursively walks the meta components tree and builds a
+// ref/id → component map. ref takes priority over id for the same component so that
+// identifier-based lookups match the data-binding key rather than the element id.
+func collectMetaComponentMap(comps interface{}, compMap map[string]map[string]interface{}) {
+	compSlice, ok := comps.([]interface{})
+	if !ok {
+		return
+	}
+	for _, comp := range compSlice {
+		cm, ok := comp.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if ref, ok := cm["ref"].(string); ok && ref != "" {
+			compMap[ref] = cm
+		}
+		if id, ok := cm["id"].(string); ok && id != "" {
+			if _, exists := compMap[id]; !exists {
+				compMap[id] = cm
+			}
+		}
+		collectMetaComponentMap(cm["components"], compMap)
+	}
 }

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/common"
 )
 
+const testEmailAttr = "email"
+
 type PromptOnlyNodeTestSuite struct {
 	suite.Suite
 }
@@ -66,7 +68,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithRequiredData() {
 		{"No user input provided", map[string]string{}, false, 2},
 		{
 			"All required data provided",
-			map[string]string{"username": "testuser", "email": "test@example.com"},
+			map[string]string{"username": "testuser", testEmailAttr: "test@example.com"},
 			true,
 			0,
 		},
@@ -81,7 +83,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithRequiredData() {
 				{
 					Inputs: []common.Input{
 						{Identifier: "username", Required: true},
-						{Identifier: "email", Required: true},
+						{Identifier: testEmailAttr, Required: true},
 					},
 					Action: &common.Action{Ref: "submit", NextNode: "next"},
 				},
@@ -611,7 +613,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureReason_ClearsCurrentActi
 	promptNode.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Required: true},
+				{Identifier: testEmailAttr, Required: true},
 			},
 			Action: &common.Action{Ref: "submit", NextNode: "next"},
 		},
@@ -621,7 +623,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureReason_ClearsCurrentActi
 		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs: map[string]string{
-			"email": "existing@example.com",
+			testEmailAttr: "existing@example.com",
 		},
 		RuntimeData: map[string]string{
 			"failureReason": "A user with this email already exists",
@@ -782,7 +784,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetAllInputs() {
 		},
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Required: true},
+				{Identifier: testEmailAttr, Required: true},
 			},
 			Action: &common.Action{Ref: "signup", NextNode: "register_node"},
 		},
@@ -797,7 +799,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetAllInputs() {
 	s.Len(allInputs, 3, "Should return all inputs from all prompts")
 	s.Equal("username", allInputs[0].Identifier)
 	s.Equal("password", allInputs[1].Identifier)
-	s.Equal("email", allInputs[2].Identifier)
+	s.Equal(testEmailAttr, allInputs[2].Identifier)
 }
 
 func (s *PromptOnlyNodeTestSuite) TestGetAllInputsEmpty() {
@@ -827,7 +829,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetAllActions() {
 		},
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Required: true},
+				{Identifier: testEmailAttr, Required: true},
 			},
 			Action: &common.Action{Ref: "reset", NextNode: "reset_node"},
 		},
@@ -855,7 +857,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetAllActionsWithNilAction() {
 		},
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Required: true},
+				{Identifier: testEmailAttr, Required: true},
 			},
 			Action: nil, // No action
 		},
@@ -1081,14 +1083,15 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataNoMatch() {
 		},
 	})
 
-	// ForwardedData has inputs but different Identifier
+	// ForwardedData has an input with a different Identifier — it is a schema-derived input
+	// that is not in the node's prompt definition, so it gets appended to the response.
 	ctx := &NodeContext{
 		ExecutionID: "test-flow",
 		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
-					Identifier: "userType", // Different identifier
+					Identifier: "userType",
 					Options:    []string{"option1", "option2"},
 				},
 			},
@@ -1098,12 +1101,53 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataNoMatch() {
 
 	s.Nil(err)
 	s.NotNil(resp)
-	s.Len(resp.Inputs, 1)
+	// username (from prompt) + userType (schema-derived from ForwardedData) are both missing
+	s.Len(resp.Inputs, 2)
 
-	// Verify prompt input is unchanged since no match
-	promptInput := resp.Inputs[0]
-	s.Equal("username", promptInput.Identifier)
-	s.Empty(promptInput.Options, "Options should remain empty when no matching forwarded input")
+	inputMap := make(map[string]common.Input, len(resp.Inputs))
+	for _, inp := range resp.Inputs {
+		inputMap[inp.Identifier] = inp
+	}
+	s.Contains(inputMap, "username", "prompt-defined input must be present")
+	s.Empty(inputMap["username"].Options, "username Options should remain empty")
+	s.Contains(inputMap, "userType", "schema-derived input must be appended")
+	s.ElementsMatch([]string{"option1", "option2"}, inputMap["userType"].Options,
+		"forwarded options must be propagated to the appended input")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataSchemaInputSkippedWhenScalarResolved() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "username", Required: true},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	// ForwardedDataKeyInputs lists "userType" as a schema-derived input, but
+	// ForwardedData also carries a resolved scalar string for "userType". The
+	// scalar wins: the input must NOT be re-appended to the response.
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{"username": "alice"},
+		ForwardedData: map[string]interface{}{
+			"userType": "customer",
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "userType", Options: []string{"customer", "admin"}},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	for _, inp := range resp.Inputs {
+		s.NotEqual("userType", inp.Identifier,
+			"schema-derived input must be skipped when a scalar value is already forwarded")
+	}
 }
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteWithNoForwardedData() {
@@ -1157,6 +1201,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataMultipleInputs() {
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
 					Identifier: "userType",
+					Type:       "SELECT",
 					Options:    []string{"employee", "customer"},
 				},
 			},
@@ -1262,13 +1307,14 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataPreservesPromptFie
 	s.NotNil(resp)
 	s.Len(resp.Inputs, 1)
 
-	// Verify only Options is enriched, other fields preserved from prompt definition
+	// Verify prompt definition fields are preserved; options are NOT enriched because the
+	// forwarded input type ("DIFFERENT_TYPE") does not match the node input type ("SELECT").
 	enrichedInput := resp.Inputs[0]
 	s.Equal("usertype_input_custom", enrichedInput.Ref, "Ref should NOT be overwritten")
 	s.Equal("userType", enrichedInput.Identifier)
 	s.Equal("SELECT", enrichedInput.Type, "Type should NOT be overwritten")
 	s.True(enrichedInput.Required, "Required should NOT be overwritten")
-	s.ElementsMatch([]string{"option1"}, enrichedInput.Options, "Only Options should be enriched")
+	s.Empty(enrichedInput.Options, "Options should NOT be enriched when forwarded type does not match")
 }
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataEmptyOptions() {
@@ -1570,7 +1616,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInRuntimeDat
 	promptNode.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 				{Identifier: "username", Ref: "input_username", Required: true},
 			},
 			Action: &common.Action{Ref: "submit", NextNode: "next"},
@@ -1581,7 +1627,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInRuntimeDat
 		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{},
-		RuntimeData:   map[string]string{"email": "user@example.com"},
+		RuntimeData:   map[string]string{testEmailAttr: "user@example.com"},
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1598,7 +1644,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInForwardedD
 	promptNode.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 				{Identifier: "username", Ref: "input_username", Required: true},
 			},
 			Action: &common.Action{Ref: "submit", NextNode: "next"},
@@ -1609,7 +1655,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_SkipsInputInForwardedD
 		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{},
-		ForwardedData: map[string]interface{}{"email": "user@example.com"},
+		ForwardedData: map[string]interface{}{testEmailAttr: "user@example.com"},
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1626,7 +1672,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_DoesNotSkipForwardedDa
 	promptNode.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 			},
 			Action: &common.Action{Ref: "submit", NextNode: "next"},
 		},
@@ -1637,7 +1683,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_DoesNotSkipForwardedDa
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{},
 		ForwardedData: map[string]interface{}{
-			"email": []common.Input{{Identifier: "email"}},
+			testEmailAttr: []common.Input{{Identifier: testEmailAttr}},
 		},
 	}
 	resp, err := node.Execute(ctx)
@@ -1654,7 +1700,7 @@ func (s *PromptOnlyNodeTestSuite) TestAppendMissingInputs_RuntimeDataDoesNotAffe
 	promptNode.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 				{Identifier: "username", Ref: "input_username", Required: true},
 			},
 			Action: &common.Action{Ref: "submit", NextNode: "next"},
@@ -1680,7 +1726,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_PartialInputSet() {
 		"components": []interface{}{
 			map[string]interface{}{"type": "TEXT", "id": "heading"},
 			map[string]interface{}{
-				"type": "BLOCK",
+				"type": common.MetaComponentTypeBlock,
 				"id":   "form_block",
 				"components": []interface{}{
 					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_given_name"},
@@ -1700,7 +1746,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_PartialInputSet() {
 			Inputs: []common.Input{
 				{Identifier: "given_name", Ref: "input_given_name", Required: true},
 				{Identifier: "family_name", Ref: "input_family_name", Required: true},
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 			},
 			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
 		},
@@ -1709,7 +1755,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_PartialInputSet() {
 	ctx := &NodeContext{
 		ExecutionID: "test-flow",
 		UserInputs:  map[string]string{},
-		RuntimeData: map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{testEmailAttr: "user@example.com"},
 		Verbose:     true,
 	}
 	resp, err := node.Execute(ctx)
@@ -1753,7 +1799,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_AllInputsMissing() {
 		"components": []interface{}{
 			map[string]interface{}{"type": "TEXT", "id": "heading"},
 			map[string]interface{}{
-				"type": "BLOCK",
+				"type": common.MetaComponentTypeBlock,
 				"id":   "form_block",
 				"components": []interface{}{
 					map[string]interface{}{"type": "TEXT_INPUT", "id": "input_given_name"},
@@ -1773,7 +1819,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_AllInputsMissing() {
 			Inputs: []common.Input{
 				{Identifier: "given_name", Ref: "input_given_name", Required: true},
 				{Identifier: "family_name", Ref: "input_family_name", Required: true},
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 			},
 			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
 		},
@@ -1874,7 +1920,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_DisabledWhenVerboseFal
 	pn.SetPrompts([]common.Prompt{
 		{
 			Inputs: []common.Input{
-				{Identifier: "email", Ref: "input_email", Required: true},
+				{Identifier: testEmailAttr, Ref: "input_email", Required: true},
 				{Identifier: "username", Ref: "input_username", Required: true},
 			},
 			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
@@ -1885,7 +1931,7 @@ func (s *PromptOnlyNodeTestSuite) TestVerboseMetaTrimming_DisabledWhenVerboseFal
 	ctx := &NodeContext{
 		ExecutionID: "test-flow",
 		UserInputs:  map[string]string{},
-		RuntimeData: map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{testEmailAttr: "user@example.com"},
 		Verbose:     false,
 	}
 	resp, err := node.Execute(ctx)
@@ -1954,4 +2000,767 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_NoTypeField() 
 			s.Empty(actionType, "Action type should be empty when not defined")
 		}
 	}
+}
+
+// ── enrichInputsFromForwardedData — schema-derived input injection ────────────
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_AddsInputNotInNodeResponse() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	// No prompt inputs configured — the schema-derived input comes only from ForwardedData.
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Inputs, 1)
+	s.Equal(testEmailAttr, resp.Inputs[0].Identifier)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_DoesNotDuplicateExistingInput() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: testEmailAttr, Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	emailCount := 0
+	for _, inp := range resp.Inputs {
+		if inp.Identifier == testEmailAttr {
+			emailCount++
+		}
+	}
+	s.Equal(1, emailCount, "email must appear exactly once, not duplicated from ForwardedData")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_MixedNewAndExisting() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: "username", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "username", Required: true},
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+
+	identifiers := make(map[string]int)
+	for _, inp := range resp.Inputs {
+		identifiers[inp.Identifier]++
+	}
+	s.Equal(1, identifiers["username"], "username must appear exactly once")
+	s.Equal(1, identifiers[testEmailAttr], "email (schema-derived) must be appended once")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_NilForwardedData_NoChange() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: "username", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: nil,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Len(resp.Inputs, 1)
+	s.Equal("username", resp.Inputs[0].Identifier)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_UpdatesRequiredFlag() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: "email", Type: "TEXT_INPUT", Required: false}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "email", Type: "TEXT_INPUT", Required: true},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().Len(resp.Inputs, 1)
+	s.True(resp.Inputs[0].Required, "required flag must be promoted to true by ForwardedData")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_PropagatesSelectOptions() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: "role", Type: common.InputTypeSelect, Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "role", Type: common.InputTypeSelect, Required: true, Options: []string{"admin", "user"}},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().Len(resp.Inputs, 1)
+	s.Equal([]string{"admin", "user"}, resp.Inputs[0].Options, "options must be propagated from ForwardedData")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestHasRequiredInputs_UnknownActionFallsBackToAllInputs() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Identifier: testInputName, Type: "TEXT_INPUT", Required: true}},
+			Action: &common.Action{Ref: "known_action", NextNode: "next"},
+		},
+	})
+
+	// CurrentAction is set but does not match any prompt action.
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "unknown_action",
+		UserInputs:    map[string]string{},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().NotNil(resp)
+	// Falls back to all inputs — username must be in the response.
+	found := false
+	for _, inp := range resp.Inputs {
+		if inp.Identifier == testInputName {
+			found = true
+		}
+	}
+	s.True(found, "when action is unknown, all prompt inputs must be requested")
+}
+
+// ── appendSyntheticMetaComponents — meta synthesis ───────────────────────────
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_CreatedForSchemaInputWithDisplayName() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"id": "input_username", "type": "TEXT_INPUT"},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: "input_username", Identifier: "username", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		Verbose:       true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+
+	// No BLOCK in original meta — synthetic input must be inside a generated BLOCK.
+	var emailComp map[string]interface{}
+	for _, c := range comps {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cm["type"] == common.MetaComponentTypeBlock {
+			for _, child := range cm["components"].([]interface{}) {
+				if childMap, ok := child.(map[string]interface{}); ok && childMap["id"] == testEmailAttr {
+					emailComp = childMap
+				}
+			}
+		}
+	}
+	s.Require().NotNil(emailComp, "synthetic component for email should be present inside a BLOCK")
+	s.Equal("Email Address", emailComp["label"], "label should use DisplayName")
+	s.Equal("TEXT_INPUT", emailComp["type"], "type should match input.Type, not a generic INPUT string")
+	s.Equal(testEmailAttr, emailComp["ref"], "ref should be set to the identifier")
+	s.Equal(true, emailComp["required"], "required should be propagated")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_FallsBackToIdentifierWhenNoDisplayName() {
+	meta := map[string]interface{}{
+		"components": []interface{}{},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	// No prompt inputs — schema-derived input comes from ForwardedData
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: ""},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(comps, 1, "a single generated BLOCK should be present at the top level")
+
+	block, ok := comps[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal(common.MetaComponentTypeBlock, block["type"], "synthetic inputs must be wrapped in a BLOCK")
+	blockChildren, ok := block["components"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(blockChildren, 1)
+
+	comp := blockChildren[0].(map[string]interface{})
+	s.Equal(testEmailAttr, comp["label"], "label must fall back to Identifier when DisplayName is empty")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_NotAddedWhenMetaComponentAlreadyExists() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"id": testEmailAttr, "type": "TEXT_INPUT", "label": "E-mail"},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: testEmailAttr, Identifier: testEmailAttr, Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		Verbose:       true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+
+	emailCount := 0
+	for _, c := range comps {
+		if cm, ok := c.(map[string]interface{}); ok && cm["id"] == testEmailAttr {
+			emailCount++
+		}
+	}
+	s.Equal(1, emailCount, "email component must not be duplicated when it already exists in meta")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_NotAddedWhenMetaComponentExistsByRef() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"id": "input_email", "ref": testEmailAttr, "type": "TEXT_INPUT", "label": "E-mail"},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+
+	emailCount := 0
+	for _, c := range comps {
+		if cm, ok := c.(map[string]interface{}); ok {
+			if cm["ref"] == testEmailAttr || cm["id"] == testEmailAttr {
+				emailCount++
+			}
+		}
+	}
+	s.Equal(1, emailCount, "email component must not be duplicated when meta component ref matches identifier")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_InsertedInsideBlockBeforeAction() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"id": "image", "type": "IMAGE"},
+			map[string]interface{}{
+				"id":   "block_schema",
+				"type": common.MetaComponentTypeBlock,
+				"components": []interface{}{
+					map[string]interface{}{"id": "action_submit", "type": "ACTION", "ref": "action_submit"},
+				},
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{},
+			Action: &common.Action{Ref: "action_submit", NextNode: "provisioning"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "mobileNumber", Type: "TEXT_INPUT", Required: true, DisplayName: "Mobile Number"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	topComps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Len(topComps, 2, "top-level component count must not change — synthetic input goes inside the BLOCK")
+
+	// Find the BLOCK and inspect its children.
+	var blockChildren []interface{}
+	for _, c := range topComps {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cm["type"] == common.MetaComponentTypeBlock {
+			blockChildren, _ = cm["components"].([]interface{})
+		}
+	}
+	s.Require().Len(blockChildren, 2, "BLOCK must contain the synthetic input and the original action")
+
+	inputComp, ok := blockChildren[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("mobileNumber", inputComp["id"], "synthetic input must be first — before the ACTION")
+	s.Equal("TEXT_INPUT", inputComp["type"])
+	s.Equal("mobileNumber", inputComp["ref"])
+	s.Equal("Mobile Number", inputComp["label"])
+	s.Equal(true, inputComp["required"])
+
+	actionComp, ok := blockChildren[1].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("ACTION", actionComp["type"], "ACTION must remain after the synthetic input")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_PlaceholderReplacedWithSyntheticInputs() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":   "block_dynamic",
+				"type": common.MetaComponentTypeBlock,
+				"components": []interface{}{
+					map[string]interface{}{
+						"id":   "dynamic_inputs",
+						"type": common.MetaComponentTypeDynamicInputPlaceholder,
+					},
+					map[string]interface{}{"id": "action_submit", "type": "ACTION", "ref": "action_submit"},
+				},
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email"},
+				{Identifier: "given_name", Type: "TEXT_INPUT", Required: true, DisplayName: "First Name"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	topComps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Len(topComps, 1)
+
+	block, ok := topComps[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal(common.MetaComponentTypeBlock, block["type"])
+
+	children, ok := block["components"].([]interface{})
+	s.Require().True(ok)
+	// placeholder replaced by 2 synthetic inputs + 1 action = 3 total
+	s.Require().Len(children, 3, "placeholder must be replaced by synthetic inputs; ACTION remains at end")
+
+	// No placeholder in final output.
+	for _, c := range children {
+		if cm, ok := c.(map[string]interface{}); ok {
+			s.NotEqual(common.MetaComponentTypeDynamicInputPlaceholder, cm["type"],
+				"placeholder must not appear in the final meta")
+		}
+	}
+
+	email, ok := children[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal(testEmailAttr, email["id"])
+	s.Equal("Email", email["label"])
+
+	action, ok := children[2].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("ACTION", action["type"], "ACTION must stay after synthetic inputs")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_PlaceholderStrippedWhenNoSyntheticInputs() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":   "block_dynamic",
+				"type": common.MetaComponentTypeBlock,
+				"components": []interface{}{
+					map[string]interface{}{
+						"id":   "dynamic_inputs",
+						"type": common.MetaComponentTypeDynamicInputPlaceholder,
+					},
+					map[string]interface{}{"id": "action_submit", "type": "ACTION", "ref": "action_submit"},
+				},
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	// No ForwardedData inputs — no synthetic inputs will be generated.
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	topComps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+
+	block, ok := topComps[0].(map[string]interface{})
+	s.Require().True(ok)
+	children, ok := block["components"].([]interface{})
+	s.Require().True(ok)
+	// placeholder removed, only ACTION remains
+	s.Require().Len(children, 1, "placeholder must be stripped even when there are no synthetic inputs")
+	action, ok := children[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("ACTION", action["type"])
+	for _, c := range children {
+		if cm, ok := c.(map[string]interface{}); ok {
+			s.NotEqual(common.MetaComponentTypeDynamicInputPlaceholder, cm["type"],
+				"placeholder must never appear in the final meta")
+		}
+	}
+}
+
+func (s *PromptOnlyNodeTestSuite) TestFilterMetaComponents_NonMapComponentPassedThrough() {
+	// filterMetaComponents is exercised via trimMetaToRequestedInputs in verbose mode.
+	// A non-map element (plain string) in the components list covers the !ok branch
+	// that passes non-map items through unchanged. The node must be in an incomplete
+	// state (no action selected, required input missing) so that meta is rendered.
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			"plain-string-component",
+			map[string]interface{}{
+				"id":   "block_inputs",
+				"type": common.MetaComponentTypeBlock,
+				"components": []interface{}{
+					map[string]interface{}{"id": "input_username", "ref": "input_username", "type": "TEXT_INPUT"},
+					map[string]interface{}{"id": "action_submit", "type": "ACTION", "ref": "action_submit"},
+				},
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: "input_username", Identifier: "username", Required: true}},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	// No action selected + required input missing → node is INCOMPLETE → meta rendered.
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	found := false
+	for _, c := range comps {
+		if str, ok := c.(string); ok && str == "plain-string-component" {
+			found = true
+		}
+	}
+	s.True(found, "non-map components must pass through filterMetaComponents unchanged")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_SkipsInputAlreadyInUserInputs() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{testEmailAttr: "user@example.com"},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true},
+				{Identifier: "username", Type: "TEXT_INPUT", Required: true},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	for _, inp := range resp.Inputs {
+		s.NotEqual(testEmailAttr, inp.Identifier,
+			"email already in UserInputs must not appear in missing inputs")
+	}
+	identifiers := make(map[string]bool)
+	for _, inp := range resp.Inputs {
+		identifiers[inp.Identifier] = true
+	}
+	s.True(identifiers["username"], "username not in UserInputs must be appended")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_SkipsInputAlreadyInRuntimeData() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{testEmailAttr: "user@example.com"},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true},
+				{Identifier: "username", Type: "TEXT_INPUT", Required: true},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	for _, inp := range resp.Inputs {
+		s.NotEqual(testEmailAttr, inp.Identifier,
+			"email already in RuntimeData must not appear in missing inputs")
+	}
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_EmptyInputType_FallsBackToText() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":   "block_inputs",
+				"type": common.MetaComponentTypeBlock,
+				"components": []interface{}{
+					map[string]interface{}{
+						"id":   "dynamic_inputs",
+						"type": common.MetaComponentTypeDynamicInputPlaceholder,
+					},
+					map[string]interface{}{"id": "action_submit", "type": "ACTION", "ref": "action_submit"},
+				},
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: "input_email", Identifier: testEmailAttr, Required: true}},
+			Action: &common.Action{Ref: "action_submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "schemaField", Type: "", Required: true, DisplayName: "Schema Field"},
+			},
+		},
+		Verbose: true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+
+	for _, comp := range comps {
+		blockMap, ok := comp.(map[string]interface{})
+		if !ok || blockMap["type"] != common.MetaComponentTypeBlock {
+			continue
+		}
+		inner, ok := blockMap["components"].([]interface{})
+		s.Require().True(ok)
+		for _, ic := range inner {
+			icMap, ok := ic.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if icMap["ref"] == "schemaField" {
+				s.Equal(common.InputTypeText, icMap["type"],
+					"empty input type must fall back to TEXT")
+				return
+			}
+		}
+	}
+	s.Fail("synthetic component for schemaField not found in meta")
 }

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -18,8 +18,6 @@
 
 package executor
 
-import "github.com/asgardeo/thunder/internal/flow/common"
-
 // Executor name constants
 const (
 	ExecutorNameBasicAuth = "BasicAuthExecutor"
@@ -100,22 +98,6 @@ const (
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
 var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}
-
-// nonUserAttributes contains the list of user attributes that do not belong to user entity.
-var nonUserAttributes = []string{"userID", "code", "nonce", "state", "flowID",
-	"otp", "attemptCount", "expiryTimeInMillis", "otpSessionToken", "value",
-	"authorized_permissions",
-	common.RuntimeKeyRequiredOptionalAttributes, common.RuntimeKeyRequiredEssentialAttributes,
-	common.RuntimeKeyRequestedPermissions, common.RuntimeKeyRequiredLocales,
-	userTypeKey, ouIDKey, defaultOUIDKey, userInputOuName, userInputOuHandle, userInputOuDesc, userInputInviteToken,
-	common.RuntimeKeyUserEligibleForProvisioning, common.RuntimeKeySkipProvisioning,
-	common.RuntimeKeyUserAutoProvisioned, common.RuntimeKeyStoredInviteToken,
-	common.RuntimeKeyInviteLink,
-	common.RuntimeKeyConsentID, common.RuntimeKeyStepTimeout, userInputConsentDecisions,
-	common.RuntimeKeyConsentedAttributes, common.RuntimeKeyConsentSessionToken,
-	"applicationId", "idpId", "senderId",
-	common.RuntimeKeyCandidateUsers, common.RuntimeKeyClientID, common.RuntimeKeyUserAttributesCacheTTLSeconds,
-	common.RuntimeKeyUserAmbiguous, runtimeKeySMSOTPMobileNumber, runtimeKeySMSOTPPhoneAttr}
 
 // Failure reason constants
 const (

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -92,7 +92,7 @@ func Initialize(
 		flowFactory, idpService, userSchemaService, googleSvc, authnProvider))
 
 	reg.RegisterExecutor(ExecutorNameProvisioning, newProvisioningExecutor(flowFactory,
-		groupService, roleService, entityProvider))
+		groupService, roleService, entityProvider, userSchemaService))
 	reg.RegisterExecutor(ExecutorNameOUCreation, newOUExecutor(flowFactory, ouService))
 
 	reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(flowFactory, entityProvider))

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/entityprovider"
@@ -32,16 +31,18 @@ import (
 	"github.com/asgardeo/thunder/internal/group"
 	"github.com/asgardeo/thunder/internal/role"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 // provisioningExecutor implements the ExecutorInterface for user provisioning in a flow.
 type provisioningExecutor struct {
 	core.ExecutorInterface
 	identifyingExecutorInterface
-	entityProvider entityprovider.EntityProviderInterface
-	groupService   group.GroupServiceInterface
-	roleService    role.RoleServiceInterface
-	logger         *log.Logger
+	entityProvider    entityprovider.EntityProviderInterface
+	groupService      group.GroupServiceInterface
+	roleService       role.RoleServiceInterface
+	userSchemaService userschema.UserSchemaServiceInterface
+	logger            *log.Logger
 }
 
 var _ core.ExecutorInterface = (*provisioningExecutor)(nil)
@@ -53,6 +54,7 @@ func newProvisioningExecutor(
 	groupService group.GroupServiceInterface,
 	roleService role.RoleServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) *provisioningExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, ExecutorNameProvisioning),
 		log.String(log.LoggerKeyExecutorName, ExecutorNameProvisioning))
@@ -69,6 +71,7 @@ func newProvisioningExecutor(
 		entityProvider:               entityProvider,
 		groupService:                 groupService,
 		roleService:                  roleService,
+		userSchemaService:            userSchemaService,
 		logger:                       logger,
 	}
 }
@@ -103,7 +106,10 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		return execResp, nil
 	}
 
-	userAttributes := p.getAttributesForProvisioning(ctx)
+	userAttributes, err := p.getAttributesForProvisioning(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if len(userAttributes) == 0 {
 		logger.Debug("No user attributes provided for provisioning")
 		execResp.Status = common.ExecFailure
@@ -231,99 +237,175 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 }
 
 // HasRequiredInputs checks if the required inputs are provided in the context and appends any
-// missing inputs to the executor response. Returns true if required inputs are found, otherwise false.
+// missing inputs to the executor response. Returns true if all required inputs — both
+// node-defined and schema-derived — are satisfied, otherwise false.
 func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Checking inputs for the provisioning executor")
 
-	if p.ExecutorInterface.HasRequiredInputs(ctx, execResp) {
-		return true
-	}
-	if len(execResp.Inputs) == 0 {
-		return true
+	if execResp.RuntimeData == nil {
+		execResp.RuntimeData = make(map[string]string)
 	}
 
-	// Update the executor response with the required inputs retrieved from authenticated user attributes.
-	authnUserAttrs := ctx.AuthenticatedUser.Attributes
-	if len(authnUserAttrs) > 0 {
-		logger.Debug("Authenticated user attributes found, updating executor response required inputs")
+	// run the base executor check for node-defined inputs.
+	nodeInputsSatisfied := p.checkNodeInputs(ctx, execResp, logger)
 
-		// Clear the required data in the executor response to avoid duplicates.
-		missingAttributes := execResp.Inputs
-		execResp.Inputs = make([]common.Input, 0)
-		if execResp.RuntimeData == nil {
-			execResp.RuntimeData = make(map[string]string)
-		}
-
-		for _, input := range missingAttributes {
-			attribute, exists := authnUserAttrs[input.Identifier]
-			if exists {
-				attributeStr, ok := attribute.(string)
-				if ok {
-					logger.Debug("Input exists in authenticated user attributes, adding to runtime data",
-						log.String("attributeName", input.Identifier))
-					execResp.RuntimeData[input.Identifier] = attributeStr
-				}
-			} else {
-				logger.Debug("Input does not exist in authenticated user attributes, adding to required inputs",
-					log.String("attributeName", input.Identifier))
-				execResp.Inputs = append(execResp.Inputs, input)
-			}
-		}
-
-		if len(execResp.Inputs) == 0 {
-			logger.Debug("All required inputs are available in authenticated user attributes, " +
-				"no further action needed")
-			return true
-		}
+	// fetch required non-credential attributes from the user schema.
+	schemaAttrs, err := p.fetchSchemaAttributes(ctx, logger)
+	if err != nil {
+		execResp.Status = common.ExecFailure
+		return false
+	}
+	if len(schemaAttrs) == 0 {
+		return nodeInputsSatisfied
 	}
 
-	return false
-}
-
-// getAttributesForProvisioning retrieves the input attributes from the context to be stored in user profile.
-func (p *provisioningExecutor) getAttributesForProvisioning(ctx *core.NodeContext) map[string]interface{} {
-	attributesMap := make(map[string]interface{})
-	requiredInputAttrs := p.GetRequiredInputs(ctx)
-
-	// If no input attributes are defined, get all user attributes from the context.
-	if len(requiredInputAttrs) == 0 {
-		for key, value := range ctx.UserInputs {
-			if !slices.Contains(nonUserAttributes, key) {
-				attributesMap[key] = value
-			}
-		}
-		for key, value := range ctx.AuthenticatedUser.Attributes {
-			if !slices.Contains(nonUserAttributes, key) {
-				attributesMap[key] = value
-			}
-		}
-		for key, value := range ctx.RuntimeData {
-			if !slices.Contains(nonUserAttributes, key) {
-				attributesMap[key] = value
-			}
-		}
-		return attributesMap
-	}
-
-	// Otherwise, filter the required input attributes and get their values from the context.
-	for _, inputAttr := range requiredInputAttrs {
-		if slices.Contains(nonUserAttributes, inputAttr.Identifier) {
+	schemaMissingAttrs := make([]common.Input, 0, len(schemaAttrs))
+	for _, attr := range schemaAttrs {
+		if p.isAttrSatisfied(ctx, attr.Attribute) {
 			continue
 		}
 
-		value, exists := ctx.UserInputs[inputAttr.Identifier]
-		if exists {
-			attributesMap[inputAttr.Identifier] = value
-		} else if runtimeValue, exists := ctx.RuntimeData[inputAttr.Identifier]; exists {
-			attributesMap[inputAttr.Identifier] = runtimeValue
-		} else if authnValue, exists := ctx.AuthenticatedUser.Attributes[inputAttr.Identifier]; exists {
-			attributesMap[inputAttr.Identifier] = authnValue
+		schemaMissingAttrs = append(schemaMissingAttrs, common.Input{
+			Identifier:  attr.Attribute,
+			Type:        common.InputTypeText,
+			Required:    true,
+			DisplayName: attr.DisplayName,
+		})
+	}
+
+	if len(schemaMissingAttrs) == 0 {
+		return nodeInputsSatisfied
+	}
+
+	execResp.Inputs = upsertInputs(execResp.Inputs, schemaMissingAttrs)
+	if execResp.ForwardedData == nil {
+		execResp.ForwardedData = make(map[string]interface{})
+	}
+	execResp.ForwardedData[common.ForwardedDataKeyInputs] = schemaMissingAttrs
+	logger.Debug("Schema-required attributes are missing, requesting via prompt",
+		log.Int("missingCount", len(schemaMissingAttrs)))
+	return false
+}
+
+// checkNodeInputs runs the base executor's input check, then clears any inputs satisfied by authenticated user attrs.
+func (p *provisioningExecutor) checkNodeInputs(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse, logger *log.Logger) bool {
+	nodeInputsSatisfied := p.ExecutorInterface.HasRequiredInputs(ctx, execResp)
+	if nodeInputsSatisfied || len(execResp.Inputs) == 0 {
+		return nodeInputsSatisfied
+	}
+
+	authnAttrs := ctx.AuthenticatedUser.Attributes
+	if len(authnAttrs) == 0 {
+		return false
+	}
+
+	logger.Debug("Authenticated user attributes found, checking missing node inputs")
+	remaining := execResp.Inputs[:0]
+	for _, input := range execResp.Inputs {
+		val, exists := authnAttrs[input.Identifier]
+		strVal, isStr := val.(string)
+		if exists && isStr && strVal != "" {
+			continue
+		}
+		remaining = append(remaining, input)
+	}
+	execResp.Inputs = remaining
+	return len(remaining) == 0
+}
+
+// fetchSchemaAttributes retrieves required non-credential attributes from the user schema service.
+func (p *provisioningExecutor) fetchSchemaAttributes(
+	ctx *core.NodeContext, logger *log.Logger,
+) ([]userschema.AttributeInfo, error) {
+	if p.userSchemaService == nil {
+		return nil, nil
+	}
+	userType := p.getUserType(ctx)
+	if userType == "" {
+		return nil, fmt.Errorf("user type not found")
+	}
+	attrs, svcErr := p.userSchemaService.GetNonCredentialAttributes(ctx.Context, userType, true)
+	if svcErr != nil {
+		logger.Warn("Failed to fetch schema attributes for provisioning, skipping schema check",
+			log.Any("error", svcErr))
+		return nil, nil
+	}
+	return attrs, nil
+}
+
+// isAttrSatisfied returns true if the attribute has a non-empty usable value in any context source.
+func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr string) bool {
+	if val, ok := ctx.UserInputs[attr]; ok && val != "" {
+		return true
+	}
+	if val, ok := ctx.RuntimeData[attr]; ok && val != "" {
+		return true
+	}
+	if val, ok := ctx.AuthenticatedUser.Attributes[attr]; ok {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// getAttributesForProvisioning returns the user profile attributes to store.
+// Schema is the whitelist: required attrs always collected, optional attrs only if in node inputs.
+func (p *provisioningExecutor) getAttributesForProvisioning(ctx *core.NodeContext) (map[string]interface{}, error) {
+	nodeInputAttrs := p.GetRequiredInputs(ctx)
+	schemaAttrs, err := p.fetchAllNonCredentialAttributes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(schemaAttrs) == 0 {
+		return make(map[string]interface{}), nil
+	}
+	nodeInputSet := make(map[string]struct{}, len(nodeInputAttrs))
+	for _, inp := range nodeInputAttrs {
+		nodeInputSet[inp.Identifier] = struct{}{}
+	}
+
+	attributesMap := make(map[string]interface{})
+	for _, a := range schemaAttrs {
+		_, inNodeInputs := nodeInputSet[a.Attribute]
+		if len(nodeInputSet) > 0 && !a.Required && !inNodeInputs {
+			continue
+		}
+
+		if value, exists := ctx.UserInputs[a.Attribute]; exists && value != "" {
+			attributesMap[a.Attribute] = value
+		} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
+			attributesMap[a.Attribute] = runtimeValue
+		} else if authnValue, exists := ctx.AuthenticatedUser.Attributes[a.Attribute]; exists {
+			if strVal, ok := authnValue.(string); ok && strVal != "" {
+				attributesMap[a.Attribute] = authnValue
+			}
 		}
 	}
 
-	return attributesMap
+	return attributesMap, nil
+}
+
+// fetchAllNonCredentialAttributes retrieves all non-credential schema attributes with their required status.
+func (p *provisioningExecutor) fetchAllNonCredentialAttributes(
+	ctx *core.NodeContext,
+) ([]userschema.AttributeInfo, error) {
+	if p.userSchemaService == nil {
+		return nil, nil
+	}
+	userType := p.getUserType(ctx)
+	if userType == "" {
+		return nil, fmt.Errorf("user type not found")
+	}
+	attrs, svcErr := p.userSchemaService.GetNonCredentialAttributes(ctx.Context, userType, false)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to fetch schema attributes for user type %q: %s",
+			userType, svcErr.Error.DefaultValue)
+	}
+	return attrs, nil
 }
 
 // appendNonIdentifyingAttributes appends non-identifying attributes to the provided attributes map.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -35,10 +35,12 @@ import (
 	"github.com/asgardeo/thunder/internal/group"
 	"github.com/asgardeo/thunder/internal/role"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/userschema/model"
 	"github.com/asgardeo/thunder/tests/mocks/entityprovidermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/groupmock"
 	"github.com/asgardeo/thunder/tests/mocks/rolemock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 const (
@@ -48,11 +50,12 @@ const (
 
 type ProvisioningExecutorTestSuite struct {
 	suite.Suite
-	mockGroupService   *groupmock.GroupServiceInterfaceMock
-	mockRoleService    *rolemock.RoleServiceInterfaceMock
-	mockFlowFactory    *coremock.FlowFactoryInterfaceMock
-	mockEntityProvider *entityprovidermock.EntityProviderInterfaceMock
-	executor           *provisioningExecutor
+	mockGroupService      *groupmock.GroupServiceInterfaceMock
+	mockRoleService       *rolemock.RoleServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockEntityProvider    *entityprovidermock.EntityProviderInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	executor              *provisioningExecutor
 }
 
 func TestProvisioningExecutorSuite(t *testing.T) {
@@ -64,6 +67,7 @@ func (suite *ProvisioningExecutorTestSuite) SetupTest() {
 	suite.mockRoleService = rolemock.NewRoleServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	suite.mockEntityProvider = entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 
 	// Mock the embedded identifying executor first
 	identifyingMock := suite.createMockIdentifyingExecutor()
@@ -75,7 +79,23 @@ func (suite *ProvisioningExecutorTestSuite) SetupTest() {
 		[]common.Input{}, []common.Input{}).Return(mockExec)
 
 	suite.executor = newProvisioningExecutor(suite.mockFlowFactory,
-		suite.mockGroupService, suite.mockRoleService, suite.mockEntityProvider)
+		suite.mockGroupService, suite.mockRoleService, suite.mockEntityProvider,
+		suite.mockUserSchemaService)
+}
+
+// expectSchemaForProvisioning sets up the schema service mocks for Execute tests.
+// GetRequiredNonCredentialAttributes returns empty (no schema prompting needed).
+// GetNonCredentialAttributes returns a broad required-attr set covering all Execute test contexts;
+// only attrs that actually have values in the test context will be collected.
+func (suite *ProvisioningExecutorTestSuite) expectSchemaForProvisioning() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Maybe()
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: "email", Required: true},
+			{Attribute: "sub", Required: true},
+		}, nil).Maybe()
 }
 
 func (suite *ProvisioningExecutorTestSuite) createMockIdentifyingExecutor() core.ExecutorInterface {
@@ -126,6 +146,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_NonRegistrationFlow() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser", "email": "new@example.com"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -195,13 +216,15 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAlreadyExists() {
+	suite.expectSchemaForProvisioning()
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "existinguser",
 		},
-		NodeInputs: []common.Input{{Identifier: "username", Type: "string", Required: true}},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
 	}
 
 	userID := "user-existing"
@@ -231,10 +254,10 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_NoUserAttributes() {
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
-	assert.Contains(suite.T(), resp.FailureReason, "No user attributes provided")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
+	suite.expectSchemaForProvisioning()
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -263,13 +286,17 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFromAuthUser() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Attributes: map[string]interface{}{"email": "test@example.com"},
 		},
-		NodeInputs: []common.Input{{Identifier: "email", Type: "string", Required: true}},
+		NodeInputs:  []common.Input{{Identifier: "email", Type: "string", Required: true}},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
 	}
 
 	execResp := &common.ExecutorResponse{
@@ -281,24 +308,28 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFrom
 
 	assert.True(suite.T(), result)
 	assert.Empty(suite.T(), execResp.Inputs)
-	assert.Equal(suite.T(), "test@example.com", execResp.RuntimeData["email"])
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FromMultipleSources() {
+// TestGetAttributesForProvisioning_SchemaEmpty_ReturnsEmpty verifies that when the schema
+// is unavailable (no userTypeKey → getUserType returns ""), an empty map is returned.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaEmpty_ReturnsEmpty() {
 	ctx := &core.NodeContext{
-		UserInputs:  map[string]string{"username": "testuser", "code": "auth-code"},
-		RuntimeData: map[string]string{"email": "test@example.com"},
+		UserInputs:  map[string]string{"username": "testuser", "email": "test@example.com"},
+		RuntimeData: map[string]string{},
 		NodeInputs:  []common.Input{},
 	}
 
-	result := suite.executor.getAttributesForProvisioning(ctx)
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
 
-	assert.Contains(suite.T(), result, "username")
-	assert.Contains(suite.T(), result, "email")
-	assert.NotContains(suite.T(), result, "code")
+	assert.Empty(suite.T(), result)
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FilterNonUserAttributes() {
+// TestGetAttributesForProvisioning_SchemaWhitelist_ExcludesNonSchemaAttrs verifies that the schema
+// acts as a whitelist — attributes not in the schema are excluded even if present in context.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaWhitelist_ExcludesNonSchemaAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{{Attribute: "username", Required: true}}, nil).Once()
+
 	ctx := &core.NodeContext{
 		UserInputs: map[string]string{
 			"username": "testuser",
@@ -306,162 +337,265 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 			"code":     "auth-code",
 			"nonce":    "test-nonce",
 		},
-		NodeInputs: []common.Input{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
 	}
 
-	result := suite.executor.getAttributesForProvisioning(ctx)
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
 
-	assert.Contains(suite.T(), result, "username")
+	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.NotContains(suite.T(), result, "userID")
 	assert.NotContains(suite.T(), result, "code")
 	assert.NotContains(suite.T(), result, "nonce")
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_WithAuthenticatedUserAttributes() {
+// TestGetAttributesForProvisioning_RequiredAttrsFromMultipleSources verifies that required schema
+// attributes are resolved from UserInputs, AuthenticatedUser.Attributes, and RuntimeData.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_RequiredAttrsFromMultipleSources() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: "email", Required: true},
+			{Attribute: "given_name", Required: true},
+			{Attribute: "phone", Required: true},
+		}, nil).Once()
+
 	ctx := &core.NodeContext{
 		UserInputs: map[string]string{"username": "testuser"},
 		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
-			UserID:          "user-123",
 			Attributes: map[string]interface{}{
-				"email":       "authenticated@example.com",
-				"given_name":  "Test",
-				"family_name": "User",
-			},
-		},
-		RuntimeData: map[string]string{"phone": "+1234567890"},
-		NodeInputs:  []common.Input{},
-	}
-
-	result := suite.executor.getAttributesForProvisioning(ctx)
-
-	// Should include attributes from all three sources
-	assert.Contains(suite.T(), result, "username")
-	assert.Contains(suite.T(), result, "email")
-	assert.Contains(suite.T(), result, "given_name")
-	assert.Contains(suite.T(), result, "family_name")
-	assert.Contains(suite.T(), result, "phone")
-	assert.Equal(suite.T(), "testuser", result["username"])
-	assert.Equal(suite.T(), "authenticated@example.com", result["email"])
-	assert.Equal(suite.T(), "Test", result["given_name"])
-}
-
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_AttributePriority() {
-	ctx := &core.NodeContext{
-		UserInputs: map[string]string{
-			"email": "userinput@example.com",
-		},
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
-			Attributes: map[string]interface{}{
-				"email": "authenticated@example.com",
-				"name":  "Authenticated Name",
-			},
-		},
-		RuntimeData: map[string]string{
-			"email": "runtime@example.com",
-			"phone": "+1234567890",
-		},
-		NodeInputs: []common.Input{},
-	}
-
-	result := suite.executor.getAttributesForProvisioning(ctx)
-
-	// RuntimeData comes last in the loop, so it overwrites for 'email'
-	assert.Equal(suite.T(), "runtime@example.com", result["email"])
-	// AuthenticatedUser.Attributes should provide 'name' (not in other sources)
-	assert.Equal(suite.T(), "Authenticated Name", result["name"])
-	// RuntimeData should provide 'phone' (not in other sources)
-	assert.Equal(suite.T(), "+1234567890", result["phone"])
-}
-
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_WithRequiredInputs_FromAuthUser() {
-	ctx := &core.NodeContext{
-		UserInputs: map[string]string{
-			"username": "testuser",
-		},
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
-			Attributes: map[string]interface{}{
-				"email":      "authenticated@example.com",
+				"email":      "auth@example.com",
 				"given_name": "Test",
 			},
 		},
 		RuntimeData: map[string]string{
-			"phone": "+1234567890",
+			userTypeKey: testUserType,
+			"phone":     "+1234567890",
 		},
-		NodeInputs: []common.Input{
-			{Identifier: "username", Type: "string", Required: true},
-			{Identifier: "email", Type: "string", Required: true},
-			{Identifier: "phone", Type: "string", Required: false},
-		},
+		NodeInputs: []common.Input{},
 	}
 
-	result := suite.executor.getAttributesForProvisioning(ctx)
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
 
-	// Note: GetInputs is mocked to return empty, so this test behaves like no required inputs
-	// All attributes from all sources will be included
-	assert.Contains(suite.T(), result, "username")
-	assert.Contains(suite.T(), result, "email")
-	assert.Contains(suite.T(), result, "phone")
-	assert.Contains(suite.T(), result, "given_name") // Will be included since GetInputs returns empty
+	assert.Equal(suite.T(), "testuser", result["username"])
+	assert.Equal(suite.T(), "auth@example.com", result["email"])
+	assert.Equal(suite.T(), "Test", result["given_name"])
+	assert.Equal(suite.T(), "+1234567890", result["phone"])
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_WithRequiredInputs_Priority() {
+// TestGetAttributesForProvisioning_ContextPriority verifies priority: UserInputs wins over
+// AuthenticatedUser.Attributes which wins over RuntimeData (first non-empty source wins).
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_ContextPriority() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "name", Required: true},
+			{Attribute: "phone", Required: true},
+		}, nil).Once()
+
 	ctx := &core.NodeContext{
-		UserInputs: map[string]string{
-			"email": "userinput@example.com",
-		},
+		UserInputs: map[string]string{"email": "userinput@example.com"},
 		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
 			Attributes: map[string]interface{}{
-				"email": "authenticated@example.com",
-				"phone": "+9999999999",
+				"email": "authn@example.com",
+				"name":  "Authn Name",
 			},
 		},
 		RuntimeData: map[string]string{
-			"phone": "+1234567890",
+			userTypeKey: testUserType,
+			"email":     "runtime@example.com",
+			"phone":     "+1234567890",
 		},
-		NodeInputs: []common.Input{
-			{Identifier: "email", Type: "string", Required: true},
-			{Identifier: "phone", Type: "string", Required: true},
-		},
+		NodeInputs: []common.Input{},
 	}
 
-	result := suite.executor.getAttributesForProvisioning(ctx)
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
 
-	// Note: GetInputs is mocked to return empty, so RuntimeData overwrites
-	// RuntimeData comes last in the loop and overwrites for 'phone'
+	// UserInputs is checked first — wins for email.
+	assert.Equal(suite.T(), "userinput@example.com", result["email"])
+	// Only in AuthenticatedUser — comes from there.
+	assert.Equal(suite.T(), "Authn Name", result["name"])
+	// Only in RuntimeData — comes from there.
 	assert.Equal(suite.T(), "+1234567890", result["phone"])
-	// email exists in all three, RuntimeData wins (no 'email' in RuntimeData, so AuthenticatedUser wins)
-	assert.Equal(suite.T(), "authenticated@example.com", result["email"])
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FilterNonUserAttributesFromAuthUser() {
+// TestGetAttributesForProvisioning_AllAttrsCollectedWhenNoNodeInputs verifies that when
+// node inputs are empty, all schema attrs with available values are collected (both required and optional).
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_AllAttrsCollectedWhenNoNodeInputs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "phone", Required: false},
+		}, nil).Once()
+
 	ctx := &core.NodeContext{
-		UserInputs: map[string]string{},
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
-			Attributes: map[string]interface{}{
-				"email":  "authenticated@example.com",
-				"userID": "should-be-filtered",
-				"code":   "should-be-filtered",
-				"nonce":  "should-be-filtered",
-			},
+		UserInputs: map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{
+			userTypeKey: testUserType,
+			"phone":     "+1234567890",
 		},
-		RuntimeData: map[string]string{},
-		NodeInputs:  []common.Input{},
+		NodeInputs: []common.Input{},
 	}
 
-	result := suite.executor.getAttributesForProvisioning(ctx)
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
 
-	assert.Contains(suite.T(), result, "email")
-	assert.NotContains(suite.T(), result, "userID")
-	assert.NotContains(suite.T(), result, "code")
-	assert.NotContains(suite.T(), result, "nonce")
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.Equal(suite.T(), "+1234567890", result["phone"],
+		"optional attr with a value must be collected when node inputs are empty")
+}
+
+// TestGetAttributesForProvisioning_OptionalAttrCollectedWhenInNodeInputs verifies that an optional
+// schema attr is collected when it is explicitly listed in node inputs.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrCollectedWhenInNodeInputs() {
+	nodeInputs := []common.Input{
+		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
+		{Identifier: "phone", Type: "TEXT_INPUT", Required: false},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "phone", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			"email": "user@example.com",
+			"phone": "+1234567890",
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+	}
+
+	result, _ := exec.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.Equal(suite.T(), "+1234567890", result["phone"],
+		"optional attr in node inputs must be collected")
+}
+
+// newExecutorWithNodeInputs creates a provisioningExecutor whose embedded ExecutorInterface
+// returns the given inputs from GetRequiredInputs.
+func (suite *ProvisioningExecutorTestSuite) newExecutorWithNodeInputs(inputs []common.Input) *provisioningExecutor {
+	mockExec := coremock.NewExecutorInterfaceMock(suite.T())
+	mockExec.On("GetRequiredInputs", mock.Anything).Return(inputs).Maybe()
+	mockExec.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(true).Maybe()
+
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockFlowFactory.On("CreateExecutor", ExecutorNameProvisioning, common.ExecutorTypeRegistration,
+		mock.Anything, mock.Anything).Return(mockExec)
+
+	identifyingMock := suite.createMockIdentifyingExecutor()
+	mockFlowFactory.On("CreateExecutor", ExecutorNameIdentifying, common.ExecutorTypeUtility,
+		mock.Anything, mock.Anything).Return(identifyingMock).Maybe()
+
+	return newProvisioningExecutor(mockFlowFactory,
+		suite.mockGroupService, suite.mockRoleService, suite.mockEntityProvider,
+		suite.mockUserSchemaService)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FilteredPath_RequiredAttrFromUserInputs() {
+	nodeInputs := []common.Input{
+		{Identifier: "username", Type: "TEXT_INPUT", Required: true},
+		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: "email", Required: true},
+			{Attribute: "mobileNumber", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			"username":     "testuser",
+			"email":        "test@example.com",
+			"mobileNumber": "0771234567",
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+	}
+
+	result, _ := exec.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "testuser", result["username"])
+	assert.Equal(suite.T(), "test@example.com", result["email"])
+	assert.Equal(suite.T(), "0771234567", result["mobileNumber"],
+		"required schema attr from UserInputs must be included even though it is not in node inputs")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FilteredPath_RequiredAttrFromAuthnAttrs() {
+	nodeInputs := []common.Input{
+		{Identifier: "username", Type: "TEXT_INPUT", Required: true},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: "email", Required: true},
+			{Attribute: "given_name", Required: true},
+			{Attribute: "mobileNumber", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{"username": "testuser"},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"email":        "federated@example.com",
+				"given_name":   "Test",
+				"mobileNumber": "0779876543",
+			},
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+	}
+
+	result, _ := exec.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "testuser", result["username"])
+	assert.Equal(suite.T(), "federated@example.com", result["email"])
+	assert.Equal(suite.T(), "Test", result["given_name"])
+	assert.Equal(suite.T(), "0779876543", result["mobileNumber"])
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_FilteredPath_UserInputTakesPriority() {
+	nodeInputs := []common.Input{
+		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "username", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{"email": "userinput@example.com"},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"email":    "authn@example.com",
+				"username": "federateduser",
+			},
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+	}
+
+	result, _ := exec.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "userinput@example.com", result["email"],
+		"UserInputs must win over AuthenticatedUser.Attributes for the same key")
+	assert.Equal(suite.T(), "federateduser", result["username"],
+		"required schema attr from AuthenticatedUser.Attributes must still be included")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlreadyExists() {
+	suite.expectSchemaForProvisioning()
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -470,6 +604,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlr
 		},
 		RuntimeData: map[string]string{
 			common.RuntimeKeySkipProvisioning: dataValueTrue,
+			userTypeKey:                       testUserType,
 		},
 		NodeInputs: []common.Input{
 			{Identifier: "username", Type: "string", Required: true},
@@ -495,6 +630,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlr
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_ProceedsNormally() {
+	suite.expectSchemaForProvisioning()
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -553,6 +689,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_Proceed
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvisioning() {
+	suite.expectSchemaForProvisioning()
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
@@ -602,6 +739,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvision
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_SetAfterCreation() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser", "email": "new@example.com"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -708,6 +846,7 @@ func (suite *ProvisioningExecutorTestSuite) TestAppendNonIdentifyingAttributes()
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_RegistrationFlow_SkipProvisioningWithExistingUser() {
+	suite.expectSchemaForProvisioning()
 	userID := "existing-user-id"
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
@@ -717,6 +856,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_RegistrationFlow_SkipPro
 		},
 		RuntimeData: map[string]string{
 			common.RuntimeKeySkipProvisioning: dataValueTrue,
+			userTypeKey:                       testUserType,
 		},
 		NodeInputs: []common.Input{
 			{Identifier: "username", Type: "string", Required: true},
@@ -739,58 +879,49 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_RegistrationFlow_SkipPro
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingInputs() {
-	tests := []struct {
-		name        string
-		runtimeData map[string]string
-	}{
-		{
-			name: "MissingOUID",
-			runtimeData: map[string]string{
-				userTypeKey: testUserType,
-			},
-		},
-		{
-			name: "MissingUserType",
-			runtimeData: map[string]string{
-				ouIDKey: testOUID,
-			},
-		},
+func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingInputs_MissingOUID() {
+	suite.expectSchemaForProvisioning()
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"username": "newuser"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
 	}
 
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			ctx := &core.NodeContext{
-				ExecutionID: "flow-123",
-				FlowType:    common.FlowTypeRegistration,
-				UserInputs: map[string]string{
-					"username": "newuser",
-				},
-				RuntimeData: tt.runtimeData,
-				NodeInputs: []common.Input{
-					{Identifier: "username", Type: "string", Required: true},
-				},
-			}
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{"username": "newuser"}).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
 
-			attrs := map[string]interface{}{
-				"username": "newuser",
-			}
-			suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(nil,
-				entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	resp, err := suite.executor.Execute(ctx)
 
-			resp, err := suite.executor.Execute(ctx)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Failed to create user", resp.FailureReason)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "CreateEntity")
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+}
 
-			assert.NoError(suite.T(), err)
-			assert.NotNil(suite.T(), resp)
-			assert.Equal(suite.T(), common.ExecFailure, resp.Status)
-			assert.Equal(suite.T(), "Failed to create user", resp.FailureReason)
-			suite.mockEntityProvider.AssertNotCalled(suite.T(), "CreateEntity")
-			suite.mockEntityProvider.AssertExpectations(suite.T())
-		})
+func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingInputs_MissingUserType() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"username": "newuser"},
+		RuntimeData: map[string]string{ouIDKey: testOUID},
+		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
 	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity")
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "CreateEntity")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFailures() {
+	suite.expectSchemaForProvisioning()
 	tests := []struct {
 		name               string
 		createdUser        *entityprovider.Entity
@@ -942,12 +1073,16 @@ func (suite *ProvisioningExecutorTestSuite) TestGetUserType() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AllAttributesInRuntimeData() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
-			"email":    "user@example.com",
-			"username": "testuser",
+			"email":     "user@example.com",
+			"username":  "testuser",
+			userTypeKey: testUserType,
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Attributes: map[string]interface{}{},
@@ -971,6 +1106,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AllAttributesI
 
 // Test group assignment failure - provisioning should fail, but role assignment should still be attempted
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentFails() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1028,6 +1164,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentF
 
 // Test both group and role assignment failure - provisioning should fail with combined error
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_BothGroupAndRoleAssignmentFail() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1088,6 +1225,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_BothGroupAndRole
 
 // Test role assignment failure - provisioning should fail, but group assignment succeeds
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFails() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1147,6 +1285,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFa
 
 // Test group with existing members - user should be appended
 func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1200,6 +1339,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers
 
 // Test authentication flow with auto-provisioning still assigns groups/roles
 func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisioning_AssignsGroupsAndRoles() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "provisioneduser"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1253,6 +1393,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisionin
 
 // Test successful provisioning with both group and role assignment (detailed verification)
 func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRoleAssignment() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser", "email": "new@example.com"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1325,6 +1466,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRole
 // Cross-OU provisioning tests
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_Success() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"sub": "user-sub-123"}
 	attrsJSON, _ := json.Marshal(attrs)
 
@@ -1371,6 +1513,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_Success() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_Fails() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"sub": "user-sub-123"}
 
 	existingUserID := testExistingUserID
@@ -1398,6 +1541,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_Fails
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_Fails() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"sub": "user-sub-123"}
 
 	existingUserID := testExistingUserID
@@ -1432,6 +1576,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_Fails() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NoTargetOU_Fails() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"sub": "user-sub-123"}
 
 	existingUserID := testExistingUserID
@@ -1461,6 +1606,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NoTargetOU_Fails
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_GetUserError() {
+	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"sub": "user-sub-123"}
 
 	existingUserID := testExistingUserID
@@ -1488,4 +1634,487 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_GetUserError() {
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), resp)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByUserInputs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: "Email"}}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result)
+	assert.Empty(suite.T(), execResp.Inputs)
+	assert.Nil(suite.T(), execResp.ForwardedData)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByRuntimeData() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: ""}}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType, "email": "user@example.com"},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result)
+	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByAuthnAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email"},
+			{Attribute: "firstName", DisplayName: "First Name"},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"email":     "user@example.com",
+				"firstName": "Test",
+			},
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result)
+	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMissing_AppendedToInputsAndForwardedData() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email Address"},
+			{Attribute: "firstName", DisplayName: ""},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 2)
+
+	inputMap := make(map[string]common.Input, len(execResp.Inputs))
+	for _, inp := range execResp.Inputs {
+		inputMap[inp.Identifier] = inp
+	}
+
+	emailInput, ok := inputMap["email"]
+	assert.True(suite.T(), ok)
+	assert.True(suite.T(), emailInput.Required)
+	assert.Equal(suite.T(), "Email Address", emailInput.DisplayName)
+
+	firstNameInput, ok := inputMap["firstName"]
+	assert.True(suite.T(), ok)
+	assert.Equal(suite.T(), "", firstNameInput.DisplayName)
+
+	assert.NotNil(suite.T(), execResp.ForwardedData)
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	assert.Len(suite.T(), fwdInputs, 2)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrCoveredByNodeInput_NotDuplicated() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: "Email"}}, nil).Once()
+
+	// email is already a node-defined input — schema must not create a second copy
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "email", Type: "string", Required: true}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result, "node input still missing so overall result is false")
+	emailCount := 0
+	for _, inp := range execResp.Inputs {
+		if inp.Identifier == "email" {
+			emailCount++
+		}
+	}
+	assert.Equal(suite.T(), 1, emailCount, "email must appear exactly once, not duplicated by schema")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MissingNodeInput_SchemaAttrsSatisfied_ReturnsFalse() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: ""}}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "username", Required: true}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result, "node input username is missing so overall must be false")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaServiceError_FallsThrough() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result, "schema service error should not fail the executor")
+	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaFilteredNoNodeInputs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Required: true},
+			{Attribute: "email", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			"username":    "testuser",
+			"extra_field": "should-not-appear",
+		},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"email": "test@example.com",
+			},
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
+	}
+
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "testuser", result["username"])
+	assert.Equal(suite.T(), "test@example.com", result["email"])
+	assert.NotContains(suite.T(), result, "extra_field",
+		"attrs not defined in schema must be excluded when schema is available")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrCollectedWhenNoNodeInputs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "phone", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{userTypeKey: testUserType, "phone": "+1234567890"},
+		NodeInputs:  []common.Input{},
+	}
+
+	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.Equal(suite.T(), "+1234567890", result["phone"],
+		"optional schema attr with a value must be collected when node inputs are empty")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaServiceError_ReturnsError() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs:  map[string]string{"email": "user@example.com", "username": "testuser"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
+	}
+
+	result, err := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.Nil(suite.T(), result, "schema service error must return nil map")
+	assert.Error(suite.T(), err, "schema service error must propagate as an error")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrSkippedWhenNotInNodeInputs() {
+	nodeInputs := []common.Input{{Identifier: "email", Required: true}}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "phone", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs:  map[string]string{"email": "user@example.com", "phone": "+1234567890"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+	}
+
+	result, err := exec.getAttributesForProvisioning(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.NotContains(suite.T(), result, "phone",
+		"optional attr not in nodeInputSet must be skipped when nodeInputSet is non-empty")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingNodeInputs_ExecUserInputRequired() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_GetAttributesError_ReturnsServerError() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Nil(suite.T(), resp)
+	assert.Error(suite.T(), err)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_EmptySchemaAttrs_NoUserAttributes() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "No user attributes provided for provisioning", resp.FailureReason)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_IdentifyUser_AmbiguousMatch_ReturnsFailureEarly() {
+	suite.expectSchemaForProvisioning()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"username": "newuser"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []common.Input{{Identifier: "username", Type: "string", Required: true}},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"username": "newuser"}).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeAmbiguousEntity, "ambiguous", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.NotEqual(suite.T(), failureReasonUserNotFound, resp.FailureReason)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_UnmarshalAttributesError_ReturnsServerError() {
+	suite.expectSchemaForProvisioning()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"username": "newuser"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []common.Input{{Identifier: "username", Type: "string", Required: true}},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{"username": "newuser"}).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.mockEntityProvider.On("CreateEntity", mock.Anything, mock.Anything).
+		Return(&entityprovider.Entity{
+			ID:         testNewUserID,
+			OUID:       testOUID,
+			Type:       testUserType,
+			Attributes: []byte(`invalid json`),
+		}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Nil(suite.T(), resp)
+	assert.Error(suite.T(), err)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NilRuntimeData_IsInitialized() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: nil}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.NotNil(suite.T(), execResp.RuntimeData)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestCheckNodeInputs_InputNotSatisfiedByAuthnAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []common.Input{{Identifier: "username", Required: true}},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{"email": "test@example.com"},
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), "username", execResp.Inputs[0].Identifier)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetGroupToAssign_NonStringValue_ReturnsEmpty() {
+	ctx := &core.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyAssignGroup: 42,
+		},
+	}
+
+	result := suite.executor.getGroupToAssign(ctx)
+
+	assert.Equal(suite.T(), "", result)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetRoleToAssign_NonStringValue_ReturnsEmpty() {
+	ctx := &core.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyAssignRole: true,
+		},
+	}
+
+	result := suite.executor.getRoleToAssign(ctx)
+
+	assert.Equal(suite.T(), "", result)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributes_NilService_ReturnsNil() {
+	pe := &provisioningExecutor{
+		ExecutorInterface:            suite.executor.ExecutorInterface,
+		identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
+		entityProvider:               suite.executor.entityProvider,
+		groupService:                 suite.executor.groupService,
+		roleService:                  suite.executor.roleService,
+		userSchemaService:            nil,
+		logger:                       suite.executor.logger,
+	}
+
+	ctx := &core.NodeContext{
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+
+	attrs, err := pe.fetchSchemaAttributes(ctx, pe.logger)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), attrs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestFetchAllNonCredentialAttributes_NilService_ReturnsNil() {
+	pe := &provisioningExecutor{
+		ExecutorInterface:            suite.executor.ExecutorInterface,
+		identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
+		entityProvider:               suite.executor.entityProvider,
+		groupService:                 suite.executor.groupService,
+		roleService:                  suite.executor.roleService,
+		userSchemaService:            nil,
+		logger:                       suite.executor.logger,
+	}
+
+	ctx := &core.NodeContext{
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+
+	attrs, err := pe.fetchAllNonCredentialAttributes(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), attrs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestCreateUserInStore_MissingUserType_ReturnsError() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		RuntimeData: map[string]string{ouIDKey: testOUID},
+	}
+
+	result, err := suite.executor.createUserInStore(ctx, map[string]interface{}{"username": "testuser"})
+
+	assert.Nil(suite.T(), result)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "user type not found")
 }

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -25,6 +25,7 @@ import (
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/entityprovider"
+	"github.com/asgardeo/thunder/internal/flow/common"
 )
 
 // getAuthnServiceName returns the authn service name for an executor.
@@ -59,4 +60,21 @@ func GetUserAttribute(user *entityprovider.Entity, attributeKey string) (string,
 	}
 
 	return "", fmt.Errorf("attribute '%s' not found or is empty", attributeKey)
+}
+
+// upsertInputs merges incoming inputs into existing: replaces entries with a matching
+// Identifier in-place, appends entries that are not yet present.
+func upsertInputs(existing []common.Input, incoming []common.Input) []common.Input {
+	idxMap := make(map[string]int, len(existing))
+	for i, inp := range existing {
+		idxMap[inp.Identifier] = i
+	}
+	for _, inp := range incoming {
+		if idx, exists := idxMap[inp.Identifier]; exists {
+			existing[idx] = inp
+		} else {
+			existing = append(existing, inp)
+		}
+	}
+	return existing
 }

--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -308,6 +308,82 @@ func (_c *UserSchemaServiceInterfaceMock_GetDisplayAttributesByNames_Call) RunAn
 	return _c
 }
 
+// GetNonCredentialAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetNonCredentialAttributes(ctx context.Context, userType string, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, requiredOnly)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNonCredentialAttributes")
+	}
+
+	var r0 []AttributeInfo
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) ([]AttributeInfo, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, requiredOnly)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) []AttributeInfo); ok {
+		r0 = returnFunc(ctx, userType, requiredOnly)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]AttributeInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, requiredOnly)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNonCredentialAttributes'
+type UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call struct {
+	*mock.Call
+}
+
+// GetNonCredentialAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+//   - requiredOnly bool
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetNonCredentialAttributes(ctx interface{}, userType interface{}, requiredOnly interface{}) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call{Call: _e.mock.On("GetNonCredentialAttributes", ctx, userType, requiredOnly)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) Run(run func(ctx context.Context, userType string, requiredOnly bool)) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) Return(vs []AttributeInfo, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Return(vs, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUniqueAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userType)

--- a/backend/internal/userschema/model/array.go
+++ b/backend/internal/userschema/model/array.go
@@ -44,6 +44,10 @@ func (p *array) isDisplayable() bool {
 	return false
 }
 
+func (p *array) getDisplayName() string {
+	return p.displayName
+}
+
 func (p *array) isUnique() bool {
 	return false
 }

--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -43,6 +43,10 @@ func (p *boolean) isDisplayable() bool {
 	return false
 }
 
+func (p *boolean) getDisplayName() string {
+	return p.displayName
+}
+
 func (p *boolean) isUnique() bool {
 	return false
 }

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -49,6 +49,10 @@ func (p *number) isDisplayable() bool {
 	return true
 }
 
+func (p *number) getDisplayName() string {
+	return p.displayName
+}
+
 func (p *number) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	numberValue, ok := convertToFloat64(value)
 	if !ok {

--- a/backend/internal/userschema/model/object.go
+++ b/backend/internal/userschema/model/object.go
@@ -43,6 +43,10 @@ func (p *object) isDisplayable() bool {
 	return false
 }
 
+func (p *object) getDisplayName() string {
+	return p.displayName
+}
+
 func (p *object) isUnique() bool {
 	return false
 }

--- a/backend/internal/userschema/model/schema.go
+++ b/backend/internal/userschema/model/schema.go
@@ -45,6 +45,7 @@ type property interface {
 	isCredential() bool
 	isDisplayable() bool
 	isUnique() bool
+	getDisplayName() string
 	validateValue(value interface{}, path string, logger *log.Logger) (bool, error)
 	validateUniqueness(value interface{}, path string,
 		exists func(map[string]interface{}) (bool, error), logger *log.Logger) (bool, error)
@@ -110,6 +111,35 @@ func (cs *Schema) ValidateAsDisplayAttribute(name string) DisplayAttributeStatus
 		return DisplayAttributeIsCredential
 	}
 	return DisplayAttributeValid
+}
+
+// AttributeInfo holds an attribute name, its required status, and its human-readable display label.
+// DisplayName may be empty when the schema definition omits the `displayName` field;
+// callers should fall back to Attribute when rendering a label.
+type AttributeInfo struct {
+	Attribute   string
+	DisplayName string
+	Required    bool
+}
+
+// GetNonCredentialAttributes returns top-level properties not marked as credentials.
+// When requiredOnly is true, only required properties are included.
+func (cs *Schema) GetNonCredentialAttributes(requiredOnly bool) []AttributeInfo {
+	result := make([]AttributeInfo, 0, len(cs.properties))
+	for attr, prop := range cs.properties {
+		if prop.isCredential() {
+			continue
+		}
+		if requiredOnly && !prop.isRequired() {
+			continue
+		}
+		result = append(result, AttributeInfo{
+			Attribute:   attr,
+			DisplayName: prop.getDisplayName(),
+			Required:    prop.isRequired(),
+		})
+	}
+	return result
 }
 
 // GetCredentialAttributes returns the names of top-level properties marked as credentials.

--- a/backend/internal/userschema/model/schema_test.go
+++ b/backend/internal/userschema/model/schema_test.go
@@ -271,3 +271,106 @@ func (s *SchemaValidateTestSuite) TestValidate_SkipCredentialRequired() {
 	s.Require().NoError(err)
 	s.Require().False(ok, "missing required credential should fail when skipCredentialRequired=false")
 }
+
+func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_ReturnsOnlyRequiredNonCredential() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"email":     {"type": "string", "required": true},
+		"firstName": {"type": "string", "required": true, "displayName": "First Name"},
+		"password":  {"type": "string", "required": true, "credential": true},
+		"age":       {"type": "number"}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetNonCredentialAttributes(true)
+
+	// Only email and firstName should be returned — password is credential, age is not required.
+	s.Len(attrs, 2)
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	email, ok := attrMap["email"]
+	s.Require().True(ok, "email should be in results")
+	s.Equal("", email.DisplayName, "email has no displayName, should be empty")
+
+	firstName, ok := attrMap["firstName"]
+	s.Require().True(ok, "firstName should be in results")
+	s.Equal("First Name", firstName.DisplayName)
+
+	_, hasPassword := attrMap["password"]
+	s.False(hasPassword, "password is credential and must be excluded")
+
+	_, hasAge := attrMap["age"]
+	s.False(hasAge, "age is not required and must be excluded")
+}
+
+func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_EmptySchema() {
+	schema := &Schema{properties: map[string]property{}}
+
+	attrs := schema.GetNonCredentialAttributes(true)
+
+	s.Empty(attrs, "empty schema should return no required attributes")
+}
+
+func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_AllCredential() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"password": {"type": "string", "required": true, "credential": true},
+		"pin":      {"type": "string", "required": true, "credential": true}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetNonCredentialAttributes(true)
+
+	s.Empty(attrs, "all required properties are credentials, result should be empty")
+}
+
+func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_AllAttrs_IncludesOptional() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"email":     {"type": "string", "required": true},
+		"firstName": {"type": "string", "required": true, "displayName": "First Name"},
+		"password":  {"type": "string", "required": true, "credential": true},
+		"age":       {"type": "number"}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetNonCredentialAttributes(false)
+
+	// email, firstName, age — password excluded (credential).
+	s.Len(attrs, 3, "all non-credential attributes should be returned regardless of required flag")
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	s.True(attrMap["email"].Required)
+	s.True(attrMap["firstName"].Required)
+	s.Equal("First Name", attrMap["firstName"].DisplayName)
+	s.False(attrMap["age"].Required, "optional attribute should be present with Required=false")
+	_, hasPassword := attrMap["password"]
+	s.False(hasPassword, "credential must always be excluded")
+}
+
+func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_DisplayNameOnNonStringTypes() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"active":  {"type": "boolean", "displayName": "Active Status"},
+		"score":   {"type": "number",  "displayName": "Score"},
+		"address": {"type": "object",  "displayName": "Address", "properties": {"city": {"type": "string"}}},
+		"tags":    {"type": "array",   "displayName": "Tags",    "items": {"type": "string"}}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetNonCredentialAttributes(false)
+	s.Len(attrs, 4)
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+	s.Equal("Active Status", attrMap["active"].DisplayName)
+	s.Equal("Score", attrMap["score"].DisplayName)
+	s.Equal("Address", attrMap["address"].DisplayName)
+	s.Equal("Tags", attrMap["tags"].DisplayName)
+}

--- a/backend/internal/userschema/model/string.go
+++ b/backend/internal/userschema/model/string.go
@@ -51,6 +51,10 @@ func (p *str) isDisplayable() bool {
 	return true
 }
 
+func (p *str) getDisplayName() string {
+	return p.displayName
+}
+
 func (p *str) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	strValue, ok := value.(string)
 	if !ok {

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -40,6 +40,10 @@ import (
 
 const userSchemaLoggerComponentName = "UserSchemaService"
 
+// AttributeInfo is an alias for model.AttributeInfo, exported at the userschema package
+// level so callers do not need to import the internal model package directly.
+type AttributeInfo = model.AttributeInfo
+
 // UserSchemaServiceInterface defines the interface for the user schema service.
 type UserSchemaServiceInterface interface {
 	GetUserSchemaList(ctx context.Context, limit, offset int,
@@ -74,6 +78,9 @@ type UserSchemaServiceInterface interface {
 	GetDisplayAttributesByNames(
 		ctx context.Context, names []string,
 	) (map[string]string, *serviceerror.ServiceError)
+	GetNonCredentialAttributes(
+		ctx context.Context, userType string, requiredOnly bool,
+	) ([]AttributeInfo, *serviceerror.ServiceError)
 }
 
 // userSchemaService is the default implementation of the UserSchemaServiceInterface.
@@ -625,6 +632,25 @@ func (us *userSchemaService) GetDisplayAttributesByNames(
 	}
 
 	return result, nil
+}
+
+// GetNonCredentialAttributes returns non-credential attributes defined in the schema for the given
+// user type. When requiredOnly is true, only required attributes are returned.
+func (us *userSchemaService) GetNonCredentialAttributes(
+	ctx context.Context, userType string, requiredOnly bool,
+) ([]AttributeInfo, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
+
+	compiledSchema, err := us.getCompiledSchemaForUserType(ctx, userType, logger)
+	if err != nil {
+		if errors.Is(err, ErrUserSchemaNotFound) {
+			return nil, &ErrorUserSchemaNotFound
+		}
+		return nil, logAndReturnServerError(logger,
+			"Failed to load user schema for non-credential attributes", err)
+	}
+
+	return compiledSchema.GetNonCredentialAttributes(requiredOnly), nil
 }
 
 func (us *userSchemaService) getCompiledSchemaForUserType(

--- a/backend/internal/userschema/service_test.go
+++ b/backend/internal/userschema/service_test.go
@@ -751,15 +751,15 @@ func TestValidateUserSchemaDefinitionWithNilSystemAttributes(t *testing.T) {
 	require.Nil(t, err)
 }
 
-type GetCredentialAttributesTestSuite struct {
+type UserSchemaServiceTestSuite struct {
 	suite.Suite
 }
 
-func TestGetCredentialAttributesTestSuite(t *testing.T) {
-	suite.Run(t, new(GetCredentialAttributesTestSuite))
+func TestUserSchemaServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(UserSchemaServiceTestSuite))
 }
 
-func (s *GetCredentialAttributesTestSuite) TestReturnsCredentialFieldNames() {
+func (s *UserSchemaServiceTestSuite) TestGetCredentialAttributes_ReturnsCredentialFieldNames() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "customer").
@@ -786,7 +786,7 @@ func (s *GetCredentialAttributesTestSuite) TestReturnsCredentialFieldNames() {
 	s.Require().Equal([]string{"apiKey", "password"}, fields)
 }
 
-func (s *GetCredentialAttributesTestSuite) TestNoCredentials_ReturnsEmpty() {
+func (s *UserSchemaServiceTestSuite) TestGetCredentialAttributes_TestNoCredentials_ReturnsEmpty() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "customer").
@@ -810,7 +810,7 @@ func (s *GetCredentialAttributesTestSuite) TestNoCredentials_ReturnsEmpty() {
 	s.Require().Empty(fields)
 }
 
-func (s *GetCredentialAttributesTestSuite) TestSchemaNotFound_ReturnsError() {
+func (s *UserSchemaServiceTestSuite) TestGetCredentialAttributes_TestSchemaNotFound_ReturnsError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "unknown").
@@ -831,7 +831,7 @@ func (s *GetCredentialAttributesTestSuite) TestSchemaNotFound_ReturnsError() {
 	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
 }
 
-func (s *GetCredentialAttributesTestSuite) TestEmptyUserType_ReturnsError() {
+func (s *UserSchemaServiceTestSuite) TestGetCredentialAttributes_TestEmptyUserType_ReturnsError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 
 	service := &userSchemaService{
@@ -848,7 +848,7 @@ func (s *GetCredentialAttributesTestSuite) TestEmptyUserType_ReturnsError() {
 	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
 }
 
-func (s *GetCredentialAttributesTestSuite) TestStoreError_ReturnsInternalError() {
+func (s *UserSchemaServiceTestSuite) TestGetCredentialAttributes_TestStoreError_ReturnsInternalError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "customer").
@@ -869,15 +869,7 @@ func (s *GetCredentialAttributesTestSuite) TestStoreError_ReturnsInternalError()
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
 }
 
-type GetUniqueAttributesTestSuite struct {
-	suite.Suite
-}
-
-func TestGetUniqueAttributesTestSuite(t *testing.T) {
-	suite.Run(t, new(GetUniqueAttributesTestSuite))
-}
-
-func (s *GetUniqueAttributesTestSuite) TestReturnsUniqueFieldNames() {
+func (s *UserSchemaServiceTestSuite) TestGetUniqueAttributes_ReturnsUniqueFieldNames() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "customer").
@@ -902,7 +894,7 @@ func (s *GetUniqueAttributesTestSuite) TestReturnsUniqueFieldNames() {
 	s.Require().Equal([]string{"email", "username"}, fields)
 }
 
-func (s *GetUniqueAttributesTestSuite) TestNoUniqueAttributes_ReturnsEmpty() {
+func (s *UserSchemaServiceTestSuite) TestGetUniqueAttributes_TestNoUniqueAttributes_ReturnsEmpty() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "customer").
@@ -922,7 +914,7 @@ func (s *GetUniqueAttributesTestSuite) TestNoUniqueAttributes_ReturnsEmpty() {
 	s.Require().Empty(fields)
 }
 
-func (s *GetUniqueAttributesTestSuite) TestSchemaNotFound_ReturnsError() {
+func (s *UserSchemaServiceTestSuite) TestGetUniqueAttributes_TestSchemaNotFound_ReturnsError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetUserSchemaByName", context.Background(), "unknown").
@@ -941,7 +933,7 @@ func (s *GetUniqueAttributesTestSuite) TestSchemaNotFound_ReturnsError() {
 	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
 }
 
-func (s *GetUniqueAttributesTestSuite) TestEmptyUserType_ReturnsError() {
+func (s *UserSchemaServiceTestSuite) TestGetUniqueAttributes_TestEmptyUserType_ReturnsError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 
 	service := &userSchemaService{
@@ -1249,15 +1241,7 @@ func TestValidateDisplayAttribute_DottedPath_DeeplyNestedValid(t *testing.T) {
 
 // GetDisplayAttributesByNames tests
 
-type GetDisplayAttributesByNamesTestSuite struct {
-	suite.Suite
-}
-
-func TestGetDisplayAttributesByNamesTestSuite(t *testing.T) {
-	suite.Run(t, new(GetDisplayAttributesByNamesTestSuite))
-}
-
-func (s *GetDisplayAttributesByNamesTestSuite) TestReturnsDisplayAttributes() {
+func (s *UserSchemaServiceTestSuite) TestGetDisplayAttributesByNames_ReturnsDisplayAttributes() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	expected := map[string]string{"SchemaA": "email", "SchemaB": "given_name"}
 	storeMock.
@@ -1274,7 +1258,7 @@ func (s *GetDisplayAttributesByNamesTestSuite) TestReturnsDisplayAttributes() {
 	s.Require().Equal(expected, result)
 }
 
-func (s *GetDisplayAttributesByNamesTestSuite) TestEmptyInput_ReturnsEmptyMap() {
+func (s *UserSchemaServiceTestSuite) TestGetDisplayAttributesByNames_TestEmptyInput_ReturnsEmptyMap() {
 	service := &userSchemaService{}
 
 	result, svcErr := service.GetDisplayAttributesByNames(context.Background(), []string{})
@@ -1283,7 +1267,7 @@ func (s *GetDisplayAttributesByNamesTestSuite) TestEmptyInput_ReturnsEmptyMap() 
 	s.Require().Empty(result)
 }
 
-func (s *GetDisplayAttributesByNamesTestSuite) TestStoreError_ReturnsServerError() {
+func (s *UserSchemaServiceTestSuite) TestGetDisplayAttributesByNames_TestStoreError_ReturnsServerError() {
 	storeMock := newUserSchemaStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetDisplayAttributesByNames", mock.Anything, []string{"SchemaA"}).
@@ -1296,4 +1280,151 @@ func (s *GetDisplayAttributesByNamesTestSuite) TestStoreError_ReturnsServerError
 
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_RequiredOnly_ReturnsAttributes() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "INTERNAL").
+		Return(UserSchema{
+			Schema: json.RawMessage(
+				`{"email":{"type":"string","required":true},` +
+					`"firstName":{"type":"string","required":true,"displayName":"First Name"},` +
+					`"password":{"type":"string","required":true,"credential":true},` +
+					`"age":{"type":"number"}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "INTERNAL", true)
+
+	s.Require().Nil(svcErr)
+	s.Require().Len(attrs, 2)
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	email, ok := attrMap["email"]
+	s.Require().True(ok, "email should be returned")
+	s.Equal("", email.DisplayName)
+
+	firstName, ok := attrMap["firstName"]
+	s.Require().True(ok, "firstName should be returned")
+	s.Equal("First Name", firstName.DisplayName)
+
+	_, hasPassword := attrMap["password"]
+	s.False(hasPassword, "password is credential and must be excluded")
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_TestUnknownUserType_ReturnsError() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "unknown").
+		Return(UserSchema{}, ErrUserSchemaNotFound).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "unknown", true)
+
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
+	s.Require().Nil(attrs)
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_TestEmptyUserType_ReturnsError() {
+	service := &userSchemaService{
+		userSchemaStore: newUserSchemaStoreInterfaceMock(s.T()),
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "", true)
+
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
+	s.Require().Nil(attrs)
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_TestAllCredentials_ReturnsEmpty() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "INTERNAL").
+		Return(UserSchema{
+			Schema: json.RawMessage(
+				`{"password":{"type":"string","required":true,"credential":true}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "INTERNAL", true)
+
+	s.Require().Nil(svcErr)
+	s.Require().Empty(attrs)
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_AllAttrs_IncludesOptional() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "INTERNAL").
+		Return(UserSchema{
+			Schema: json.RawMessage(
+				`{"email":{"type":"string","required":true},` +
+					`"mobileNumber":{"type":"string"},` +
+					`"password":{"type":"string","required":true,"credential":true}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "INTERNAL", false)
+
+	s.Require().Nil(svcErr)
+	s.Require().Len(attrs, 2, "email and mobileNumber should be returned; password excluded as credential")
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+	s.True(attrMap["email"].Required)
+	s.False(attrMap["mobileNumber"].Required, "optional attribute must be included with Required=false")
+	_, hasPassword := attrMap["password"]
+	s.False(hasPassword, "credential must always be excluded")
+}
+
+func (s *UserSchemaServiceTestSuite) TestGetNonCredentialAttributes_StoreError_ReturnsServerError() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "INTERNAL").
+		Return(UserSchema{}, errors.New("db failure")).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), "INTERNAL", false)
+
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
+	s.Require().Nil(attrs)
 }

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -309,6 +309,82 @@ func (_c *UserSchemaServiceInterfaceMock_GetDisplayAttributesByNames_Call) RunAn
 	return _c
 }
 
+// GetNonCredentialAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetNonCredentialAttributes(ctx context.Context, userType string, requiredOnly bool) ([]userschema.AttributeInfo, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, requiredOnly)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNonCredentialAttributes")
+	}
+
+	var r0 []userschema.AttributeInfo
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) ([]userschema.AttributeInfo, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, requiredOnly)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) []userschema.AttributeInfo); ok {
+		r0 = returnFunc(ctx, userType, requiredOnly)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]userschema.AttributeInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, requiredOnly)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNonCredentialAttributes'
+type UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call struct {
+	*mock.Call
+}
+
+// GetNonCredentialAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+//   - requiredOnly bool
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetNonCredentialAttributes(ctx interface{}, userType interface{}, requiredOnly interface{}) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call{Call: _e.mock.On("GetNonCredentialAttributes", ctx, userType, requiredOnly)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) Run(run func(ctx context.Context, userType string, requiredOnly bool)) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) Return(vs []userschema.AttributeInfo, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Return(vs, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string, requiredOnly bool) ([]userschema.AttributeInfo, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetNonCredentialAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUniqueAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userType)

--- a/tests/integration/flow/registration/basic_registration_test.go
+++ b/tests/integration/flow/registration/basic_registration_test.go
@@ -46,13 +46,16 @@ var (
 				"credential": true,
 			},
 			"email": map[string]interface{}{
-				"type": "string",
+				"type":     "string",
+				"required": true,
 			},
 			"given_name": map[string]interface{}{
-				"type": "string",
+				"type":     "string",
+				"required": true,
 			},
 			"family_name": map[string]interface{}{
-				"type": "string",
+				"type":     "string",
+				"required": true,
 			},
 			"mobileNumber": map[string]interface{}{
 				"type": "string",
@@ -194,7 +197,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_schema_attrs",
 		completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
@@ -324,7 +327,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_schema_attrs",
 		completeFlowStep.ChallengeToken)
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
@@ -452,7 +455,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithoutToken
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_schema_attrs",
 		completeFlowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
@@ -521,7 +524,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info",
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_schema_attrs",
 		completeFlowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
@@ -542,4 +545,471 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 	ts.Require().Empty(jwtClaims.OUID, "ouId should NOT be present when user_attributes is empty")
 	ts.Require().Empty(jwtClaims.OuName, "ouName should NOT be present when user_attributes is empty")
 	ts.Require().Empty(jwtClaims.OuHandle, "ouHandle should NOT be present when user_attributes is empty")
+}
+
+// TestSchemaDriverInputs_DynamicPromptForMissingRequiredAttrs verifies that when only credentials
+// are submitted, the provisioning executor detects schema-required attributes and triggers an
+// additional prompt step carrying those inputs dynamically.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_DynamicPromptForMissingRequiredAttrs() {
+	username := common.GenerateUniqueUsername("schemauser")
+
+	// Step 1: Initiate flow — credentials only, no schema attrs.
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{
+		"username": username,
+		"password": "testpassword123",
+	}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	// Step 2: Expect an incomplete step prompting for schema-required attrs.
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Data.Inputs, "schema-required inputs should be present in the prompt")
+	ts.Require().True(common.ValidateRequiredInputs(flowStep.Data.Inputs, []string{"email", "given_name", "family_name"}),
+		"email, given_name, family_name must be dynamically prompted")
+	ts.Require().False(common.HasInput(flowStep.Data.Inputs, "username"),
+		"username should not appear again — it was already provided")
+	ts.Require().False(common.HasInput(flowStep.Data.Inputs, "mobileNumber"),
+		"optional mobileNumber should not be prompted when not in node inputs")
+
+	// Step 3: Submit schema attrs and complete.
+	inputs = map[string]string{
+		"email":       username + "@example.com",
+		"given_name":  "Schema",
+		"family_name": "User",
+	}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_schema_attrs", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(user)
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+}
+
+// TestSchemaDriverInputs_NoPromptWhenAllInputsPresent verifies that when all schema-required
+// attributes are provided upfront in the initial request, the flow completes without an
+// additional schema-attrs prompt step.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_NoPromptWhenAllInputsPresent() {
+	username := common.GenerateUniqueUsername("nopromptuser")
+
+	inputs := map[string]string{
+		"username":    username,
+		"password":    "testpassword123",
+		"email":       username + "@example.com",
+		"given_name":  "No",
+		"family_name": "Prompt",
+	}
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, inputs, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus,
+		"flow should complete in one step when all required attrs are provided")
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(user)
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+}
+
+// TestSchemaDriverInputs_OptionalAttrProvisionedWhenInNodeInputs verifies that an optional
+// schema attribute (mobileNumber) is collected and stored when it is explicitly listed as a
+// node input in the provisioning executor configuration.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_OptionalAttrProvisionedWhenInNodeInputs() {
+	// Create a custom flow that adds mobileNumber as a node input on the provisioning executor.
+	optionalAttrFlow := testutils.Flow{
+		Name:     "Optional Attr Registration Flow",
+		Handle:   "optional-attr-reg-flow",
+		FlowType: "REGISTRATION",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "user_type_resolver"},
+			{
+				"id":   "user_type_resolver",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "UserTypeResolver",
+				},
+				"onSuccess":    "prompt_credentials",
+				"onIncomplete": "prompt_usertype",
+			},
+			{
+				"id":   "prompt_usertype",
+				"type": "PROMPT",
+				"meta": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{"type": "BLOCK", "id": "block_usertype", "components": []map[string]interface{}{
+							{"type": "SELECT", "id": "usertype_input", "ref": "userType", "label": "User Type", "required": true, "options": []string{}},
+							{"type": "ACTION", "id": "action_usertype", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT"},
+						}},
+					},
+				},
+				"prompts": []map[string]interface{}{
+					{"inputs": []map[string]interface{}{{"ref": "usertype_input", "identifier": "userType", "type": "SELECT", "required": true}},
+						"action": map[string]interface{}{"ref": "action_usertype", "nextNode": "user_type_resolver"}},
+				},
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"meta": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{"type": "BLOCK", "id": "block_creds", "components": []map[string]interface{}{
+							{"type": "TEXT_INPUT", "id": "input_username", "ref": "username", "label": "Username", "required": true},
+							{"type": "PASSWORD_INPUT", "id": "input_password", "ref": "password", "label": "Password", "required": true},
+							{"type": "ACTION", "id": "action_credentials", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT"},
+						}},
+					},
+				},
+				"prompts": []map[string]interface{}{
+					{"inputs": []map[string]interface{}{
+						{"ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					}, "action": map[string]interface{}{"ref": "action_credentials", "nextNode": "basic_auth"}},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+				},
+				"onSuccess": "provisioning",
+			},
+			{
+				"id":   "provisioning",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "ProvisioningExecutor",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+						{"ref": "input_003", "identifier": "mobileNumber", "type": "TEXT_INPUT", "required": false},
+					},
+				},
+				"onSuccess":    "auth_assert",
+				"onIncomplete": "prompt_schema_attrs",
+			},
+			{
+				"id":   "prompt_schema_attrs",
+				"type": "PROMPT",
+				"meta": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{"align": "center", "type": "TEXT", "id": "heading_schema_attrs", "label": "Complete Your Profile", "variant": "HEADING_1"},
+						{"type": "BLOCK", "id": "block_dynamic_user_inputs", "components": []map[string]interface{}{
+							{"type": "ACTION", "id": "action_schema_attrs", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT"},
+						}},
+					},
+				},
+				"prompts": []map[string]interface{}{
+					{"inputs": []map[string]interface{}{}, "action": map[string]interface{}{"ref": "action_schema_attrs", "nextNode": "provisioning"}},
+				},
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+
+	flowID, err := testutils.CreateFlow(optionalAttrFlow)
+	ts.Require().NoError(err, "Failed to create optional attr flow")
+	defer func() {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete optional attr flow: %v", err)
+		}
+	}()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		OUID:                      ts.testOUID,
+		Name:                      "Optional Attr Test App",
+		IsRegistrationFlowEnabled: true,
+		ClientID:                  "optional_attr_test_client",
+		ClientSecret:              "optional_attr_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{testUserSchema.Name},
+		RegistrationFlowID:        flowID,
+	})
+	ts.Require().NoError(err, "Failed to create test app")
+	defer func() {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test app: %v", err)
+		}
+	}()
+
+	username := common.GenerateUniqueUsername("optionaluser")
+	mobile := "+94771234567"
+
+	// Initiate with credentials.
+	flowStep, err := common.InitiateRegistrationFlow(appID, false, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{"username": username, "password": "testpassword123"}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	// Submit schema-required attrs and the optional mobileNumber.
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	inputs = map[string]string{
+		"email":        username + "@example.com",
+		"given_name":   "Optional",
+		"family_name":  "User",
+		"mobileNumber": mobile,
+	}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_schema_attrs", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	// Verify mobileNumber was stored.
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(user)
+	userAttrs, err := testutils.GetUserAttributes(*user)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mobile, userAttrs["mobileNumber"],
+		"optional mobileNumber should be provisioned when listed in node inputs")
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+}
+
+// TestSchemaDriverInputs_VerboseModeReturnsDynamicMeta verifies that in verbose mode the
+// prompt_schema_attrs step includes synthetic meta components for each schema-derived input
+// that has no pre-configured meta component in the flow graph node.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_VerboseModeReturnsDynamicMeta() {
+	username := common.GenerateUniqueUsername("verboseuser")
+
+	// Initiate with verbose=true and credentials only.
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, true, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{"username": username, "password": "testpassword123"}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	// Verbose mode must return meta.
+	ts.Require().NotNil(flowStep.Data.Meta, "meta should be present in verbose mode")
+
+	metaMap, ok := flowStep.Data.Meta.(map[string]interface{})
+	ts.Require().True(ok, "meta should be a JSON object")
+
+	components, ok := metaMap["components"].([]interface{})
+	ts.Require().True(ok, "meta.components should be an array")
+	ts.Require().NotEmpty(components, "meta.components should not be empty")
+
+	// Collect all component refs/ids from the meta tree.
+	componentRefs := collectMetaComponentRefs(components)
+	for _, attr := range []string{"email", "given_name", "family_name"} {
+		ts.Require().True(componentRefs[attr],
+			"synthetic meta component must exist for schema-derived input %q", attr)
+	}
+
+	// Complete registration.
+	inputs = map[string]string{
+		"email":       username + "@example.com",
+		"given_name":  "Verbose",
+		"family_name": "User",
+	}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_schema_attrs", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(user)
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+}
+
+// TestSchemaDriverInputs_PromptedInputsHaveRequiredTrue verifies that all schema-required inputs
+// surfaced in the INCOMPLETE prompt step carry required=true.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_PromptedInputsHaveRequiredTrue() {
+	username := common.GenerateUniqueUsername("reqflaguser")
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{"username": username, "password": "testpassword123"}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Data.Inputs)
+	for _, inp := range flowStep.Data.Inputs {
+		ts.Require().True(inp.Required,
+			"schema-required attr %q must have required=true in the prompt response", inp.Identifier)
+	}
+}
+
+// TestSchemaDriverInputs_VerboseMeta_NoDynamicPlaceholder verifies that the
+// DYNAMIC_INPUT_PLACEHOLDER sentinel component is replaced and never appears in
+// the meta returned to the client.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_VerboseMeta_NoDynamicPlaceholder() {
+	username := common.GenerateUniqueUsername("noplaceholder")
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, true, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{"username": username, "password": "testpassword123"}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotNil(flowStep.Data.Meta)
+
+	metaMap, ok := flowStep.Data.Meta.(map[string]interface{})
+	ts.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	ts.Require().True(ok)
+
+	types := collectMetaComponentTypes(comps)
+	ts.Require().False(types["DYNAMIC_INPUT_PLACEHOLDER"],
+		"DYNAMIC_INPUT_PLACEHOLDER must be replaced, not present in the meta output")
+}
+
+// TestSchemaDriverInputs_DisplayNameUsedAsMetaLabel verifies that when a schema attribute
+// has a displayName, the synthetic meta component generated for it in verbose mode uses
+// the displayName as the label, not the attribute identifier.
+func (ts *BasicRegistrationFlowTestSuite) TestSchemaDriverInputs_DisplayNameUsedAsMetaLabel() {
+	schemaWithDisplayName := testutils.UserSchema{
+		Name: "dn-label-test-type",
+		OUID: ts.testOUID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+			"email": map[string]interface{}{
+				"type":        "string",
+				"required":    true,
+				"displayName": "Email Address",
+			},
+			"given_name": map[string]interface{}{
+				"type":     "string",
+				"required": true,
+			},
+		},
+		AllowSelfRegistration: true,
+	}
+	schemaID, err := testutils.CreateUserType(schemaWithDisplayName)
+	ts.Require().NoError(err, "Failed to create displayName test schema")
+	defer func() {
+		if err := testutils.DeleteUserType(schemaID); err != nil {
+			ts.T().Logf("Failed to delete displayName test schema: %v", err)
+		}
+	}()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		OUID:                      ts.testOUID,
+		Name:                      "DisplayName Label Test App",
+		IsRegistrationFlowEnabled: true,
+		ClientID:                  "dn_label_test_client",
+		ClientSecret:              "dn_label_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{schemaWithDisplayName.Name},
+	})
+	ts.Require().NoError(err, "Failed to create displayName test app")
+	defer func() {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete displayName test app: %v", err)
+		}
+	}()
+
+	username := common.GenerateUniqueUsername("dnlabeluser")
+
+	flowStep, err := common.InitiateRegistrationFlow(appID, true, nil, "")
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{"username": username, "password": "testpassword123"}
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotNil(flowStep.Data.Meta, "verbose meta must be present in schema-prompting step")
+
+	metaMap, ok := flowStep.Data.Meta.(map[string]interface{})
+	ts.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	ts.Require().True(ok)
+
+	emailLabel, found := findMetaComponentLabel(comps, "email")
+	ts.Require().True(found, "synthetic meta component for 'email' must exist")
+	ts.Require().Equal("Email Address", emailLabel,
+		"displayName must be used as the label for schema-derived inputs with displayName set")
+
+	givenNameLabel, found := findMetaComponentLabel(comps, "given_name")
+	ts.Require().True(found, "synthetic meta component for 'given_name' must exist")
+	ts.Require().Equal("given_name", givenNameLabel,
+		"identifier must be used as fallback label when displayName is absent")
+}
+
+// collectMetaComponentRefs recursively collects "ref" and "id" values from a meta components tree.
+func collectMetaComponentRefs(components []interface{}) map[string]bool {
+	refs := make(map[string]bool)
+	for _, c := range components {
+		comp, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if ref, ok := comp["ref"].(string); ok && ref != "" {
+			refs[ref] = true
+		}
+		if id, ok := comp["id"].(string); ok && id != "" {
+			refs[id] = true
+		}
+		if children, ok := comp["components"].([]interface{}); ok {
+			for k, v := range collectMetaComponentRefs(children) {
+				refs[k] = v
+			}
+		}
+	}
+	return refs
+}
+
+// collectMetaComponentTypes recursively collects all "type" values from a meta components tree.
+func collectMetaComponentTypes(components []interface{}) map[string]bool {
+	types := make(map[string]bool)
+	for _, c := range components {
+		comp, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, ok := comp["type"].(string); ok && t != "" {
+			types[t] = true
+		}
+		if children, ok := comp["components"].([]interface{}); ok {
+			for k, v := range collectMetaComponentTypes(children) {
+				types[k] = v
+			}
+		}
+	}
+	return types
+}
+
+// findMetaComponentLabel recursively searches for a component by ref or id and returns its label.
+func findMetaComponentLabel(components []interface{}, ref string) (string, bool) {
+	for _, c := range components {
+		comp, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		compRef, _ := comp["ref"].(string)
+		compID, _ := comp["id"].(string)
+		if compRef == ref || compID == ref {
+			if label, ok := comp["label"].(string); ok {
+				return label, true
+			}
+		}
+		if children, ok := comp["components"].([]interface{}); ok {
+			if label, found := findMetaComponentLabel(children, ref); found {
+				return label, found
+			}
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
### Purpose
Registration flows hardcoded user profile attributes (e.g., given_name, family_name, email) directly in flow JSON definitions and in the provisioning executor's input list. This meant every new schema attribute required a flow JSON change, and flows could prompt for fields the user schema didn't even define.

This PR makes provisioning inputs schema-driven: the provisioning executor queries the user schema at runtime to determine which non-credential required attributes are missing, and the prompt node dynamically renders input components for them without any hardcoded field definitions in the flow.

### Approach

**Provisioning executor (provisioning_executor.go):**

Extended HasRequiredInputs to call GetRequiredNonCredentialAttributes on the user schema service after checking node-defined inputs.
Schema-only attributes (not already covered by node inputs) are checked across all context sources (user inputs, runtime data, authenticated user attributes). Missing ones are appended to the executor response and forwarded via ForwardedData to the prompt node.
A single credential attribute (password) is still handled explicitly via the node input definition — schema credential collection is intentionally out of scope (see schema model analysis).

**Prompt node (prompt_node.go):**

Added enrichInputsFromForwardedData: reads schema-derived inputs forwarded by the provisioning executor and appends any that are unsatisfied and not already in the node's prompt definition.
Added appendSyntheticMetaComponents: generates minimal UI component entries (type, label, ref) for schema-derived inputs that have no pre-configured meta component, allowing the frontend to render them without flow JSON changes.


### Related Issues
- https://github.com/asgardeo/thunder/issues/2020

### Related PRs
- https://github.com/asgardeo/thunder/pull/2388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added select/dropdown input support, new meta component types (BLOCK/ACTION), synthetic metadata injection for schema-derived inputs, provisioning that validates and surfaces required non-credential user attributes, and internal input display labels hidden from API/JSON. Public user-schema endpoints expose non-credential and required non-credential attributes.

* **Tests**
  * Expanded coverage for input serialization, forwarded-data enrichment, graph serialization, provisioning attribute handling, schema attribute discovery, and added mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->