### PR TITLE
[DOCs] Update documentation to replace 'Develop' with 'Console'

### DIFF
--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -24,7 +24,7 @@ Building from source produces a distributable `.zip` file at `THUNDER_ROOT/targe
 
 - Compiles the Go backend binary
 - Initializes SQLite databases (config, runtime, user)
-- Builds the frontend React apps (Thunder Gate + Thunder Develop)
+- Builds the frontend React apps (Thunder Gate + Thunder Console)
 - Builds the documentation
 - Builds sample apps
 
@@ -82,14 +82,14 @@ This command will automatically set up your complete development environment:
 - Initializes SQLite databases
 - Starts the backend server
 - Runs the bootstrap script which creates:
-  - The `Develop` application with the correct redirect URIs
+  - The `Console` application with the correct redirect URIs
   - The default admin user (`admin` / `admin`)
 
 **Services that start:**
 
 - **Backend server**: [https://localhost:8090](https://localhost:8090)
 - **Thunder Gate** (Login/Register): [https://localhost:5190/gate](https://localhost:5190/gate)
-- **Thunder Develop** (Admin Console): [https://localhost:5191/develop](https://localhost:5191/develop)
+- **Thunder Console** (Admin Console): [https://localhost:5191/console](https://localhost:5191/console)
 :::
 
 ### Option B: Separate terminals (for debugging independently)
@@ -124,17 +124,17 @@ Use this approach when you need to debug the backend and frontend independently.
   <CodeBlock lang="bash" label="Linux/macOS">
     {`THUNDER_SKIP_SECURITY=true THUNDER_API_BASE="https://localhost:8090" \\
   backend/cmd/server/bootstrap/01-default-resources.sh \\
-  --develop-redirect-uris "https://localhost:5191/develop"`}
+  --console-redirect-uris "https://localhost:5191/console"`}
   </CodeBlock>
   <CodeBlock lang="powershell" label="Windows">
     {`$env:THUNDER_SKIP_SECURITY = "true"
 $env:THUNDER_API_BASE = "https://localhost:8090"
 & backend\\cmd\\server\\bootstrap\\01-default-resources.ps1 \`
-  --develop-redirect-uris "https://localhost:5191/develop"`}
+  --console-redirect-uris "https://localhost:5191/console"`}
   </CodeBlock>
 </CodeGroup>
 
-This creates the `Develop` application and the default admin user (`admin` / `admin`). You only need to do this once — the data persists in the SQLite databases.
+This creates the `Console` application and the default admin user (`admin` / `admin`). You only need to do this once — the data persists in the SQLite databases.
 
 :::warning
 Don't use `./setup.sh` here. That script is designed for the packaged distribution zip and expects a compiled `./thunder` binary at the project root. From source code, always use the bootstrap script directly as shown above, or use `make run` (Option A) which handles everything for you.
@@ -158,7 +158,7 @@ For development environments, `make run` executes the `backend/cmd/server/bootst
 - Admin user (`admin` / `admin`)
 - System resource server with system actions and permissions
 - Administrator role and role assignment
-- `DEVELOP` application
+- `Console` application
 
 ### Full Bootstrap (`./setup.sh`)
 

--- a/docs/content/community/contributing/contributing-code/debugging.mdx
+++ b/docs/content/community/contributing/contributing-code/debugging.mdx
@@ -7,7 +7,7 @@ hide_table_of_contents: false
 
 # Debugging Guide
 
-This guide covers setting up a local debugging environment for Thunder's backend, Gate app, Develop app, and React SDK sample application.
+This guide covers setting up a local debugging environment for Thunder's backend, Gate app, Console app, and React SDK sample application.
 
 ## Introduction
 
@@ -17,7 +17,7 @@ Thunder consists of the following components:
 |-----------|-------------|------|
 | Backend | Go-based API server | 8090 |
 | Gate App | React-based authentication gateway | 5190 |
-| Develop App | React-based developer console | 5191 |
+| Console App | React-based developer console | 5191 |
 | React SDK Sample | Sample app demonstrating OAuth integration | 3000 |
 
 This guide focuses on local development and debugging with SQLite for database storage.
@@ -86,7 +86,7 @@ In a **new terminal**, seed data (one-time only):
 ```bash
 THUNDER_API_BASE="https://localhost:8090" \
   backend/cmd/server/bootstrap/01-default-resources.sh \
-  --develop-redirect-uris "https://localhost:5191/develop"
+  --console-redirect-uris "https://localhost:5191/console"
 
 THUNDER_API_BASE="https://localhost:8090" \
   backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -132,11 +132,11 @@ npm run dev
 
 ## Connect Debuggers
 
-### Connect to Develop App (Browser DevTools)
+### Connect to Console App (Browser DevTools)
 
-1. Open [https://localhost:5191/develop](https://localhost:5191/develop) in Chrome
+1. Open [https://localhost:5191/console](https://localhost:5191/console) in Chrome
 2. Open DevTools (`Cmd+Option+I` on macOS, `F12` on Windows/Linux)
-3. Navigate to **Sources** → `top` → `localhost:5191` → `develop` → `src`
+3. Navigate to **Sources** → `top` → `localhost:5191` → `console` → `src`
 4. Click on a line number to set a breakpoint
 5. When that line executes, Chrome pauses execution and lets you inspect variables
 
@@ -173,7 +173,7 @@ npm run dev
 
 This walks through debugging the user creation flow from the UI to database storage.
 
-### 1. Set Develop App Breakpoints
+### 1. Set Console App Breakpoints
 
 In Chrome DevTools, open:
 
@@ -189,7 +189,7 @@ In VS Code, open these files and set breakpoints:
 
 ### 3. Trigger the Flow
 
-1. Navigate to [https://localhost:5191/develop](https://localhost:5191/develop)
+1. Navigate to [https://localhost:5191/console](https://localhost:5191/console)
 2. Log in with admin credentials (`admin` / `admin`)
 3. Go to **Users** section
 4. Click **Add User**

--- a/docs/content/community/contributing/contributing-code/documentation-development/glossary.mdx
+++ b/docs/content/community/contributing/contributing-code/documentation-development/glossary.mdx
@@ -192,7 +192,7 @@ A design configuration that controls the visual appearance of the sign-in experi
 
 ### Thunder Console
 
-The administrative web interface for managing Thunder. Access the Thunder Console at `https://localhost:8090/develop` to manage applications, users, flows, and other resources.
+The administrative web interface for managing Thunder. Access the Thunder Console at `https://localhost:8090/console` to manage applications, users, flows, and other resources.
 
 ### Thunder Gate
 

