### PR TITLE
Add missing i18n translations for user type selector in self signup

### DIFF
--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -204,6 +204,10 @@
       "forms.phone.actions.next.label": "Next",
       "forms.sms_sent.title": "Check Your Phone",
       "forms.sms_sent.message": "We sent you a verification link via SMS. Please check your messages and click the link to continue."
+    },
+    "elements": {
+      "fields.usertype.label": "User Type",
+      "fields.usertype.placeholder": "Select User Type"
     }
   }
 }


### PR DESCRIPTION
### Purpose

Fixes the user type selection screen in self-signup showing raw i18n keys (`elements.fields.usertype.label`, `elements.fields.usertype.placeholder`) instead of resolved translations ("User Type", "Select User Type").

<img width="649" alt="Screenshot showing unresolved i18n keys" src="https://github.com/user-attachments/assets/09e41835-58ee-489b-b69a-d307aaaa2b27" />

### Approach

The flow inference code ([inference.go:393-394](https://github.com/asgardeo/thunder/blob/main/backend/internal/flow/mgt/inference.go#L393-L394)) generates the user type SELECT component with `{{ t(elements:fields.usertype.label) }}` and `{{ t(elements:fields.usertype.placeholder) }}`.

The Asgardeo SDK's `resolveFlowTemplateLiterals` resolves these by converting `:` to `.` and looking up the flattened key (e.g., `elements.fields.usertype.label`) in its I18nProvider bundles. These bundles are populated from two sources:

1. **SDK defaults** (`@asgardeo/i18n`) — contains most `elements.*` keys but not the Thunder-specific `usertype` keys
2. **Flow meta endpoint** — the `FlowMetaProvider` fetches `/flow/meta`, flattens the namespace-grouped translations, and injects them into the SDK's I18nProvider

The `elements` namespace was missing from the backend's i18n seed data (`en-US.json`), so the flow meta response never included these translations, causing the raw keys to be displayed.

**Fix:** Add the `elements` namespace with the two missing translation keys to the i18n seed file. On bootstrap, these are stored in the database and served via the flow meta endpoint.

### Related Issues
- Fixes #2345

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - N/A — no breaking changes

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added English translations for new User Type field UI elements, including label and placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->