### PR TITLE
Fix PR builder checks being skipped on label events

### DIFF
--- a/.github/workflows/dependency-approved-retrigger.yml
+++ b/.github/workflows/dependency-approved-retrigger.yml
@@ -1,0 +1,41 @@
+# Re-runs the PR Builder workflow when the `dependencies-approved` label is added.
+# The PR Builder intentionally does not trigger on `labeled` events to avoid
+# skipping all checks when unrelated labels are added.
+
+name: 🔄 Re-run PR Builder on Dependency Approval
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  retrigger:
+    name: 🔄 Re-trigger PR Builder
+    if: github.event.label.name == 'dependencies-approved'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-run latest PR Builder
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pr-builder.yml',
+              head_sha: context.payload.pull_request.head.sha,
+              per_page: 1
+            });
+
+            if (runs.data.workflow_runs.length > 0) {
+              const run = runs.data.workflow_runs[0];
+              core.info(`Re-running PR Builder run #${run.id} (${run.status})`);
+              await github.rest.actions.reRunWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            } else {
+              core.warning('No PR Builder run found for this commit. The PR Builder will run on the next push.');
+            }

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -7,14 +7,14 @@ name: 👷🛠️ PR Builder
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   merge_group:
   workflow_dispatch:
 
 # Avoid running multiple PR builders for the same PR on subsequent pushes.
 concurrency:
   group: pr-builder-${{ github.ref }}
-  cancel-in-progress: ${{ github.event.action != 'labeled' }}
+  cancel-in-progress: true
 
 env:
   GOFLAGS: "-mod=readonly"
@@ -29,7 +29,7 @@ jobs:
 
   security-audit:
     name: 🔒 Security Audit
-    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -113,7 +113,7 @@ jobs:
 
   dependency-review:
     name: 🔎 Dependency Review
-    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,7 +133,7 @@ jobs:
 
   verify-mocks:
     name: 🔍 Verify Mock Files
-    if: ${{ (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -169,7 +169,7 @@ jobs:
   lint:
     name: 🧹 Lint Code
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && ((github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -227,7 +227,7 @@ jobs:
   build:
     name: 🛠️ Build Product
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -318,7 +318,7 @@ jobs:
   test-frontend:
     name: 🧪 Frontend Tests (shard ${{ matrix.shard }}/4)
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -437,7 +437,7 @@ jobs:
   build_samples:
     name: 🛠️ Build Sample Apps
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -789,7 +789,7 @@ jobs:
 
   detect-powershell-changes:
     name: 🔍 Detect PowerShell Changes
-    if: (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.filter.outputs.powershell }}
@@ -813,7 +813,7 @@ jobs:
 
   detect-docs-changes:
     name: 🔍 Detect Documentation Changes
-    if: (github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'dependencies-approved')) || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.filter.outputs.docs }}


### PR DESCRIPTION
### Purpose

When any label (e.g., `Type/Improvement`) is added to a PR, the PR builder workflow triggers but all jobs are skipped because:

1. `labeled` was previously a trigger type, so adding any label fires the workflow.
2. Every job condition filtered specifically for `dependencies-approved`, causing all non-matching label events to skip every check.
3. GitHub treats skipped checks as passing, making it appear as if CI passed when it never ran.

This was observed in #2455 where all checks show as "skipped" after adding the `Type/Improvement` label.

The `labeled` trigger type has since been removed from the PR builder, but three jobs still reference a dead `trigger-pr-builder` label condition, and there's no mechanism to re-trigger the builder when `dependencies-approved` is added.

### Approach

1. **Remove dead label references** from `build`, `test-frontend`, and `build_samples` job conditions in `pr-builder.yml` (the `trigger-pr-builder` label check is unreachable since `labeled` is no longer a trigger type).

2. **Add `dependency-approved-retrigger.yml`** workflow that:
   - Triggers on `pull_request: [labeled]`
   - Only runs when the label is `dependencies-approved`
   - Re-runs the most recent PR Builder workflow run for that PR's head commit via the GitHub API

This keeps label events completely out of the PR builder while restoring the dependency approval re-trigger flow.

### Related Issues
- #2455

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.