--- a/docs/content/community/contributing/contributing-code/frontend-development/overview.mdx
+++ b/docs/content/community/contributing/contributing-code/frontend-development/overview.mdx
@@ -12,7 +12,7 @@ The frontend is an Nx-managed monorepo under `frontend/` with two React apps:
 | App | Location | Purpose | Development Port |
 |-----|----------|---------|----------|
 | Thunder Gate | `frontend/apps/thunder-gate/` | Login, registration, recovery UI | 5190 |
-| Thunder Develop | `frontend/apps/thunder-develop/` | Admin console | 5191 |
+| Thunder Console | `frontend/apps/thunder-console/` | Admin console | 5191 |
 
 ## File Naming
 

--- a/docs/content/guides/quick-start/quickstart.mdx
+++ b/docs/content/guides/quick-start/quickstart.mdx
@@ -20,7 +20,7 @@ You can get started with Thunder in minutes. This guide walks you through regist
 
 An application in Thunder defines how your users authenticate and what they can access. Register one to get a **Client ID** and use it to integrate your own application with Thunder.
 
-1. Sign in to the Thunder Console at [https://localhost:8090/develop](https://localhost:8090/develop).
+1. Sign in to the Thunder Console at [https://localhost:8090/console](https://localhost:8090/console).
 2. Navigate to **Applications** → **New Application**.
 3. Enter an **Application Name**.
 4. Select the **Sign-In Options**. Users will use these methods to sign in to your application (for example, Username & Password or social login).


### PR DESCRIPTION
### Purpose
This pull request updates the documentation to rename all references to the "Thunder Develop" app to "Thunder Console." It also updates related file paths, URLs, redirect URIs, and command-line flags to match the new naming. This ensures consistency across developer guides, setup instructions, and the glossary.

Key documentation updates:

**App Naming and URLs:**

* All references to "Thunder Develop" have been changed to "Thunder Console" throughout the documentation, including in quick start guides, debugging instructions, and the glossary. Associated URLs have been updated from `/develop` to `/console` [[1]](diffhunk://#diff-3828dc55a3952f873d9a653db1e499baa59a422278b0e0e3c567778b4f481cf0L27-R27) [[2]](diffhunk://#diff-3828dc55a3952f873d9a653db1e499baa59a422278b0e0e3c567778b4f481cf0L85-R92) [[3]](diffhunk://#diff-3828dc55a3952f873d9a653db1e499baa59a422278b0e0e3c567778b4f481cf0L127-R137) [[4]](diffhunk://#diff-3828dc55a3952f873d9a653db1e499baa59a422278b0e0e3c567778b4f481cf0L161-R161) [[5]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL10-R10) [[6]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL20-R20) [[7]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL89-R89) [[8]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL135-R139) [[9]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL176-R176) [[10]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL192-R192) [[11]](diffhunk://#diff-d3161042c8df8c14392f2dc9e15589d5f0553b4ec83638ac78380c554d2b3f97L195-R195) [[12]](diffhunk://#diff-d88c37e7203b4e371cf7d4676146ca8a5cc422929aa33a7a2dd178d1e5bcfb8bL15-R15) [[13]](diffhunk://#diff-9cc313f9ae4f82e84738037070c2a11fd2c8ecfc29137d4ebd21e271a59885f9L23-R23).

**Setup and Bootstrap Scripts:**

* Updated CLI flags and redirect URIs in setup and bootstrap script instructions to use `--console-redirect-uris` and `/console` instead of `--develop-redirect-uris` and `/develop` [[1]](diffhunk://#diff-3828dc55a3952f873d9a653db1e499baa59a422278b0e0e3c567778b4f481cf0L127-R137) [[2]](diffhunk://#diff-9d53fd9678b6b4caa8b15ca02b0790f632a7e72411a2d8ab0f460aee5624665cL89-R89).

These changes help avoid confusion and maintain accuracy now that the admin app's name and routes have been standardized.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and debugging guides to reference the Thunder Console application instead of Thunder Develop.
  * Updated all localhost URLs and navigation paths from `/develop` to `/console` in setup and quickstart documentation.
  * Updated administrative interface links and seeding instructions to align with the Thunder Console endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->