### PR TITLE
Refactor Dependency Injection of Cache and Encryption

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	// Initialize the cache manager.
-	initCacheManager(logger)
+	cacheManager := cache.Initialize()
 
 	// Initialize system permission strings before any service or middleware uses them.
 	security.InitSystemPermissions(cfg.Resource.SystemResourceServer.Handle)
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	// Register the services.
-	jwtService := registerServices(mux)
+	jwtService := registerServices(mux, cacheManager)
 
 	// Register static file handlers for frontend applications.
 	registerStaticFileHandlers(logger, mux, serverHome)
@@ -121,7 +121,7 @@ func main() {
 	// Wait for shutdown signal
 	<-sigChan
 	logger.Info("Shutting down server...")
-	gracefulShutdown(logger, server)
+	gracefulShutdown(logger, server, cacheManager)
 }
 
 // getThunderHome retrieves and return the home directory.
@@ -162,15 +162,6 @@ func initThunderConfigurations(logger *log.Logger, serverHome string) *config.Co
 	}
 
 	return cfg
-}
-
-// initCacheManager initializes the cache manager with centralized cleanup.
-func initCacheManager(logger *log.Logger) {
-	cm := cache.GetCacheManager()
-	if cm == nil {
-		logger.Fatal("Failed to get cache manager instance")
-	}
-	cm.Init()
 }
 
 // loadCertConfig loads the certificate configuration and extracts the Key ID (kid).
@@ -243,6 +234,7 @@ func createSecurityMiddleware(logger *log.Logger, mux *http.ServeMux,
 func gracefulShutdown(
 	logger *log.Logger,
 	server *http.Server,
+	cacheManager cache.CacheManagerInterface,
 ) {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
@@ -265,7 +257,6 @@ func gracefulShutdown(
 		logger.Debug("Database connections closed successfully")
 	}
 
-	cacheManager := cache.GetCacheManager()
 	if cacheManager != nil {
 		cacheManager.Close()
 		logger.Debug("Cache manager closed successfully")

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -60,6 +60,7 @@ import (
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/resource"
 	"github.com/asgardeo/thunder/internal/role"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/cryptolab/hash"
 	dbprovider "github.com/asgardeo/thunder/internal/system/database/provider"
@@ -85,7 +86,7 @@ import (
 var observabilitySvc observability.ObservabilityServiceInterface
 
 // registerServices registers all the services with the provided HTTP multiplexer.
-func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
+func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterface) jwt.JWTServiceInterface {
 	logger := log.GetLogger()
 
 	// Load the server's private key for signing JWTs.
@@ -142,14 +143,14 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 
 	// Initialize user type service
 	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
-		mux, ouService, ouAuthzService, consentService)
+		mux, cacheManager, ouService, ouAuthzService, consentService)
 	if err != nil {
 		logger.Fatal("Failed to initialize EntityTypeService", log.Error(err))
 	}
 	exporters = append(exporters, entityTypeExporter)
 
 	// Initialize entity service
-	entityService, err := entity.Initialize(hashService, entityTypeService, ouService)
+	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)
 	if err != nil {
 		logger.Fatal("Failed to initialize EntityService", log.Error(err))
 	}
@@ -244,7 +245,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	attributeCacheService := attributecache.Initialize()
 
 	// Initialize flow and executor services.
-	flowFactory, graphCache := flowcore.Initialize()
+	flowFactory, graphCache := flowcore.Initialize(cacheManager)
 	var emailClient email.EmailClientInterface
 	emailClient, err = email.Initialize()
 	if err != nil {
@@ -257,12 +258,13 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 		observabilitySvc, groupService, roleService, entityProvider, attributeCacheService, emailClient,
 		templateService, oauthAuthnService, oidcAuthnService, githubAuthnService, googleAuthnService)
 
-	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(mux, mcpServer, flowFactory, execRegistry, graphCache)
+	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
+		mux, mcpServer, cacheManager, flowFactory, execRegistry, graphCache)
 	if err != nil {
 		logger.Fatal("Failed to initialize FlowMgtService", log.Error(err))
 	}
 	exporters = append(exporters, flowMgtExporter)
-	certservice, err := cert.Initialize(dbprovider.GetDBProvider())
+	certservice, err := cert.Initialize(cacheManager, dbprovider.GetDBProvider())
 	if err != nil {
 		logger.Fatal("Failed to initialize CertificateService", log.Error(err))
 	}
@@ -281,7 +283,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	exporters = append(exporters, layoutExporter)
 
 	inboundClientService, err := inboundclient.Initialize(
-		certservice, entityProvider,
+		cacheManager, certservice, entityProvider,
 		themeMgtService, layoutMgtService, flowMgtService, entityTypeService, consentService)
 	if err != nil {
 		logger.Fatal("Failed to initialize InboundClientService", log.Error(err))

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -72,6 +72,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/importer"
 	"github.com/asgardeo/thunder/internal/system/jose"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
+	"github.com/asgardeo/thunder/internal/system/kmprovider/defaultkm"
 	"github.com/asgardeo/thunder/internal/system/kmprovider/defaultkm/pkiservice"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/mcp"
@@ -94,6 +95,12 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	if err != nil {
 		logger.Fatal("Failed to initialize certificate service", log.Error(err))
 	}
+
+	configCryptoSvc, err := defaultkm.InitConfigProvider()
+	if err != nil {
+		logger.Fatal("Failed to initialize config crypto provider", log.Error(err))
+	}
+	runtimeCryptoSvc := defaultkm.NewRuntimeCryptoService(pkiService, configCryptoSvc)
 
 	jwtService, jweService, err := jose.Initialize(pkiService)
 	if err != nil {
@@ -327,7 +334,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	)
 
 	flowExecService, err := flowexec.Initialize(mux, flowMgtService, applicationService, execRegistry,
-		observabilitySvc)
+		observabilitySvc, runtimeCryptoSvc)
 	if err != nil {
 		logger.Fatal("Failed to initialize flow execution service", log.Error(err))
 	}

--- a/backend/internal/cert/cache_backed_store.go
+++ b/backend/internal/cert/cache_backed_store.go
@@ -36,10 +36,12 @@ type cacheBackedStore struct {
 }
 
 // NewCachedBackedCertificateStore creates a new instance of CachedBackedCertificateStore.
-func newCachedBackedCertificateStore() certificateStoreInterface {
+func newCachedBackedCertificateStore(
+	certByIDCache cache.CacheInterface[*Certificate],
+	certByReferenceCache cache.CacheInterface[*Certificate]) certificateStoreInterface {
 	return &cacheBackedStore{
-		certByIDCache:        cache.GetCache[*Certificate]("CertificateByIDCache"),
-		certByReferenceCache: cache.GetCache[*Certificate]("CertificateByReferenceCache"),
+		certByIDCache:        certByIDCache,
+		certByReferenceCache: certByReferenceCache,
 		store:                newCertificateStore(),
 	}
 }

--- a/backend/internal/cert/init.go
+++ b/backend/internal/cert/init.go
@@ -19,16 +19,20 @@
 package cert
 
 import (
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 )
 
 // Initialize initializes and returns the certificate service.
-func Initialize(dbProvider provider.DBProviderInterface) (CertificateServiceInterface, error) {
+func Initialize(cacheManager cache.CacheManagerInterface, dbProvider provider.DBProviderInterface) (
+	CertificateServiceInterface, error) {
 	txn, err := dbProvider.GetConfigDBTransactioner()
 	if err != nil {
 		return nil, err
 	}
-	certStore := newCachedBackedCertificateStore()
+	certByIDCache := cache.GetCache[*Certificate](cacheManager, "CertificateByIDCache")
+	certByReferenceCache := cache.GetCache[*Certificate](cacheManager, "CertificateByReferenceCache")
+	certStore := newCachedBackedCertificateStore(certByIDCache, certByReferenceCache)
 	certService := newCertificateService(certStore, txn)
 	return certService, nil
 }

--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -35,9 +35,10 @@ type cacheBackedEntityStore struct {
 }
 
 // newCacheBackedEntityStore creates a cache-backed wrapper around the given store.
-func newCacheBackedEntityStore(store entityStoreInterface) entityStoreInterface {
+func newCacheBackedEntityStore(store entityStoreInterface,
+	entityByIDCache cache.CacheInterface[*Entity]) entityStoreInterface {
 	return &cacheBackedEntityStore{
-		entityByIDCache: cache.GetCache[*Entity]("EntityByIDCache"),
+		entityByIDCache: entityByIDCache,
 		store:           store,
 		logger: log.GetLogger().With(
 			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),

--- a/backend/internal/entity/init.go
+++ b/backend/internal/entity/init.go
@@ -21,6 +21,7 @@ package entity
 import (
 	"github.com/asgardeo/thunder/internal/entitytype"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/cryptolab/hash"
 	"github.com/asgardeo/thunder/internal/system/transaction"
 )
@@ -30,11 +31,12 @@ import (
 // Declarative resources are loaded on demand by consumer packages (e.g. user, application)
 // based on their own store mode configuration.
 func Initialize(
+	cacheManager cache.CacheManagerInterface,
 	hashService hash.HashServiceInterface,
 	entityTypeService entitytype.EntityTypeServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
 ) (EntityServiceInterface, error) {
-	store, transactioner, err := initializeStore()
+	store, transactioner, err := initializeStore(cacheManager)
 	if err != nil {
 		return nil, err
 	}
@@ -44,12 +46,14 @@ func Initialize(
 }
 
 // initializeStore always creates a composite store (DB + in-memory file store).
-func initializeStore() (entityStoreInterface, transaction.Transactioner, error) {
+func initializeStore(cacheManager cache.CacheManagerInterface) (
+	entityStoreInterface, transaction.Transactioner, error) {
 	fileStore := newEntityFileBasedStore()
 	dbStore, transactioner, err := newEntityDBStore()
 	if err != nil {
 		return nil, nil, err
 	}
-	cacheBackedEntityStore := newCacheBackedEntityStore(dbStore)
+	entityByIDCache := cache.GetCache[*Entity](cacheManager, "EntityByIDCache")
+	cacheBackedEntityStore := newCacheBackedEntityStore(dbStore, entityByIDCache)
 	return newEntityCompositeStore(fileStore, cacheBackedEntityStore), transactioner, nil
 }

--- a/backend/internal/entitytype/cache_backed_store.go
+++ b/backend/internal/entitytype/cache_backed_store.go
@@ -37,10 +37,14 @@ type cachedBackedEntityTypeStore struct {
 }
 
 // newCachedBackedEntityTypeStore creates a cache-backed wrapper around the given store.
-func newCachedBackedEntityTypeStore(store entityTypeStoreInterface) entityTypeStoreInterface {
+func newCachedBackedEntityTypeStore(
+	store entityTypeStoreInterface,
+	entityTypeByIDCache cache.CacheInterface[*EntityType],
+	entityTypeByNameCache cache.CacheInterface[*EntityType],
+) entityTypeStoreInterface {
 	return &cachedBackedEntityTypeStore{
-		schemaByIDCache:   cache.GetCache[*EntityType]("EntityTypeByIDCache"),
-		schemaByNameCache: cache.GetCache[*EntityType]("EntityTypeByNameCache"),
+		schemaByIDCache:   entityTypeByIDCache,
+		schemaByNameCache: entityTypeByNameCache,
 		store:             store,
 		logger: log.GetLogger().With(
 			log.String(log.LoggerKeyComponentName, "CacheBackedEntityTypeStore")),

--- a/backend/internal/entitytype/init.go
+++ b/backend/internal/entitytype/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/consent"
 	oupkg "github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
@@ -33,13 +34,14 @@ import (
 // Initialize initializes the entity type service and registers its routes.
 func Initialize(
 	mux *http.ServeMux,
+	cacheManager cache.CacheManagerInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	authzService sysauthz.SystemAuthorizationServiceInterface,
 	consentService consent.ConsentServiceInterface,
 ) (EntityTypeServiceInterface, declarativeresource.ResourceExporter, error) {
 	// Step 1: Determine store mode and initialize store and transactioner
 	storeMode := getEntityTypeStoreMode()
-	entityTypeStore, transactioner, err := initializeStore(storeMode)
+	entityTypeStore, transactioner, err := initializeStore(storeMode, cacheManager)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +93,11 @@ func Initialize(
 // - If entity_type.store is not specified, falls back to global declarative_resources.enabled:
 //   - If declarative_resources.enabled = true: behaves as IMMUTABLE mode
 //   - If declarative_resources.enabled = false: behaves as MUTABLE mode
-func initializeStore(storeMode serverconst.StoreMode) (entityTypeStoreInterface, transaction.Transactioner, error) {
+func initializeStore(storeMode serverconst.StoreMode, cacheManager cache.CacheManagerInterface) (
+	entityTypeStoreInterface, transaction.Transactioner, error) {
+	entityTypeByIDCache := cache.GetCache[*EntityType](cacheManager, "EntityTypeByIDCache")
+	entityTypeByNameCache := cache.GetCache[*EntityType](cacheManager, "EntityTypeByNameCache")
+
 	switch storeMode {
 	case serverconst.StoreModeComposite:
 		fileStore, _ := newEntityTypeFileBasedStore()
@@ -99,7 +105,8 @@ func initializeStore(storeMode serverconst.StoreMode) (entityTypeStoreInterface,
 		if err != nil {
 			return nil, nil, err
 		}
-		return newCompositeEntityTypeStore(fileStore, dbStore), transactioner, nil
+		cachedDBStore := newCachedBackedEntityTypeStore(dbStore, entityTypeByIDCache, entityTypeByNameCache)
+		return newCompositeEntityTypeStore(fileStore, cachedDBStore), transactioner, nil
 
 	case serverconst.StoreModeDeclarative:
 		fileStore, transactioner := newEntityTypeFileBasedStore()
@@ -110,7 +117,7 @@ func initializeStore(storeMode serverconst.StoreMode) (entityTypeStoreInterface,
 		if err != nil {
 			return nil, nil, err
 		}
-		return newCachedBackedEntityTypeStore(dbStore), transactioner, nil
+		return newCachedBackedEntityTypeStore(dbStore, entityTypeByIDCache, entityTypeByNameCache), transactioner, nil
 	}
 }
 

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	oupkg "github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -87,7 +88,8 @@ func (suite *InitTestSuite) TestInitialize() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	service, _, err := Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	service, _, err := Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	suite.NotNil(service)
@@ -110,7 +112,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types", nil)
@@ -137,7 +140,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPost, "/user-types", nil)
@@ -172,7 +176,8 @@ func (suite *InitTestSuite) TestInitialize_DBTransactionerError() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.Error(suite.T(), err)
 	if err != nil {
 		assert.Contains(suite.T(), err.Error(), "failed to get config database client")
@@ -195,7 +200,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types/test-id", nil)
@@ -222,7 +228,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPut, "/user-types/test-id", nil)
@@ -249,7 +256,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/user-types/test-id", nil)
@@ -276,7 +284,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types", nil)
@@ -303,7 +312,8 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflightByID() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(suite.mux, suite.mockOUService, nil, suite.mockConsentService)
+	_, _, err = Initialize(
+		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types/test-id", nil)
@@ -511,7 +521,7 @@ func TestInitialize_Standalone(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -539,7 +549,7 @@ func TestInitializeStore_MutableMode(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -572,7 +582,7 @@ func TestInitializeStore_DeclarativeMode(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -603,7 +613,7 @@ func TestInitializeStore_CompositeMode(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -636,7 +646,7 @@ func TestInitializeStore_DefaultFallbackToMutable(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -669,7 +679,7 @@ func TestInitializeStore_GlobalDeclarativeEnabled(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -704,7 +714,7 @@ func TestInitialize_MutableMode(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -747,7 +757,7 @@ func TestInitialize_StoreModes(t *testing.T) {
 				Maybe()
 			mockConsentService := mockConsentServiceWithDisabled(t)
 
-			service, exporter, err := Initialize(mux, mockOUService, nil, mockConsentService)
+			service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, service)
@@ -1138,7 +1148,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(mux, mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1198,7 +1208,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(mux, mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1272,7 +1282,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to OU service failure
-	_, _, err = Initialize(mux, mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 
@@ -1332,7 +1342,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid JSON
-	_, _, err = Initialize(mux, mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }

--- a/backend/internal/flow/core/graph_cache.go
+++ b/backend/internal/flow/core/graph_cache.go
@@ -38,9 +38,9 @@ type graphCache struct {
 }
 
 // newGraphCache creates a new in-memory cache instance of graphCache.
-func newGraphCache() GraphCacheInterface {
+func newGraphCache(c cache.CacheInterface[*graph]) GraphCacheInterface {
 	return &graphCache{
-		cache: cache.GetInMemoryCache[*graph]("FlowGraphCache"),
+		cache: c,
 	}
 }
 

--- a/backend/internal/flow/core/init.go
+++ b/backend/internal/flow/core/init.go
@@ -19,9 +19,12 @@
 // Package core provides the core structs for flow management and execution.
 package core
 
+import "github.com/asgardeo/thunder/internal/system/cache"
+
 // Initialize initializes the core flow package
-func Initialize() (FlowFactoryInterface, GraphCacheInterface) {
+func Initialize(cacheManager cache.CacheManagerInterface) (FlowFactoryInterface, GraphCacheInterface) {
 	flowFactory := newFlowFactory()
-	graphCache := newGraphCache()
+	graphCacheInst := cache.GetInMemoryCache[*graph](cacheManager, "FlowGraphCache")
+	graphCache := newGraphCache(graphCacheInst)
 	return flowFactory, graphCache
 }

--- a/backend/internal/flow/flowexec/flowStoreInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/flowStoreInterface_mock_test.go
@@ -163,16 +163,16 @@ func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx 
 }
 
 // StoreFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) StoreFlowContext(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error {
-	ret := _mock.Called(ctx, engineCtx, expirySeconds)
+func (_mock *flowStoreInterfaceMock) StoreFlowContext(ctx context.Context, dbModel FlowContextDB, expirySeconds int64) error {
+	ret := _mock.Called(ctx, dbModel, expirySeconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StoreFlowContext")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, EngineContext, int64) error); ok {
-		r0 = returnFunc(ctx, engineCtx, expirySeconds)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, FlowContextDB, int64) error); ok {
+		r0 = returnFunc(ctx, dbModel, expirySeconds)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -186,21 +186,21 @@ type flowStoreInterfaceMock_StoreFlowContext_Call struct {
 
 // StoreFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - engineCtx EngineContext
+//   - dbModel FlowContextDB
 //   - expirySeconds int64
-func (_e *flowStoreInterfaceMock_Expecter) StoreFlowContext(ctx interface{}, engineCtx interface{}, expirySeconds interface{}) *flowStoreInterfaceMock_StoreFlowContext_Call {
-	return &flowStoreInterfaceMock_StoreFlowContext_Call{Call: _e.mock.On("StoreFlowContext", ctx, engineCtx, expirySeconds)}
+func (_e *flowStoreInterfaceMock_Expecter) StoreFlowContext(ctx interface{}, dbModel interface{}, expirySeconds interface{}) *flowStoreInterfaceMock_StoreFlowContext_Call {
+	return &flowStoreInterfaceMock_StoreFlowContext_Call{Call: _e.mock.On("StoreFlowContext", ctx, dbModel, expirySeconds)}
 }
 
-func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Run(run func(ctx context.Context, engineCtx EngineContext, expirySeconds int64)) *flowStoreInterfaceMock_StoreFlowContext_Call {
+func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Run(run func(ctx context.Context, dbModel FlowContextDB, expirySeconds int64)) *flowStoreInterfaceMock_StoreFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 EngineContext
+		var arg1 FlowContextDB
 		if args[1] != nil {
-			arg1 = args[1].(EngineContext)
+			arg1 = args[1].(FlowContextDB)
 		}
 		var arg2 int64
 		if args[2] != nil {
@@ -220,22 +220,22 @@ func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Return(err error) *flowS
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) RunAndReturn(run func(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error) *flowStoreInterfaceMock_StoreFlowContext_Call {
+func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) RunAndReturn(run func(ctx context.Context, dbModel FlowContextDB, expirySeconds int64) error) *flowStoreInterfaceMock_StoreFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) UpdateFlowContext(ctx context.Context, engineCtx EngineContext) error {
-	ret := _mock.Called(ctx, engineCtx)
+func (_mock *flowStoreInterfaceMock) UpdateFlowContext(ctx context.Context, dbModel FlowContextDB) error {
+	ret := _mock.Called(ctx, dbModel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateFlowContext")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, EngineContext) error); ok {
-		r0 = returnFunc(ctx, engineCtx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, FlowContextDB) error); ok {
+		r0 = returnFunc(ctx, dbModel)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -249,20 +249,20 @@ type flowStoreInterfaceMock_UpdateFlowContext_Call struct {
 
 // UpdateFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - engineCtx EngineContext
-func (_e *flowStoreInterfaceMock_Expecter) UpdateFlowContext(ctx interface{}, engineCtx interface{}) *flowStoreInterfaceMock_UpdateFlowContext_Call {
-	return &flowStoreInterfaceMock_UpdateFlowContext_Call{Call: _e.mock.On("UpdateFlowContext", ctx, engineCtx)}
+//   - dbModel FlowContextDB
+func (_e *flowStoreInterfaceMock_Expecter) UpdateFlowContext(ctx interface{}, dbModel interface{}) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+	return &flowStoreInterfaceMock_UpdateFlowContext_Call{Call: _e.mock.On("UpdateFlowContext", ctx, dbModel)}
 }
 
-func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Run(run func(ctx context.Context, engineCtx EngineContext)) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Run(run func(ctx context.Context, dbModel FlowContextDB)) *flowStoreInterfaceMock_UpdateFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 EngineContext
+		var arg1 FlowContextDB
 		if args[1] != nil {
-			arg1 = args[1].(EngineContext)
+			arg1 = args[1].(FlowContextDB)
 		}
 		run(
 			arg0,
@@ -277,7 +277,7 @@ func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Return(err error) *flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) RunAndReturn(run func(ctx context.Context, engineCtx EngineContext) error) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) RunAndReturn(run func(ctx context.Context, dbModel FlowContextDB) error) *flowStoreInterfaceMock_UpdateFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowexec/init.go
+++ b/backend/internal/flow/flowexec/init.go
@@ -26,6 +26,7 @@ import (
 	flowmgt "github.com/asgardeo/thunder/internal/flow/mgt"
 	"github.com/asgardeo/thunder/internal/system/config"
 	dbprovider "github.com/asgardeo/thunder/internal/system/database/provider"
+	"github.com/asgardeo/thunder/internal/system/kmprovider"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/observability"
 	"github.com/asgardeo/thunder/internal/system/transaction"
@@ -39,6 +40,7 @@ func Initialize(
 	applicationService application.ApplicationServiceInterface,
 	executorRegistry executor.ExecutorRegistryInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
+	cryptoSvc kmprovider.RuntimeCryptoProvider,
 ) (FlowExecServiceInterface, error) {
 	var flowStore flowStoreInterface
 	var transactioner transaction.Transactioner
@@ -57,7 +59,7 @@ func Initialize(
 	}
 	flowEngine := newFlowEngine(executorRegistry, observabilitySvc)
 	flowExecService := newFlowExecService(flowMgtService, flowStore, flowEngine, applicationService,
-		observabilitySvc, transactioner)
+		observabilitySvc, transactioner, cryptoSvc)
 
 	handler := newFlowExecutionHandler(flowExecService)
 	registerRoutes(mux, handler)

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -31,9 +31,6 @@ import (
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
-	"github.com/asgardeo/thunder/internal/system/cryptolab"
-	"github.com/asgardeo/thunder/internal/system/kmprovider"
-	"github.com/asgardeo/thunder/internal/system/kmprovider/defaultkm"
 )
 
 // EngineContext holds the overall context used by the flow engine during execution.
@@ -127,32 +124,6 @@ type FlowContextDB struct {
 	UpdatedAt   time.Time
 }
 
-// isEncrypted reports whether the Context field is still in encrypted form.
-func (f *FlowContextDB) isEncrypted() bool {
-	var encCheck struct {
-		Algorithm string `json:"alg"`
-	}
-	return json.Unmarshal([]byte(f.Context), &encCheck) == nil && encCheck.Algorithm != ""
-}
-
-// decrypt decrypts the Context field in-place if it is still encrypted.
-func (f *FlowContextDB) decrypt(ctx context.Context) error {
-	if !f.isEncrypted() {
-		return nil
-	}
-	runtimeSvc, err := defaultkm.GetRuntimeCryptoService()
-	if err != nil {
-		return err
-	}
-	decrypted, err := runtimeSvc.Decrypt(
-		ctx, kmprovider.KeyRef{}, cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}, []byte(f.Context))
-	if err != nil {
-		return err
-	}
-	f.Context = string(decrypted)
-	return nil
-}
-
 // flowContextContent holds all flow state serialized into the CONTEXT JSON column.
 type flowContextContent struct {
 	AppID               string  `json:"appId"`
@@ -175,29 +146,8 @@ type flowContextContent struct {
 	ChallengeTokenHash  *string `json:"challengeTokenHash,omitempty"`
 }
 
-// encrypt marshals and encrypts the content, returning the encrypted string.
-func (c *flowContextContent) encrypt(ctx context.Context) (string, error) {
-	data, err := json.Marshal(c)
-	if err != nil {
-		return "", err
-	}
-	runtimeSvc, err := defaultkm.GetRuntimeCryptoService()
-	if err != nil {
-		return "", err
-	}
-	encrypted, _, err := runtimeSvc.Encrypt(
-		ctx, kmprovider.KeyRef{}, cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}, data)
-	if err != nil {
-		return "", err
-	}
-	return string(encrypted), nil
-}
-
 // GetGraphID extracts the graph ID from the context JSON.
-func (f *FlowContextDB) GetGraphID(ctx context.Context) (string, error) {
-	if err := f.decrypt(ctx); err != nil {
-		return "", err
-	}
+func (f *FlowContextDB) GetGraphID(_ context.Context) (string, error) {
 	var content flowContextContent
 	if err := json.Unmarshal([]byte(f.Context), &content); err != nil {
 		return "", err
@@ -207,10 +157,6 @@ func (f *FlowContextDB) GetGraphID(ctx context.Context) (string, error) {
 
 // ToEngineContext converts the database model to the flow engine context.
 func (f *FlowContextDB) ToEngineContext(ctx context.Context, graph core.GraphInterface) (EngineContext, error) {
-	// Ensure context is decrypted before parsing
-	if err := f.decrypt(ctx); err != nil {
-		return EngineContext{}, err
-	}
 	var content flowContextContent
 	if err := json.Unmarshal([]byte(f.Context), &content); err != nil {
 		return EngineContext{}, err
@@ -469,13 +415,13 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		ChallengeTokenHash:  challengeTokenHash,
 	}
 
-	encryptedContext, err := content.encrypt(ctx.Context)
+	contextJSON, err := json.Marshal(content)
 	if err != nil {
 		return nil, err
 	}
 
 	return &FlowContextDB{
 		ExecutionID: ctx.ExecutionID,
-		Context:     encryptedContext,
+		Context:     string(contextJSON),
 	}, nil
 }

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -28,7 +28,6 @@ import (
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
-	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 )
 
@@ -41,34 +40,17 @@ type ModelTestSuite struct {
 }
 
 func TestModelTestSuite(t *testing.T) {
-	// Setup test config with encryption key
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	err := config.InitializeServerRuntime("/test/thunderid/home", testConfig)
-	if err != nil {
-		t.Fatalf("failed to initialize server runtime: %v", err)
-	}
-
 	suite.Run(t, new(ModelTestSuite))
 }
 
 func (s *ModelTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
-	err := dbModel.decrypt(context.Background())
-	s.NoError(err)
 	var content flowContextContent
-	err = json.Unmarshal([]byte(dbModel.Context), &content)
+	err := json.Unmarshal([]byte(dbModel.Context), &content)
 	s.NoError(err)
 	return content
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
-	// Setup
 	testToken := "test-token-123456"
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("test-graph-id")
@@ -97,10 +79,8 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 		Graph:            mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
 	s.Equal("test-flow-id", dbModel.ExecutionID)
@@ -111,14 +91,11 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.UserID)
 	s.Equal("user-123", *content.UserID)
-
-	// Verify token is stored in decrypted context
 	s.NotNil(content.Token)
 	s.Equal(testToken, *content.Token)
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
-	// Setup
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("test-graph-id")
 
@@ -135,30 +112,25 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
-			Token:           "", // Empty token
+			Token:           "",
 			Attributes:      map[string]interface{}{},
 		},
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
 	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.True(content.IsAuthenticated)
-
-	// Verify token is nil when empty
 	s.Nil(content.Token)
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithEmptyAuthenticatedUser() {
-	// Setup
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("test-graph-id")
 
@@ -170,15 +142,13 @@ func (s *ModelTestSuite) TestFromEngineContext_WithEmptyAuthenticatedUser() {
 		FlowType:          common.FlowTypeAuthentication,
 		UserInputs:        map[string]string{},
 		RuntimeData:       map[string]string{},
-		AuthenticatedUser: authncm.AuthenticatedUser{}, // Empty authenticated user
+		AuthenticatedUser: authncm.AuthenticatedUser{},
 		ExecutionHistory:  map[string]*common.NodeExecutionRecord{},
 		Graph:             mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
 
@@ -189,13 +159,11 @@ func (s *ModelTestSuite) TestFromEngineContext_WithEmptyAuthenticatedUser() {
 }
 
 func (s *ModelTestSuite) TestToEngineContext_WithToken() {
-	// Setup - First create an encrypted token
 	testToken := "test-token-xyz789"
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("test-graph-id")
 	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
 
-	// Create the context and convert to DB model to get encrypted token
 	ctx := EngineContext{
 		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
@@ -220,22 +188,17 @@ func (s *ModelTestSuite) TestToEngineContext_WithToken() {
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.Token)
 
-	// Execute - Convert back to EngineContext
 	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
-	// Verify
 	s.NoError(err)
 	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.Equal("test-app-id", resultCtx.AppID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-456", resultCtx.AuthenticatedUser.UserID)
-
-	// Verify token is decrypted correctly
 	s.Equal(testToken, resultCtx.AuthenticatedUser.Token)
 }
 
 func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
-	// Setup
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
 
@@ -255,7 +218,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
 		RuntimeData:      &runtimeData,
 		UserAttributes:   &userAttributes,
 		ExecutionHistory: &executionHistory,
-		Token:            nil, // No token
+		Token:            nil,
 	}
 	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
@@ -263,105 +226,39 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
 		Context:     string(contextJSON),
 	}
 
-	// Execute
 	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
-	// Verify
 	s.NoError(err)
 	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal(testUserID789, resultCtx.AuthenticatedUser.UserID)
-
-	// Verify token is empty string when nil
 	s.Equal("", resultCtx.AuthenticatedUser.Token)
 }
 
-func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
-	// Setup
-	testTokens := []string{
-		"simple-token",
-		"token-with-special-chars-!@#$%^&*()",
-		"very-long-token-" + string(make([]byte, 1000)),
-		"unicode-token-🔐🔑",
+func (s *ModelTestSuite) TestGetGraphID() {
+	userInputs := `{}`
+	content := flowContextContent{
+		GraphID:          "expected-graph-id",
+		UserInputs:       &userInputs,
+		RuntimeData:      &userInputs,
+		ExecutionHistory: &userInputs,
 	}
-
-	mockGraph := coremock.NewGraphInterfaceMock(s.T())
-	mockGraph.On("GetID").Return("test-graph-id").Maybe()
-	mockGraph.On("GetType").Return(common.FlowTypeAuthentication).Maybe()
-
-	for _, testToken := range testTokens {
-		s.Run("Token: "+testToken[:min(20, len(testToken))], func() {
-			// Create context with token
-			ctx := EngineContext{
-				Context:     context.Background(),
-				ExecutionID: "test-flow-id",
-				AppID:       "test-app-id",
-				FlowType:    common.FlowTypeAuthentication,
-				AuthenticatedUser: authncm.AuthenticatedUser{
-					IsAuthenticated: true,
-					UserID:          "user-123",
-					Token:           testToken,
-					Attributes:      map[string]interface{}{},
-				},
-				UserInputs:       map[string]string{},
-				RuntimeData:      map[string]string{},
-				ExecutionHistory: map[string]*common.NodeExecutionRecord{},
-				Graph:            mockGraph,
-			}
-
-			// Convert to DB model (encrypts entire context)
-			dbModel, err := FromEngineContext(ctx)
-			s.NoError(err)
-
-			// Verify context is encrypted (contains ciphertext envelope)
-			s.Contains(dbModel.Context, `"ct"`, "context should be encrypted")
-
-			// Decrypt and convert back to EngineContext
-			s.NoError(dbModel.decrypt(context.Background()))
-			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
-			s.NoError(err)
-
-			// Verify original token is restored
-			s.Equal(testToken, resultCtx.AuthenticatedUser.Token)
-		})
-	}
-}
-
-func (s *ModelTestSuite) TestDecrypt_WithInvalidCiphertext() {
-	// Context is valid JSON with the encrypted envelope structure but has corrupted ciphertext.
-	testCases := []struct {
-		name    string
-		context string
-	}{
-		{
-			name:    "invalid base64 in ct field",
-			context: `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
-		},
-		{
-			name:    "empty ct field",
-			context: `{"alg":"AES-GCM","ct":"","kid":"key-1"}`,
-		},
-		{
-			name:    "ct too short to contain nonce",
-			context: `{"alg":"AES-GCM","ct":"dGVzdA==","kid":"key-1"}`,
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			dbModel := &FlowContextDB{ExecutionID: "test-flow-id", Context: tc.context}
-			err := dbModel.decrypt(context.Background())
-			s.Error(err)
-		})
-	}
-}
-
-func (s *ModelTestSuite) TestGetGraphID_WithDecryptionFailure() {
-	// Verifies that GetGraphID propagates a decryption error when the context
-	// looks encrypted but cannot be decrypted.
+	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
 		ExecutionID: "test-flow-id",
-		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
+		Context:     string(contextJSON),
+	}
+
+	graphID, err := dbModel.GetGraphID(context.Background())
+
+	s.NoError(err)
+	s.Equal("expected-graph-id", graphID)
+}
+
+func (s *ModelTestSuite) TestGetGraphID_InvalidJSON() {
+	dbModel := &FlowContextDB{
+		ExecutionID: "test-flow-id",
+		Context:     "not-valid-json",
 	}
 
 	graphID, err := dbModel.GetGraphID(context.Background())
@@ -369,39 +266,7 @@ func (s *ModelTestSuite) TestGetGraphID_WithDecryptionFailure() {
 	s.Empty(graphID)
 }
 
-func (s *ModelTestSuite) TestToEngineContext_WithDecryptionFailure() {
-	// Verifies that ToEngineContext propagates a decryption error when the context
-	// looks encrypted but cannot be decrypted.
-	mockGraph := coremock.NewGraphInterfaceMock(s.T())
-
-	dbModel := &FlowContextDB{
-		ExecutionID: "test-flow-id",
-		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
-	}
-
-	result, err := dbModel.ToEngineContext(context.Background(), mockGraph)
-	s.Error(err)
-	s.Equal(EngineContext{}, result)
-}
-
-func (s *ModelTestSuite) TestDecrypt_WithDecryptionFailure() {
-	// Verifies that decrypt returns an error (and does not panic) when
-	// the context looks encrypted but the ciphertext is invalid.
-	dbModel := &FlowContextDB{
-		ExecutionID: "test-flow-id",
-		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
-	}
-
-	s.True(dbModel.isEncrypted(), "context should be detected as encrypted before attempt")
-
-	err := dbModel.decrypt(context.Background())
-	s.Error(err)
-	// Context should remain unchanged (still in its original encrypted form)
-	s.True(dbModel.isEncrypted(), "context should remain encrypted after failed decryption")
-}
-
-func (s *ModelTestSuite) TestContextEncryptionRoundTrip() {
-	// Tests that the entire context JSON is encrypted and all fields survive the round trip.
+func (s *ModelTestSuite) TestContextRoundTrip() {
 	testCases := []struct {
 		name    string
 		appID   string
@@ -446,19 +311,11 @@ func (s *ModelTestSuite) TestContextEncryptionRoundTrip() {
 				Graph:            mockGraph,
 			}
 
-			// Encrypt
 			dbModel, err := FromEngineContext(ctx)
 			s.NoError(err)
 
-			// Verify context is encrypted: ciphertext envelope present, plain fields hidden
-			s.Contains(dbModel.Context, `"ct"`, "encrypted context should contain ciphertext field")
-			s.NotContains(dbModel.Context, tc.appID, "appId should not be visible in encrypted context")
-
-			// Decrypt and verify all fields are restored
-			err = dbModel.decrypt(context.Background())
-			s.NoError(err)
-			s.NotContains(dbModel.Context, `"ct"`, "decrypted context should not contain ciphertext field")
-			s.Contains(dbModel.Context, `"appId"`, "decrypted context should expose plain appId field")
+			// Context should be plain JSON (encryption is the service's responsibility)
+			s.Contains(dbModel.Context, `"appId"`)
 
 			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 			s.NoError(err)
@@ -470,98 +327,7 @@ func (s *ModelTestSuite) TestContextEncryptionRoundTrip() {
 	}
 }
 
-func (s *ModelTestSuite) TestIsEncrypted() {
-	mockGraph := coremock.NewGraphInterfaceMock(s.T())
-	mockGraph.On("GetID").Return("test-graph-id")
-
-	ctx := EngineContext{
-		ExecutionID: "test-flow-id",
-		AppID:       "test-app-id",
-		FlowType:    common.FlowTypeAuthentication,
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			Attributes: map[string]interface{}{},
-		},
-		UserInputs:       map[string]string{},
-		RuntimeData:      map[string]string{},
-		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
-		Graph:            mockGraph,
-	}
-
-	dbModel, err := FromEngineContext(ctx)
-	s.NoError(err)
-
-	// Freshly created DB model should have encrypted context
-	s.True(dbModel.isEncrypted(), "freshly encrypted context should be detected as encrypted")
-
-	// After decryption, should no longer be detected as encrypted
-	err = dbModel.decrypt(context.Background())
-	s.NoError(err)
-	s.False(dbModel.isEncrypted(), "decrypted context should not be detected as encrypted")
-
-	// Plain JSON without "alg" field should not be detected as encrypted
-	plainModel := &FlowContextDB{
-		ExecutionID: "plain-id",
-		Context:     `{"appId":"test","graphId":"graph-1","isAuthenticated":false}`,
-	}
-	s.False(plainModel.isEncrypted(), "plain JSON context should not be detected as encrypted")
-
-	// Non-JSON string should not be detected as encrypted
-	invalidModel := &FlowContextDB{ExecutionID: "invalid-id", Context: "not-json-at-all"}
-	s.False(invalidModel.isEncrypted(), "non-JSON string should not be detected as encrypted")
-}
-
-func (s *ModelTestSuite) TestDecrypt_WithEncryptedContext() {
-	mockGraph := coremock.NewGraphInterfaceMock(s.T())
-	mockGraph.On("GetID").Return("test-graph-id")
-	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
-
-	ctx := EngineContext{
-		ExecutionID: "test-flow-id",
-		AppID:       "ensure-decrypt-app",
-		FlowType:    common.FlowTypeAuthentication,
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			IsAuthenticated: true,
-			UserID:          "user-ensure",
-			Token:           "ensure-token",
-			Attributes:      map[string]interface{}{},
-		},
-		UserInputs:       map[string]string{},
-		RuntimeData:      map[string]string{},
-		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
-		Graph:            mockGraph,
-	}
-
-	dbModel, err := FromEngineContext(ctx)
-	s.NoError(err)
-	s.True(dbModel.isEncrypted())
-
-	err = dbModel.decrypt(context.Background())
-	s.NoError(err)
-	s.False(dbModel.isEncrypted(), "context should be decrypted after decrypt")
-
-	// Verify context is usable after decrypt
-	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
-	s.NoError(err)
-	s.Equal("ensure-decrypt-app", resultCtx.AppID)
-	s.Equal("user-ensure", resultCtx.AuthenticatedUser.UserID)
-	s.Equal("ensure-token", resultCtx.AuthenticatedUser.Token)
-}
-
-func (s *ModelTestSuite) TestDecrypt_WithPlainContext() {
-	// Plain JSON context should pass through decrypt unchanged
-	plainJSON := `{"appId":"test-app","graphId":"graph-1","isAuthenticated":false}`
-	dbModel := &FlowContextDB{ExecutionID: "test-flow-id", Context: plainJSON}
-
-	s.False(dbModel.isEncrypted())
-	originalContext := dbModel.Context
-
-	err := dbModel.decrypt(context.Background())
-	s.NoError(err)
-	s.Equal(originalContext, dbModel.Context, "plain context should be unchanged by decrypt")
-}
-
 func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
-	// Setup
 	testToken := "test-token-preserve-fields"
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("graph-123")
@@ -597,10 +363,8 @@ func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
 		Graph: mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify all fields are preserved
 	s.NoError(err)
 	s.Equal("flow-123", dbModel.ExecutionID)
 
@@ -625,7 +389,6 @@ func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
-	// Setup
 	testAvailableAttributes := &authnprovidercm.AttributesResponse{
 		Attributes: map[string]*authnprovidercm.AttributeResponse{
 			"email": {
@@ -668,10 +431,8 @@ func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
 		Graph:            mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
 	s.Equal("test-flow-id", dbModel.ExecutionID)
@@ -682,18 +443,13 @@ func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.UserID)
 	s.Equal("user-123", *content.UserID)
-
-	// Verify available attributes are serialized (not encrypted)
 	s.NotNil(content.AvailableAttributes)
 	s.Greater(len(*content.AvailableAttributes), 0)
-
-	// Verify available attributes can be deserialized back
 	s.Contains(*content.AvailableAttributes, "\"email\"")
 	s.Contains(*content.AvailableAttributes, "\"phoneNumber\"")
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithoutAvailableAttributes() {
-	// Setup
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetID").Return("test-graph-id")
 
@@ -710,30 +466,25 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutAvailableAttributes() {
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-123",
-			AvailableAttributes: nil, // No available attributes
+			AvailableAttributes: nil,
 			Attributes:          map[string]interface{}{},
 		},
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            mockGraph,
 	}
 
-	// Execute
 	dbModel, err := FromEngineContext(ctx)
 
-	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
 	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.True(content.IsAuthenticated)
-
-	// Verify available attributes is nil when empty
 	s.Nil(content.AvailableAttributes)
 }
 
 func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
-	// Setup
 	testAvailableAttributes := &authnprovidercm.AttributesResponse{
 		Attributes: map[string]*authnprovidercm.AttributeResponse{
 			"email": {
@@ -753,7 +504,6 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 	mockGraph.On("GetID").Return("test-graph-id")
 	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
 
-	// Create the context and convert to DB model to get serialized available attributes
 	ctx := EngineContext{
 		Context:     context.Background(),
 		ExecutionID: "test-flow-id",
@@ -778,17 +528,13 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.AvailableAttributes)
 
-	// Execute - Convert back to EngineContext
 	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
-	// Verify
 	s.NoError(err)
 	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.Equal("test-app-id", resultCtx.AppID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-456", resultCtx.AuthenticatedUser.UserID)
-
-	// Verify available attributes are deserialized correctly
 	s.NotNil(resultCtx.AuthenticatedUser.AvailableAttributes)
 	s.Len(resultCtx.AuthenticatedUser.AvailableAttributes.Attributes, 2)
 	s.Contains(resultCtx.AuthenticatedUser.AvailableAttributes.Attributes, "email")
@@ -798,7 +544,6 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 }
 
 func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
-	// Setup
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
 
@@ -818,7 +563,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
 		RuntimeData:         &runtimeData,
 		UserAttributes:      &userAttributes,
 		ExecutionHistory:    &executionHistory,
-		AvailableAttributes: nil, // No available attributes
+		AvailableAttributes: nil,
 	}
 	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
@@ -826,21 +571,16 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
 		Context:     string(contextJSON),
 	}
 
-	// Execute
 	resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 
-	// Verify
 	s.NoError(err)
 	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-987", resultCtx.AuthenticatedUser.UserID)
-
-	// Verify available attributes is nil/empty when not provided
 	s.Nil(resultCtx.AuthenticatedUser.AvailableAttributes)
 }
 
 func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
-	// Setup
 	testCases := []struct {
 		name       string
 		attributes *authnprovidercm.AttributesResponse
@@ -881,24 +621,6 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 				Verifications: map[string]*authnprovidercm.VerificationResponse{},
 			},
 		},
-		{
-			name: "Special characters in names",
-			attributes: &authnprovidercm.AttributesResponse{
-				Attributes: map[string]*authnprovidercm.AttributeResponse{
-					"custom-attr-1": {
-						AssuranceMetadataResponse: &authnprovidercm.AssuranceMetadataResponse{
-							IsVerified: true,
-						},
-					},
-					"attr_with_underscore": {
-						AssuranceMetadataResponse: &authnprovidercm.AssuranceMetadataResponse{
-							IsVerified: false,
-						},
-					},
-				},
-				Verifications: map[string]*authnprovidercm.VerificationResponse{},
-			},
-		},
 	}
 
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
@@ -907,7 +629,6 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			// Create context with available attributes
 			ctx := EngineContext{
 				Context:     context.Background(),
 				ExecutionID: "test-flow-id",
@@ -925,17 +646,14 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 				Graph:            mockGraph,
 			}
 
-			// Convert to DB model (serializes available attributes)
 			dbModel, err := FromEngineContext(ctx)
 			s.NoError(err)
 			content := s.getContextContent(dbModel)
 			s.NotNil(content.AvailableAttributes)
 
-			// Convert back to EngineContext (deserializes available attributes)
 			resultCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 			s.NoError(err)
 
-			// Verify original available attributes are restored
 			s.NotNil(resultCtx.AuthenticatedUser.AvailableAttributes)
 			s.Len(resultCtx.AuthenticatedUser.AvailableAttributes.Attributes, len(tc.attributes.Attributes))
 			for attrName, attrMetadata := range tc.attributes.Attributes {

--- a/backend/internal/flow/flowexec/redis_store.go
+++ b/backend/internal/flow/flowexec/redis_store.go
@@ -69,14 +69,9 @@ func (s *redisFlowStore) flowKey(executionID string) string {
 	return fmt.Sprintf("%s:runtime:%s:flow:%s", s.keyPrefix, s.deploymentID, executionID)
 }
 
-// StoreFlowContext serializes the engine context and stores it in Redis with a TTL.
-func (s *redisFlowStore) StoreFlowContext(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error {
+// StoreFlowContext stores the flow context in Redis with a TTL.
+func (s *redisFlowStore) StoreFlowContext(ctx context.Context, dbModel FlowContextDB, expirySeconds int64) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RedisFlowStore"))
-
-	dbModel, err := FromEngineContext(engineCtx)
-	if err != nil {
-		return fmt.Errorf("failed to convert engine context to db model: %w", err)
-	}
 
 	data, err := json.Marshal(dbModel)
 	if err != nil {
@@ -84,11 +79,11 @@ func (s *redisFlowStore) StoreFlowContext(ctx context.Context, engineCtx EngineC
 	}
 
 	ttl := time.Duration(expirySeconds) * time.Second
-	if err := s.client.Set(ctx, s.flowKey(engineCtx.ExecutionID), data, ttl).Err(); err != nil {
+	if err := s.client.Set(ctx, s.flowKey(dbModel.ExecutionID), data, ttl).Err(); err != nil {
 		return fmt.Errorf("failed to store flow context in Redis: %w", err)
 	}
 
-	logger.Debug("Stored flow context in Redis", log.String("executionID", engineCtx.ExecutionID))
+	logger.Debug("Stored flow context in Redis", log.String("executionID", dbModel.ExecutionID))
 	return nil
 }
 
@@ -111,13 +106,8 @@ func (s *redisFlowStore) GetFlowContext(ctx context.Context, executionID string)
 }
 
 // UpdateFlowContext updates the stored flow context, preserving the remaining TTL.
-func (s *redisFlowStore) UpdateFlowContext(ctx context.Context, engineCtx EngineContext) error {
-	key := s.flowKey(engineCtx.ExecutionID)
-
-	dbModel, err := FromEngineContext(engineCtx)
-	if err != nil {
-		return fmt.Errorf("failed to convert engine context to db model: %w", err)
-	}
+func (s *redisFlowStore) UpdateFlowContext(ctx context.Context, dbModel FlowContextDB) error {
+	key := s.flowKey(dbModel.ExecutionID)
 
 	data, err := json.Marshal(dbModel)
 	if err != nil {
@@ -129,7 +119,7 @@ func (s *redisFlowStore) UpdateFlowContext(ctx context.Context, engineCtx Engine
 		return fmt.Errorf("failed to update flow context in Redis: %w", err)
 	}
 	if n == 0 {
-		return fmt.Errorf("flow context not found for executionID: %s", engineCtx.ExecutionID)
+		return fmt.Errorf("flow context not found for executionID: %s", dbModel.ExecutionID)
 	}
 
 	return nil

--- a/backend/internal/flow/flowexec/redis_store_test.go
+++ b/backend/internal/flow/flowexec/redis_store_test.go
@@ -32,7 +32,6 @@ import (
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
-	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 )
 
@@ -51,22 +50,6 @@ type RedisFlowStoreTestSuite struct {
 }
 
 func TestRedisFlowStoreSuite(t *testing.T) {
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-		Server: config.ServerConfig{
-			Identifier: redisTestDeploymentID,
-		},
-	}
-	config.ResetServerRuntime()
-	if err := config.InitializeServerRuntime("/test/thunderid/home", testConfig); err != nil {
-		t.Fatalf("Failed to initialize server runtime: %v", err)
-	}
-	t.Cleanup(config.ResetServerRuntime)
-
 	suite.Run(t, new(RedisFlowStoreTestSuite))
 }
 
@@ -124,11 +107,14 @@ func (suite *RedisFlowStoreTestSuite) TestStoreFlowContext_Success() {
 	engineCtx := suite.buildEngineContext()
 	expirySeconds := int64(1800)
 
+	dbModel, err := FromEngineContext(engineCtx)
+	suite.Require().NoError(err)
+
 	statusCmd := redis.NewStatusCmd(suite.ctx)
 	suite.mockClient.On("Set", suite.ctx, suite.flowKey, mock.Anything,
 		time.Duration(expirySeconds)*time.Second).Return(statusCmd)
 
-	err := suite.store.StoreFlowContext(suite.ctx, engineCtx, expirySeconds)
+	err = suite.store.StoreFlowContext(suite.ctx, *dbModel, expirySeconds)
 	suite.NoError(err)
 }
 
@@ -136,12 +122,15 @@ func (suite *RedisFlowStoreTestSuite) TestStoreFlowContext_SetError() {
 	engineCtx := suite.buildEngineContext()
 	expirySeconds := int64(1800)
 
+	dbModel, err := FromEngineContext(engineCtx)
+	suite.Require().NoError(err)
+
 	statusCmd := redis.NewStatusCmd(suite.ctx)
 	statusCmd.SetErr(errors.New("connection refused"))
 	suite.mockClient.On("Set", suite.ctx, suite.flowKey, mock.Anything,
 		time.Duration(expirySeconds)*time.Second).Return(statusCmd)
 
-	err := suite.store.StoreFlowContext(suite.ctx, engineCtx, expirySeconds)
+	err = suite.store.StoreFlowContext(suite.ctx, *dbModel, expirySeconds)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to store flow context in Redis")
 }
@@ -198,38 +187,44 @@ func (suite *RedisFlowStoreTestSuite) TestGetFlowContext_UnmarshalError() {
 
 func (suite *RedisFlowStoreTestSuite) TestUpdateFlowContext_Success() {
 	engineCtx := suite.buildEngineContext()
+	dbModel, err := FromEngineContext(engineCtx)
+	suite.Require().NoError(err)
 
 	cmd := redis.NewCmd(suite.ctx)
 	cmd.SetVal(int64(1))
 	suite.mockClient.On("EvalSha", suite.ctx, updateFlowScript.Hash(),
 		[]string{suite.flowKey}, mock.Anything).Return(cmd)
 
-	err := suite.store.UpdateFlowContext(suite.ctx, engineCtx)
+	err = suite.store.UpdateFlowContext(suite.ctx, *dbModel)
 	suite.NoError(err)
 }
 
 func (suite *RedisFlowStoreTestSuite) TestUpdateFlowContext_KeyNotFound() {
 	engineCtx := suite.buildEngineContext()
+	dbModel, err := FromEngineContext(engineCtx)
+	suite.Require().NoError(err)
 
 	cmd := redis.NewCmd(suite.ctx)
 	cmd.SetVal(int64(0))
 	suite.mockClient.On("EvalSha", suite.ctx, updateFlowScript.Hash(),
 		[]string{suite.flowKey}, mock.Anything).Return(cmd)
 
-	err := suite.store.UpdateFlowContext(suite.ctx, engineCtx)
+	err = suite.store.UpdateFlowContext(suite.ctx, *dbModel)
 	suite.Error(err)
 	suite.Contains(err.Error(), "flow context not found for executionID")
 }
 
 func (suite *RedisFlowStoreTestSuite) TestUpdateFlowContext_ScriptError() {
 	engineCtx := suite.buildEngineContext()
+	dbModel, err := FromEngineContext(engineCtx)
+	suite.Require().NoError(err)
 
 	cmd := redis.NewCmd(suite.ctx)
 	cmd.SetErr(errors.New("connection refused"))
 	suite.mockClient.On("EvalSha", suite.ctx, updateFlowScript.Hash(),
 		[]string{suite.flowKey}, mock.Anything).Return(cmd)
 
-	err := suite.store.UpdateFlowContext(suite.ctx, engineCtx)
+	err = suite.store.UpdateFlowContext(suite.ctx, *dbModel)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to update flow context in Redis")
 }

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -21,6 +21,7 @@ package flowexec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/application"
@@ -29,8 +30,10 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	sysContext "github.com/asgardeo/thunder/internal/system/context"
+	"github.com/asgardeo/thunder/internal/system/cryptolab"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
+	"github.com/asgardeo/thunder/internal/system/kmprovider"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/observability"
 	"github.com/asgardeo/thunder/internal/system/observability/event"
@@ -60,13 +63,15 @@ type flowExecService struct {
 	appService       application.ApplicationServiceInterface
 	observabilitySvc observability.ObservabilityServiceInterface
 	transactioner    transaction.Transactioner
+	cryptoSvc        kmprovider.RuntimeCryptoProvider
 }
 
 func newFlowExecService(flowMgtService flowmgt.FlowMgtServiceInterface,
 	flowStore flowStoreInterface, flowEngine flowEngineInterface,
 	applicationService application.ApplicationServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
-	transactioner transaction.Transactioner) FlowExecServiceInterface {
+	transactioner transaction.Transactioner,
+	cryptoSvc kmprovider.RuntimeCryptoProvider) FlowExecServiceInterface {
 	return &flowExecService{
 		flowMgtService:   flowMgtService,
 		flowStore:        flowStore,
@@ -74,6 +79,7 @@ func newFlowExecService(flowMgtService flowmgt.FlowMgtServiceInterface,
 		appService:       applicationService,
 		observabilitySvc: observabilitySvc,
 		transactioner:    transactioner,
+		cryptoSvc:        cryptoSvc,
 	}
 }
 
@@ -360,8 +366,13 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 			return fmt.Errorf("flow ID cannot be empty")
 		}
 
+		encryptedEngineCtx, err := s.encryptEngineContext(ctx, engineCtx)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt flow context: %w", err)
+		}
+
 		txErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
-			return s.flowStore.UpdateFlowContext(txCtx, *engineCtx)
+			return s.flowStore.UpdateFlowContext(txCtx, *encryptedEngineCtx)
 		})
 		if txErr != nil {
 			return fmt.Errorf("failed to update flow context in database: %w", txErr)
@@ -382,8 +393,13 @@ func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineCon
 
 	expirySeconds := s.getFlowExpirySeconds(engineCtx.FlowType)
 
+	encryptedEngineCtx, err := s.encryptEngineContext(ctx, engineCtx)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt flow context: %w", err)
+	}
+
 	txErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		return s.flowStore.StoreFlowContext(txCtx, *engineCtx, expirySeconds)
+		return s.flowStore.StoreFlowContext(txCtx, *encryptedEngineCtx, expirySeconds)
 	})
 	if txErr != nil {
 		return fmt.Errorf("failed to store flow context in database: %w", txErr)
@@ -392,6 +408,22 @@ func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineCon
 	logger.Debug("Flow context stored successfully in database",
 		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return nil
+}
+
+// encryptEngineContext serializes an EngineContext and encrypts the context field, returning
+// an EncryptedEngineContext ready to be handed to the store.
+func (s *flowExecService) encryptEngineContext(ctx context.Context, engineCtx *EngineContext) (*FlowContextDB, error) {
+	serialized, err := FromEngineContext(*engineCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize engine context: %w", err)
+	}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}
+	ciphertext, _, err := s.cryptoSvc.Encrypt(ctx, kmprovider.KeyRef{}, params, []byte(serialized.Context))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt context: %w", err)
+	}
+	serialized.Context = string(ciphertext)
+	return serialized, nil
 }
 
 // getFlowGraph checks if the provided application ID is valid and returns the associated flow ID.
@@ -551,8 +583,7 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 	return engineCtx.ExecutionID, nil
 }
 
-// getFlowContext retrieves the flow context from the store based on the given execution ID.
-// It also ensures that the retrieved context is decrypted before returning.
+// getFlowContext retrieves the flow context from the store and decrypts it if needed.
 func (s *flowExecService) getFlowContext(ctx context.Context, executionID string, logger *log.Logger) (
 	*FlowContextDB, *serviceerror.ServiceError) {
 	if executionID == "" {
@@ -571,11 +602,24 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 		return nil, &ErrorInvalidExecutionID
 	}
 
-	if decryptErr := dbModel.decrypt(ctx); decryptErr != nil {
-		logger.Error("Failed to decrypt flow context",
-			log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
-		return nil, &serviceerror.InternalServerError
+	if isContextEncrypted(dbModel.Context) {
+		decryptParams := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}
+		decrypted, decryptErr := s.cryptoSvc.Decrypt(ctx, kmprovider.KeyRef{}, decryptParams, []byte(dbModel.Context))
+		if decryptErr != nil {
+			logger.Error("Failed to decrypt flow context",
+				log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
+			return nil, &serviceerror.InternalServerError
+		}
+		dbModel.Context = string(decrypted)
 	}
 
 	return dbModel, nil
+}
+
+// isContextEncrypted reports whether a context string is in encrypted form by checking for an alg field.
+func isContextEncrypted(context string) bool {
+	var encCheck struct {
+		Algorithm string `json:"alg"`
+	}
+	return json.Unmarshal([]byte(context), &encCheck) == nil && encCheck.Algorithm != ""
 }

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -20,6 +20,7 @@ package flowexec
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,10 +31,15 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	flowmgt "github.com/asgardeo/thunder/internal/flow/mgt"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/cryptolab"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	i18ncore "github.com/asgardeo/thunder/internal/system/i18n/core"
+	"github.com/asgardeo/thunder/internal/system/kmprovider"
+	"github.com/asgardeo/thunder/internal/system/kmprovider/defaultkm"
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+	"github.com/asgardeo/thunder/tests/mocks/crypto/cryptomock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/flowmgtmock"
 )
 
@@ -123,7 +129,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
 
 	// Mock application and graph - shared across all test cases
@@ -199,6 +205,9 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 			mockStore := newFlowStoreInterfaceMock(t)
 			mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 			mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+			mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+			mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return([]byte("encrypted-ctx"), nil, nil)
 
 			// Create service with mocked dependencies
 			service := &flowExecService{
@@ -207,6 +216,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 				appService:     mockAppService,
 				flowEngine:     nil,
 				transactioner:  &stubTransactioner{},
+				cryptoSvc:      mockCrypto,
 			}
 
 			initContext := &FlowInitContext{
@@ -233,49 +243,18 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 				inviteGraph := flowFactory.CreateGraph("onboarding-flow-123", common.FlowTypeUserOnboarding)
 				mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "onboarding-flow-123").Return(inviteGraph, nil)
 
-				// For system flows, StoreFlowContext is called with empty AppID
 				mockStore.EXPECT().StoreFlowContext(mock.MatchedBy(func(ctx context.Context) bool {
 					return ctx.Value(txMarkerKey{}) == "tx"
-				}), mock.MatchedBy(func(ctx EngineContext) bool {
-					// Verify executionID is generated
-					if ctx.ExecutionID == "" {
-						return false
-					}
-					// Verify runtime data according to test case expectation
-					if !tt.expectedRuntimeDataCheck(ctx) {
-						return false
-					}
-					// Verify AppID is empty for system flow
-					if ctx.AppID != "" {
-						return false
-					}
-					if ctx.FlowType != common.FlowTypeUserOnboarding {
-						return false
-					}
-					return true
+				}), mock.MatchedBy(func(encryptedEngineCtx FlowContextDB) bool {
+					return encryptedEngineCtx.ExecutionID != ""
 				}), mock.Anything).Return(nil)
 			} else {
 				mockAppService.EXPECT().GetApplication(mock.Anything, appID).Return(mockApp, nil)
 				mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
 				mockStore.EXPECT().StoreFlowContext(mock.MatchedBy(func(ctx context.Context) bool {
 					return ctx.Value(txMarkerKey{}) == "tx"
-				}), mock.MatchedBy(func(ctx EngineContext) bool {
-					// Verify executionID is generated
-					if ctx.ExecutionID == "" {
-						return false
-					}
-					// Verify runtime data according to test case expectation
-					if !tt.expectedRuntimeDataCheck(ctx) {
-						return false
-					}
-					// Verify AppID and FlowType
-					if ctx.AppID != appID {
-						return false
-					}
-					if ctx.FlowType != common.FlowTypeAuthentication {
-						return false
-					}
-					return true
+				}), mock.MatchedBy(func(encryptedEngineCtx FlowContextDB) bool {
+					return encryptedEngineCtx.ExecutionID != ""
 				}), mock.Anything).Return(nil)
 			}
 
@@ -297,7 +276,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 
 	tests := []struct {
 		name       string
@@ -388,7 +367,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 					mock.MatchedBy(func(ctx context.Context) bool {
 						return ctx.Value(txMarkerKey{}) == "tx"
 					}),
-					mock.AnythingOfType("EngineContext"), mock.Anything).Return(assert.AnError)
+					mock.AnythingOfType("FlowContextDB"), mock.Anything).Return(assert.AnError)
 			},
 			expectedErrorCode: serviceerror.InternalServerError.Code,
 		},
@@ -400,6 +379,9 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 			mockStore := newFlowStoreInterfaceMock(t)
 			mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 			mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+			mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+			mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return([]byte("encrypted-ctx"), nil, nil).Maybe()
 
 			// Create service with mocked dependencies
 			service := &flowExecService{
@@ -408,6 +390,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 				appService:     mockAppService,
 				flowEngine:     nil,
 				transactioner:  &stubTransactioner{},
+				cryptoSvc:      mockCrypto,
 			}
 
 			initContext := &FlowInitContext{
@@ -472,9 +455,124 @@ func TestGetFlowExpirySeconds(t *testing.T) {
 	}
 }
 
-func TestExecute_ContextDecryptionFailure(t *testing.T) {
-	// Tests that when the stored flow context cannot be decrypted,
-	// Execute returns an InternalServerError without proceeding further.
+func TestEncryptedPayloadStoredBeforeWrite(t *testing.T) {
+	// Verifies that the context passed to StoreFlowContext is the encrypted payload
+	// returned by cryptoSvc.Encrypt, not the plain serialized JSON.
+	const encryptedPayload = `{"alg":"AES-GCM","ct":"c2VjcmV0","kid":"k1"}`
+
+	testConfig := &config.Config{}
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize())
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	mockApp := &appmodel.Application{ID: "app-id-123", AuthFlowID: "auth-graph-1"}
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte(encryptedPayload), nil, nil)
+
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app").Return(mockApp, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
+	mockStore.EXPECT().StoreFlowContext(
+		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+		mock.MatchedBy(func(dbModel FlowContextDB) bool {
+			return dbModel.Context == encryptedPayload
+		}),
+		mock.Anything).Return(nil)
+
+	service := &flowExecService{
+		flowMgtService: mockFlowMgtSvc,
+		flowStore:      mockStore,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+		cryptoSvc:      mockCrypto,
+	}
+
+	executionID, svcErr := service.InitiateFlow(context.Background(), &FlowInitContext{
+		ApplicationID: "test-app",
+		FlowType:      "AUTHENTICATION",
+	})
+
+	assert.NotEmpty(t, executionID)
+	assert.Nil(t, svcErr)
+}
+
+func TestDecryptCalledForEncryptedStoredContext(t *testing.T) {
+	// Verifies that when GetFlowContext returns an encrypted context (has "alg" field),
+	// Decrypt is called and the engine receives the properly restored EngineContext.
+	flowFactory, _ := core.Initialize(cache.Initialize())
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	engineCtx := EngineContext{
+		ExecutionID:       "existing-execution-id",
+		AppID:             "test-app-id",
+		FlowType:          common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{Attributes: map[string]interface{}{}},
+		UserInputs:        map[string]string{},
+		RuntimeData:       map[string]string{},
+		ExecutionHistory:  map[string]*common.NodeExecutionRecord{},
+		Graph:             testGraph,
+	}
+	plainCtx, err := FromEngineContext(engineCtx)
+	assert.NoError(t, err)
+
+	// Simulate what the store returns: an encrypted blob
+	encryptedStoredCtx := &FlowContextDB{
+		ExecutionID: "existing-execution-id",
+		Context:     `{"alg":"AES-GCM","ct":"c2VjcmV0","kid":"k1"}`,
+	}
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+
+	// Decrypt should be called with the encrypted blob and return the plain JSON
+	mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything,
+		[]byte(encryptedStoredCtx.Context)).
+		Return([]byte(plainCtx.Context), nil)
+	// Encrypt called when updating context after engine runs
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("re-encrypted"), nil, nil)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(encryptedStoredCtx, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+	// Engine receives a properly restored context — not the raw encrypted bytes
+	mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
+		return ctx != nil && ctx.AppID == "test-app-id" && ctx.ExecutionID == "existing-execution-id"
+	})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
+
+	mockStore.EXPECT().UpdateFlowContext(
+		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+		mock.AnythingOfType("FlowContextDB")).Return(nil)
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+		cryptoSvc:      mockCrypto,
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	assert.Nil(t, svcErr)
+	assert.NotNil(t, flowStep)
+	assert.Equal(t, common.FlowStatusIncomplete, flowStep.Status)
+}
+
+func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
+	// Verifies that after encryptEngineContext, sensitive fields (appId, userId, token, inputs)
+	// are not visible in the encrypted bytes stored — matching the protection guarantee.
 	testConfig := &config.Config{
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
@@ -485,7 +583,163 @@ func TestExecute_ContextDecryptionFailure(t *testing.T) {
 	config.ResetServerRuntime()
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
+	cfgSvc, err := defaultkm.InitConfigProvider()
+	assert.NoError(t, err)
+
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(
+			func(
+				ctx context.Context,
+				_ kmprovider.KeyRef,
+				_ cryptolab.AlgorithmParams,
+				content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
+				encrypted, encErr := cfgSvc.Encrypt(ctx, content)
+				return encrypted, nil, encErr
+			})
+
+	flowFactory, _ := core.Initialize(cache.Initialize())
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	sensitiveAppID := "app-sensitive-99999"
+	sensitiveUserID := "user-sensitive-88888"
+	sensitiveInput := "sensitive-password-value"
+	sensitiveRuntimeData := "sensitive-state-value"
+
+	engineCtx := EngineContext{
+		ExecutionID: "test-flow-id",
+		AppID:       sensitiveAppID,
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          sensitiveUserID,
+			Attributes:      map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{"password": sensitiveInput},
+		RuntimeData:      map[string]string{"state": sensitiveRuntimeData},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+
+	svc := &flowExecService{cryptoSvc: mockCrypto}
+	encryptedEngineCtx, err := svc.encryptEngineContext(context.Background(), &engineCtx)
+	assert.NoError(t, err)
+
+	// Stored context must be encrypted
+	assert.True(t, isContextEncrypted(encryptedEngineCtx.Context),
+		"stored context should have alg field indicating encryption")
+
+	// Sensitive fields must not be visible in the raw stored bytes
+	assert.NotContains(t, encryptedEngineCtx.Context, sensitiveAppID,
+		"appId must not appear in encrypted context")
+	assert.NotContains(t, encryptedEngineCtx.Context, sensitiveUserID,
+		"userId must not appear in encrypted context")
+	assert.NotContains(t, encryptedEngineCtx.Context, sensitiveInput,
+		"user input must not appear in encrypted context")
+	assert.NotContains(t, encryptedEngineCtx.Context, sensitiveRuntimeData,
+		"runtime data must not appear in encrypted context")
+}
+
+func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
+	// Full encrypt → decrypt round trip through encryptEngineContext / getFlowContext decrypt path.
+	// Verifies all context fields — including the auth token — survive the cycle intact.
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	cfgSvc, err := defaultkm.InitConfigProvider()
+	assert.NoError(t, err)
+
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(
+			ctx context.Context,
+			_ kmprovider.KeyRef,
+			_ cryptolab.AlgorithmParams,
+			content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
+			encrypted, encErr := cfgSvc.Encrypt(ctx, content)
+			return encrypted, nil, encErr
+		})
+	mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(
+			ctx context.Context,
+			_ kmprovider.KeyRef,
+			_ cryptolab.AlgorithmParams, content []byte) ([]byte, error) {
+			return cfgSvc.Decrypt(ctx, content)
+		})
+
+	flowFactory, _ := core.Initialize(cache.Initialize())
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	originalToken := "original-secret-token-value-xyz789"
+
+	engineCtx := EngineContext{
+		ExecutionID: "round-trip-flow-id",
+		AppID:       "round-trip-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "round-trip-user-id",
+			OUID:            "round-trip-org-id",
+			UserType:        "standard",
+			Token:           originalToken,
+			Attributes:      map[string]interface{}{"email": "test@example.com"},
+		},
+		UserInputs:       map[string]string{"username": "testuser"},
+		RuntimeData:      map[string]string{"state": "abc123"},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+
+	svc := &flowExecService{cryptoSvc: mockCrypto}
+
+	// Step 1: Encrypt (as storeContext / updateContext would)
+	encryptedEngineCtx, err := svc.encryptEngineContext(context.Background(), &engineCtx)
+	assert.NoError(t, err)
+	assert.True(t, isContextEncrypted(encryptedEngineCtx.Context))
+
+	// Step 2: Simulate getFlowContext decrypt path — call through the mock so RunAndReturn fires
+	decryptedBytes, err := mockCrypto.Decrypt(
+		context.Background(), kmprovider.KeyRef{},
+		cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM},
+		[]byte(encryptedEngineCtx.Context))
+	assert.NoError(t, err)
+
+	restoredDB := &FlowContextDB{
+		ExecutionID: encryptedEngineCtx.ExecutionID,
+		Context:     string(decryptedBytes),
+	}
+
+	// Step 3: Convert back to EngineContext
+	resultCtx, err := restoredDB.ToEngineContext(context.Background(), testGraph)
+	assert.NoError(t, err)
+
+	// Verify all fields survived the round trip
+	assert.Equal(t, engineCtx.ExecutionID, resultCtx.ExecutionID)
+	assert.Equal(t, engineCtx.AppID, resultCtx.AppID)
+	assert.True(t, resultCtx.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(t, engineCtx.AuthenticatedUser.UserID, resultCtx.AuthenticatedUser.UserID)
+	assert.Equal(t, engineCtx.AuthenticatedUser.OUID, resultCtx.AuthenticatedUser.OUID)
+	assert.Equal(t, engineCtx.AuthenticatedUser.UserType, resultCtx.AuthenticatedUser.UserType)
+	assert.Equal(t, originalToken, resultCtx.AuthenticatedUser.Token,
+		"token must survive the full encrypt-decrypt round trip")
+	assert.Equal(t, len(engineCtx.UserInputs), len(resultCtx.UserInputs))
+	assert.Equal(t, len(engineCtx.RuntimeData), len(resultCtx.RuntimeData))
+}
+
+func TestExecute_ContextDecryptionFailure(t *testing.T) {
+	// Tests that when the stored flow context cannot be decrypted,
+	// Execute returns an InternalServerError without proceeding further.
 	mockStore := newFlowStoreInterfaceMock(t)
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("decryption failed"))
 
 	// Context looks encrypted (has "alg" field) but the ciphertext is invalid
 	invalidCtx := &FlowContextDB{
@@ -496,6 +750,7 @@ func TestExecute_ContextDecryptionFailure(t *testing.T) {
 
 	service := &flowExecService{
 		flowStore: mockStore,
+		cryptoSvc: mockCrypto,
 	}
 
 	_, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
@@ -506,22 +761,11 @@ func TestExecute_ContextDecryptionFailure(t *testing.T) {
 }
 
 func TestExecute_ContextDecryptionSuccess(t *testing.T) {
-	// Tests that a properly encrypted stored context is decrypted and used
-	// to continue flow execution without error.
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
-
-	flowFactory, _ := core.Initialize()
+	// Tests that a plain-text stored context (decryption already handled by service before store)
+	// is loaded and used to continue flow execution without error.
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
-	// Build a properly encrypted FlowContextDB
 	engineCtx := EngineContext{
 		ExecutionID: "existing-execution-id",
 		AppID:       "test-app-id",
@@ -534,16 +778,18 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            testGraph,
 	}
-	dbModel, err := FromEngineContext(engineCtx)
+	storedCtx, err := FromEngineContext(engineCtx)
 	assert.NoError(t, err)
-	assert.Contains(t, dbModel.Context, `"ct"`, "context should be encrypted before retrieval")
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
 	mockEngine := newFlowEngineInterfaceMock(t)
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("encrypted-ctx"), nil, nil)
 
-	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
 	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
@@ -553,7 +799,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 	})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
 	mockStore.EXPECT().UpdateFlowContext(
 		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
-		mock.AnythingOfType("EngineContext")).Return(nil)
+		mock.AnythingOfType("FlowContextDB")).Return(nil)
 
 	service := &flowExecService{
 		flowStore:      mockStore,
@@ -561,6 +807,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 		flowEngine:     mockEngine,
 		appService:     mockAppService,
 		transactioner:  &stubTransactioner{},
+		cryptoSvc:      mockCrypto,
 	}
 
 	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
@@ -572,17 +819,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 }
 
 func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
-
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -597,7 +834,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            testGraph,
 	}
-	dbModel, err := FromEngineContext(engineCtx)
+	storedCtx, err := FromEngineContext(engineCtx)
 	assert.NoError(t, err)
 
 	mockStore := newFlowStoreInterfaceMock(t)
@@ -605,17 +842,21 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 	mockEngine := newFlowEngineInterfaceMock(t)
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 
-	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
 	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte("encrypted-ctx"), nil, nil)
 
 	mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
 		return ctx != nil && ctx.ChallengeTokenIn == ""
 	})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
 	mockStore.EXPECT().UpdateFlowContext(
 		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
-		mock.AnythingOfType("EngineContext")).Return(nil)
+		mock.AnythingOfType("FlowContextDB")).Return(nil)
 
 	service := &flowExecService{
 		flowStore:      mockStore,
@@ -623,6 +864,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 		flowEngine:     mockEngine,
 		appService:     mockAppService,
 		transactioner:  &stubTransactioner{},
+		cryptoSvc:      mockCrypto,
 	}
 
 	// Execute with empty challenge token
@@ -635,17 +877,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 }
 
 func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
-
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	tests := []struct {
@@ -686,7 +918,7 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 				ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 				Graph:            testGraph,
 			}
-			dbModel, err := FromEngineContext(engineCtx)
+			storedCtx, err := FromEngineContext(engineCtx)
 			assert.NoError(t, err)
 
 			mockStore := newFlowStoreInterfaceMock(t)
@@ -694,18 +926,22 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 			mockEngine := newFlowEngineInterfaceMock(t)
 			mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 
-			mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+			mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
 			mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 			mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 				&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
 
 			expectedToken := tt.expectInContext
+			mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+			mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return([]byte("encrypted-ctx"), nil, nil)
+
 			mockEngine.EXPECT().Execute(mock.MatchedBy(func(ctx *EngineContext) bool {
 				return ctx != nil && ctx.ChallengeTokenIn == expectedToken
 			})).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
 			mockStore.EXPECT().UpdateFlowContext(
 				mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
-				mock.AnythingOfType("EngineContext")).Return(nil)
+				mock.AnythingOfType("FlowContextDB")).Return(nil)
 
 			service := &flowExecService{
 				flowStore:      mockStore,
@@ -713,6 +949,7 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 				flowEngine:     mockEngine,
 				appService:     mockAppService,
 				transactioner:  &stubTransactioner{},
+				cryptoSvc:      mockCrypto,
 			}
 
 			flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
@@ -726,17 +963,7 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 }
 
 func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T) {
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
-
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -751,7 +978,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            testGraph,
 	}
-	dbModel, err := FromEngineContext(engineCtx)
+	storedCtx, err := FromEngineContext(engineCtx)
 	assert.NoError(t, err)
 
 	mockStore := newFlowStoreInterfaceMock(t)
@@ -759,7 +986,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 	mockEngine := newFlowEngineInterfaceMock(t)
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 
-	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
 	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
@@ -785,17 +1012,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 }
 
 func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
-
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -810,7 +1027,7 @@ func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Graph:            testGraph,
 	}
-	dbModel, err := FromEngineContext(engineCtx)
+	storedCtx, err := FromEngineContext(engineCtx)
 	assert.NoError(t, err)
 
 	mockStore := newFlowStoreInterfaceMock(t)
@@ -818,7 +1035,7 @@ func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
 	mockEngine := newFlowEngineInterfaceMock(t)
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 
-	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
 	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
 	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
 		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
@@ -862,7 +1079,7 @@ func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
 	config.ResetServerRuntime()
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize()
+	flowFactory, _ := core.Initialize(cache.Initialize())
 	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
 
 	mockStore := newFlowStoreInterfaceMock(t)

--- a/backend/internal/flow/flowexec/store.go
+++ b/backend/internal/flow/flowexec/store.go
@@ -31,9 +31,9 @@ import (
 
 // flowStoreInterface defines the methods for flow context storage operations.
 type flowStoreInterface interface {
-	StoreFlowContext(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error
+	StoreFlowContext(ctx context.Context, dbModel FlowContextDB, expirySeconds int64) error
 	GetFlowContext(ctx context.Context, executionID string) (*FlowContextDB, error)
-	UpdateFlowContext(ctx context.Context, engineCtx EngineContext) error
+	UpdateFlowContext(ctx context.Context, dbModel FlowContextDB) error
 	DeleteFlowContext(ctx context.Context, executionID string) error
 }
 
@@ -52,12 +52,7 @@ func newFlowStore(dbProvider provider.DBProviderInterface) flowStoreInterface {
 }
 
 // StoreFlowContext stores the complete flow context in the database.
-func (s *flowStore) StoreFlowContext(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error {
-	dbModel, err := FromEngineContext(engineCtx)
-	if err != nil {
-		return fmt.Errorf("failed to convert engine context to database model: %w", err)
-	}
-
+func (s *flowStore) StoreFlowContext(ctx context.Context, dbModel FlowContextDB, expirySeconds int64) error {
 	expiryTime := time.Now().UTC().Add(time.Duration(expirySeconds) * time.Second)
 
 	return withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
@@ -99,12 +94,7 @@ func (s *flowStore) GetFlowContext(ctx context.Context, executionID string) (*Fl
 }
 
 // UpdateFlowContext updates the flow context in the database.
-func (s *flowStore) UpdateFlowContext(ctx context.Context, engineCtx EngineContext) error {
-	dbModel, err := FromEngineContext(engineCtx)
-	if err != nil {
-		return fmt.Errorf("failed to convert engine context to database model: %w", err)
-	}
-
+func (s *flowStore) UpdateFlowContext(ctx context.Context, dbModel FlowContextDB) error {
 	return withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
 		_, err := dbClient.ExecuteContext(ctx, QueryUpdateFlowContext,
 			dbModel.ExecutionID, dbModel.Context, s.deploymentID)

--- a/backend/internal/flow/flowexec/store_test.go
+++ b/backend/internal/flow/flowexec/store_test.go
@@ -31,10 +31,6 @@ import (
 	authnprovidercm "github.com/asgardeo/thunder/internal/authnprovider/common"
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
-	"github.com/asgardeo/thunder/internal/system/config"
-	"github.com/asgardeo/thunder/internal/system/cryptolab"
-	"github.com/asgardeo/thunder/internal/system/kmprovider"
-	"github.com/asgardeo/thunder/internal/system/kmprovider/defaultkm"
 
 	"github.com/asgardeo/thunder/tests/mocks/database/providermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
@@ -45,31 +41,12 @@ type StoreTestSuite struct {
 }
 
 func TestStoreTestSuite(t *testing.T) {
-	// Setup test config with encryption key
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-		Server: config.ServerConfig{
-			Identifier: "test-deployment",
-		},
-	}
-	config.ResetServerRuntime()
-	err := config.InitializeServerRuntime("/test/thunderid/home", testConfig)
-	if err != nil {
-		t.Fatalf("Failed to initialize server runtime: %v", err)
-	}
-
 	suite.Run(t, new(StoreTestSuite))
 }
 
 func (s *StoreTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
-	err := dbModel.decrypt(context.Background())
-	s.NoError(err)
 	var content flowContextContent
-	err = json.Unmarshal([]byte(dbModel.Context), &content)
+	err := json.Unmarshal([]byte(dbModel.Context), &content)
 	s.NoError(err)
 	return content
 }
@@ -114,7 +91,9 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithToken() {
 	}
 
 	// Execute
-	err := store.StoreFlowContext(context.Background(), ctx, expirySeconds)
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	err = store.StoreFlowContext(context.Background(), *dbModel, expirySeconds)
 
 	// Verify
 	s.NoError(err)
@@ -159,7 +138,9 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithoutToken() {
 	}
 
 	// Execute
-	err := store.StoreFlowContext(context.Background(), ctx, expirySeconds)
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	err = store.StoreFlowContext(context.Background(), *dbModel, expirySeconds)
 
 	// Verify
 	s.NoError(err)
@@ -203,7 +184,9 @@ func (s *StoreTestSuite) TestUpdateFlowContext_WithToken() {
 	}
 
 	// Execute
-	err := store.UpdateFlowContext(context.Background(), ctx)
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	err = store.UpdateFlowContext(context.Background(), *dbModel)
 
 	// Verify
 	s.NoError(err)
@@ -240,9 +223,6 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	dbModel, err := FromEngineContext(ctx)
 	s.NoError(err)
 
-	// Save encrypted context before getContextContent decrypts it in place
-	encryptedContext := dbModel.Context
-
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.Token)
 
@@ -253,7 +233,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     encryptedContext,
+			"context":     dbModel.Context,
 			"expiry_time": expiryTime,
 		},
 	}
@@ -275,7 +255,6 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	s.NotNil(result)
 	s.Equal("test-flow-id", result.ExecutionID)
 
-	// getContextContent decrypts result in place; ToEngineContext works on the decrypted context
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.Token)
@@ -295,28 +274,17 @@ func (s *StoreTestSuite) TestGetFlowContext_WithoutToken() {
 
 	expiryTime := time.Now().Add(30 * time.Minute)
 
-	// Create and encrypt context
 	contextJSON, err := json.Marshal(flowContextContent{
 		AppID:           "test-app-id",
 		IsAuthenticated: false,
 		GraphID:         "test-graph-id",
 	})
 	s.NoError(err)
-	cryptoSvc, err := defaultkm.GetRuntimeCryptoService()
-	s.Require().NoError(err)
-	encryptedContextBytes, _, err := cryptoSvc.Encrypt(
-		context.Background(),
-		kmprovider.KeyRef{},
-		cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM},
-		contextJSON,
-	)
-	s.NoError(err)
-	encryptedContext := string(encryptedContextBytes)
 
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     encryptedContext,
+			"context":     string(contextJSON),
 			"expiry_time": expiryTime,
 		},
 	}
@@ -385,24 +353,17 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 		Graph: mockGraph,
 	}
 
-	// Step 1: Convert to DB model (encrypts entire context)
+	// Step 1: Convert to DB model (serializes context to plain JSON)
 	dbModel, err := FromEngineContext(originalCtx)
 	s.NoError(err)
 	s.NotNil(dbModel)
 
-	// Verify the context is encrypted
-	s.Contains(dbModel.Context, `"ct"`, "context should be encrypted")
-
-	// Step 2: Simulate storing and retrieving from DB
-	// In a real scenario, this would be inserted into DB and read back
-	// For this test, we'll directly use the dbModel
-
-	// Step 3: Decrypt context and read the content
+	// Step 2: Verify token is serialized in context
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.Token)
 	s.Equal(originalToken, *content.Token)
 
-	// Step 4: Convert to EngineContext (context already decrypted by getContextContent)
+	// Step 3: Convert to EngineContext
 	retrievedCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 
@@ -455,19 +416,12 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_ContextEncryptionRoundTrip() {
 		Graph: mockGraph,
 	}
 
-	// Step 1: Convert to DB model (encrypts entire context)
+	// Step 1: Convert to DB model (serializes context to plain JSON)
 	dbModel, err := FromEngineContext(originalCtx)
 	s.NoError(err)
 	s.NotNil(dbModel)
 
-	// Step 2: Verify entire context is encrypted — no plain fields visible
-	s.Contains(dbModel.Context, `"ct"`, "encrypted context should contain ciphertext field")
-	s.NotContains(dbModel.Context, sensitiveAppID, "appId should not be visible in encrypted context")
-	s.NotContains(dbModel.Context, sensitiveUserID, "userId should not be visible in encrypted context")
-	s.NotContains(dbModel.Context, sensitiveInput, "userInputs should not be visible in encrypted context")
-	s.NotContains(dbModel.Context, sensitiveRuntimeData, "runtimeData should not be visible in encrypted context")
-
-	// Step 3: Decrypt and verify all fields are restored
+	// Step 2: Verify all fields are serialized correctly
 	content := s.getContextContent(dbModel)
 	s.Equal(sensitiveAppID, content.AppID)
 	s.NotNil(content.UserID)
@@ -486,6 +440,7 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_ContextEncryptionRoundTrip() {
 	retrievedCtx, err := dbModel.ToEngineContext(context.Background(), mockGraph)
 	s.NoError(err)
 	s.Equal(originalCtx.ExecutionID, retrievedCtx.ExecutionID)
+
 	s.Equal(originalCtx.AppID, retrievedCtx.AppID)
 	s.Equal(originalCtx.AuthenticatedUser.IsAuthenticated, retrievedCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal(originalCtx.AuthenticatedUser.UserID, retrievedCtx.AuthenticatedUser.UserID)
@@ -633,7 +588,9 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithAvailableAttributes() {
 	}
 
 	// Execute
-	err := store.StoreFlowContext(context.Background(), ctx, expirySeconds)
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	err = store.StoreFlowContext(context.Background(), *dbModel, expirySeconds)
 
 	// Verify
 	s.NoError(err)
@@ -691,7 +648,9 @@ func (s *StoreTestSuite) TestUpdateFlowContext_WithAvailableAttributes() {
 	}
 
 	// Execute
-	err := store.UpdateFlowContext(context.Background(), ctx)
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	err = store.UpdateFlowContext(context.Background(), *dbModel)
 
 	// Verify
 	s.NoError(err)
@@ -742,9 +701,6 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	dbModel, err := FromEngineContext(ctx)
 	s.NoError(err)
 
-	// Save encrypted context before getContextContent decrypts it in place
-	encryptedContext := dbModel.Context
-
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.AvailableAttributes)
 
@@ -755,7 +711,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     encryptedContext,
+			"context":     dbModel.Context,
 			"expiry_time": expiryTime,
 		},
 	}
@@ -777,7 +733,6 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	s.NotNil(result)
 	s.Equal("test-flow-id", result.ExecutionID)
 
-	// getContextContent decrypts result in place; ToEngineContext works on the decrypted context
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.AvailableAttributes)

--- a/backend/internal/flow/mgt/cache_backed_store.go
+++ b/backend/internal/flow/mgt/cache_backed_store.go
@@ -39,14 +39,17 @@ type cacheBackedFlowStore struct {
 }
 
 // newCacheBackedFlowStore creates a new instance of cacheBackedFlowStore.
-func newCacheBackedFlowStore() (flowStoreInterface, transaction.Transactioner, error) {
+func newCacheBackedFlowStore(
+	flowByIDCache cache.CacheInterface[*CompleteFlowDefinition],
+	flowByHandleCache cache.CacheInterface[*CompleteFlowDefinition],
+) (flowStoreInterface, transaction.Transactioner, error) {
 	store, transactioner, err := newFlowStore()
 	if err != nil {
 		return nil, nil, err
 	}
 	return &cacheBackedFlowStore{
-		flowByIDCache:     cache.GetCache[*CompleteFlowDefinition]("FlowByIDCache"),
-		flowByHandleCache: cache.GetCache[*CompleteFlowDefinition]("FlowByHandleCache"),
+		flowByIDCache:     flowByIDCache,
+		flowByHandleCache: flowByHandleCache,
 		store:             store,
 		logger: log.GetLogger().With(
 			log.String(log.LoggerKeyComponentName, cacheBackedStoreLoggerComponentName)),

--- a/backend/internal/flow/mgt/init.go
+++ b/backend/internal/flow/mgt/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/flow/executor"
 
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -38,11 +39,12 @@ import (
 func Initialize(
 	mux *http.ServeMux,
 	mcpServer *mcp.Server,
+	cacheManager cache.CacheManagerInterface,
 	flowFactory core.FlowFactoryInterface,
 	executorRegistry executor.ExecutorRegistryInterface,
 	graphCache core.GraphCacheInterface,
 ) (FlowMgtServiceInterface, declarativeresource.ResourceExporter, error) {
-	store, compositeStore, transactioner, err := initializeStore()
+	store, compositeStore, transactioner, err := initializeStore(cacheManager)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,15 +85,19 @@ func Initialize(
 //   - Reads check both stores (merged results)
 //   - Writes only go to database store
 //   - Declarative flows cannot be updated or deleted
-func initializeStore() (flowStoreInterface, *compositeFlowStore, transaction.Transactioner, error) {
+func initializeStore(cacheManager cache.CacheManagerInterface) (
+	flowStoreInterface, *compositeFlowStore, transaction.Transactioner, error) {
 	var compositeStore *compositeFlowStore
 
 	storeMode := getFlowStoreMode()
 
+	flowByIDCache := cache.GetCache[*CompleteFlowDefinition](cacheManager, "FlowByIDCache")
+	flowByHandleCache := cache.GetCache[*CompleteFlowDefinition](cacheManager, "FlowByHandleCache")
+
 	switch storeMode {
 	case serverconst.StoreModeComposite:
 		fileStore, _ := newFileBasedStore()
-		dbStore, transactioner, err := newCacheBackedFlowStore()
+		dbStore, transactioner, err := newCacheBackedFlowStore(flowByIDCache, flowByHandleCache)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -109,7 +115,7 @@ func initializeStore() (flowStoreInterface, *compositeFlowStore, transaction.Tra
 		return fileStore, nil, transactioner, nil
 
 	default:
-		store, transactioner, err := newCacheBackedFlowStore()
+		store, transactioner, err := newCacheBackedFlowStore(flowByIDCache, flowByHandleCache)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/backend/internal/flow/mgt/init_test.go
+++ b/backend/internal/flow/mgt/init_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/cors"
@@ -755,7 +756,7 @@ func (s *InitTestSuite) TestInitializeStore_MutableMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	s.NoError(err)
 	s.NotNil(store)
@@ -792,7 +793,7 @@ func (s *InitTestSuite) TestInitializeStore_DeclarativeMode() {
 	_ = config.InitializeServerRuntime("test", testConfig)
 	defer config.ResetServerRuntime()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization, not resource loading
@@ -834,7 +835,7 @@ func (s *InitTestSuite) TestInitializeStore_CompositeMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization, not resource loading
@@ -875,7 +876,7 @@ func (s *InitTestSuite) TestInitializeStore_DeclarativeMode_ResourceLoadingError
 	_ = config.InitializeServerRuntime("test", testConfig)
 	defer config.ResetServerRuntime()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	// When declarative resources path doesn't exist or has issues, error is returned
 	// The store and compositeStore should be nil when error occurs
@@ -919,7 +920,7 @@ func (s *InitTestSuite) TestInitializeStore_CompositeMode_ResourceLoadingError()
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	// When declarative resources path doesn't exist or has issues, error is returned
 	// The store and compositeStore should be nil when error occurs
@@ -963,7 +964,7 @@ func (s *InitTestSuite) TestInitializeStore_DefaultMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	s.NoError(err)
 	s.NotNil(store)
@@ -1003,7 +1004,7 @@ func (s *InitTestSuite) TestInitializeStore_ModeNormalization() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore()
+	store, compositeStore, _, err := initializeStore(cache.Initialize())
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization and mode normalization

--- a/backend/internal/inboundclient/cache_backed_store.go
+++ b/backend/internal/inboundclient/cache_backed_store.go
@@ -42,10 +42,12 @@ type cachedBackStore struct {
 }
 
 // newCachedBackStore wraps an existing inboundClientStoreInterface with caching.
-func newCachedBackStore(inner inboundClientStoreInterface) inboundClientStoreInterface {
+func newCachedBackStore(inner inboundClientStoreInterface,
+	inboundClientCache cache.CacheInterface[*inboundmodel.InboundClient],
+	oauthProfileCache cache.CacheInterface[*inboundmodel.OAuthProfile]) inboundClientStoreInterface {
 	return &cachedBackStore{
-		inboundClientCache: cache.GetCache[*inboundmodel.InboundClient](inboundClientCacheName),
-		oauthProfileCache:  cache.GetCache[*inboundmodel.OAuthProfile](oauthProfileCacheName),
+		inboundClientCache: inboundClientCache,
+		oauthProfileCache:  oauthProfileCache,
 		inner:              inner,
 	}
 }

--- a/backend/internal/inboundclient/init.go
+++ b/backend/internal/inboundclient/init.go
@@ -26,12 +26,16 @@ import (
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/entitytype"
 	flowmgt "github.com/asgardeo/thunder/internal/flow/mgt"
+	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
+	"github.com/asgardeo/thunder/internal/system/cache"
 	dre "github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
 	"github.com/asgardeo/thunder/internal/system/transaction"
 )
 
 // Initialize initializes the inbound client service.
-func Initialize(certService cert.CertificateServiceInterface,
+func Initialize(
+	cacheManager cache.CacheManagerInterface,
+	certService cert.CertificateServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 	themeMgt thememgt.ThemeMgtServiceInterface,
 	layoutMgt layoutmgt.LayoutMgtServiceInterface,
@@ -39,7 +43,7 @@ func Initialize(certService cert.CertificateServiceInterface,
 	entityType entitytype.EntityTypeServiceInterface,
 	consentService consent.ConsentServiceInterface,
 ) (InboundClientServiceInterface, error) {
-	store, transactioner, err := initializeStore()
+	store, transactioner, err := initializeStore(cacheManager)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +52,15 @@ func Initialize(certService cert.CertificateServiceInterface,
 }
 
 // initializeStore always creates a composite store (DB + in-memory file store).
-func initializeStore() (inboundClientStoreInterface, transaction.Transactioner, error) {
+func initializeStore(cacheManager cache.CacheManagerInterface) (
+	inboundClientStoreInterface, transaction.Transactioner, error) {
 	fileStore := newFileBasedStore(dre.KeyTypeInboundAuth)
 	dbStore, transactioner, err := newStore()
 	if err != nil {
 		return nil, nil, err
 	}
-	cached := newCachedBackStore(dbStore)
+	inboundClientCache := cache.GetCache[*inboundmodel.InboundClient](cacheManager, inboundClientCacheName)
+	oauthProfileCache := cache.GetCache[*inboundmodel.OAuthProfile](cacheManager, oauthProfileCacheName)
+	cached := newCachedBackStore(dbStore, inboundClientCache, oauthProfileCache)
 	return newCompositeStore(fileStore, cached), transactioner, nil
 }

--- a/backend/internal/system/cache/CacheManagerInterface_mock_test.go
+++ b/backend/internal/system/cache/CacheManagerInterface_mock_test.go
@@ -71,39 +71,6 @@ func (_c *CacheManagerInterfaceMock_Close_Call) RunAndReturn(run func()) *CacheM
 	return _c
 }
 
-// Init provides a mock function for the type CacheManagerInterfaceMock
-func (_mock *CacheManagerInterfaceMock) Init() {
-	_mock.Called()
-	return
-}
-
-// CacheManagerInterfaceMock_Init_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Init'
-type CacheManagerInterfaceMock_Init_Call struct {
-	*mock.Call
-}
-
-// Init is a helper method to define mock.On call
-func (_e *CacheManagerInterfaceMock_Expecter) Init() *CacheManagerInterfaceMock_Init_Call {
-	return &CacheManagerInterfaceMock_Init_Call{Call: _e.mock.On("Init")}
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) Run(run func()) *CacheManagerInterfaceMock_Init_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) Return() *CacheManagerInterfaceMock_Init_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) RunAndReturn(run func()) *CacheManagerInterfaceMock_Init_Call {
-	_c.Run(run)
-	return _c
-}
-
 // IsEnabled provides a mock function for the type CacheManagerInterfaceMock
 func (_mock *CacheManagerInterfaceMock) IsEnabled() bool {
 	ret := _mock.Called()

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -32,7 +32,6 @@ import (
 
 // CacheManagerInterface defines the interface for managing caches.
 type CacheManagerInterface interface {
-	Init()
 	Close()
 	IsEnabled() bool
 	getMutex() *sync.RWMutex
@@ -53,31 +52,20 @@ type CacheManager struct {
 	redisClient     *redis.Client
 }
 
-var (
-	instance CacheManagerInterface
-	once     sync.Once
-)
-
-// GetCacheManager returns a singleton instance of CacheManager.
-func GetCacheManager() CacheManagerInterface {
-	once.Do(func() {
-		instance = &CacheManager{
-			caches: make(map[string]interface{}),
-		}
-	})
-	return instance
-}
-
-// Init initializes the CacheManager, setting up caches and starting cleanup routines.
-func (cm *CacheManager) Init() {
+// Initialize creates and returns a new CacheManagerInterface instance.
+// Initialize creates, configures, and returns a ready-to-use CacheManagerInterface.
+func Initialize() CacheManagerInterface {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
 	logger.Debug("Initializing Cache Manager")
 
+	cm := &CacheManager{
+		caches: make(map[string]interface{}),
+	}
+
 	cacheConfig := config.GetServerRuntime().Config.Cache
 	if cacheConfig.Disabled {
-		cm.enabled = false
 		logger.Debug("Caching is disabled. Skipping initialization")
-		return
+		return cm
 	}
 
 	cm.enabled = true
@@ -102,7 +90,7 @@ func (cm *CacheManager) Init() {
 			}
 			cm.redisClient = nil
 			cm.enabled = false
-			return
+			return cm
 		}
 		logger.Debug("Connected to Redis successfully", log.String("address", cacheConfig.Redis.Address))
 	} else {
@@ -112,6 +100,7 @@ func (cm *CacheManager) Init() {
 
 	logger.Debug("Cache Manager initialized", log.Bool("enabled", cm.enabled),
 		log.Any("cleanupInterval", cm.cleanupInterval))
+	return cm
 }
 
 // Close shuts down the CacheManager and releases resources.
@@ -165,6 +154,10 @@ func (cm *CacheManager) getRedisClient() *redis.Client {
 
 // startCleanupRoutine starts a background routine to clean up expired caches at regular intervals.
 func (cm *CacheManager) startCleanupRoutine() {
+	if cm.cleanupInterval <= 0 {
+		return
+	}
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
 	logger.Debug("Starting cleanup routine for caches")
 
@@ -227,7 +220,7 @@ func buildRedisKeyPrefix(basePrefix string) string {
 }
 
 // newCache creates a new cache instance.
-func newCache[T any](cacheName string) CacheInterface[T] {
+func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[T] {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"),
 		log.String("cacheName", cacheName))
 
@@ -264,7 +257,7 @@ func newCache[T any](cacheName string) CacheInterface[T] {
 			cacheProperty,
 		)
 	case cacheTypeRedis:
-		redisClient := GetCacheManager().getRedisClient()
+		redisClient := cm.getRedisClient()
 		if redisClient == nil {
 			logger.Warn("Redis client not available, disabling cache")
 			return &Cache[T]{
@@ -293,20 +286,18 @@ func newCache[T any](cacheName string) CacheInterface[T] {
 		)
 	}
 
-	cache := &Cache[T]{
+	cacheInst := &Cache[T]{
 		enabled:   true,
 		cacheName: cacheName,
 		cacheImpl: internalCache,
 	}
 
-	return cache
+	return cacheInst
 }
 
-// GetInMemoryCache returns a singleton in-memory cache instance for the given type and cache name,
-func GetInMemoryCache[T any](cacheName string) CacheInterface[T] {
+// GetInMemoryCache returns a singleton in-memory cache instance for the given type and cache name.
+func GetInMemoryCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[T] {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-
-	cm := GetCacheManager()
 
 	var t T
 	typeName := reflect.TypeOf(t).String()
@@ -343,20 +334,18 @@ func GetInMemoryCache[T any](cacheName string) CacheInterface[T] {
 		internalCache = newInMemoryCache[T](cacheName, true, cacheConfig, cacheProperty)
 	}
 
-	newCache := &Cache[T]{
+	newCacheInst := &Cache[T]{
 		enabled:   !cacheConfig.Disabled && !cacheProperty.Disabled,
 		cacheName: cacheName,
 		cacheImpl: internalCache,
 	}
-	cm.addCache(cacheKey, newCache)
-	return newCache
+	cm.addCache(cacheKey, newCacheInst)
+	return newCacheInst
 }
 
 // GetCache returns a singleton cache instance for the given type and cache name.
-func GetCache[T any](cacheName string) CacheInterface[T] {
+func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[T] {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-
-	cm := GetCacheManager()
 
 	// Create unique key for the cache
 	var t T
@@ -393,10 +382,10 @@ func GetCache[T any](cacheName string) CacheInterface[T] {
 
 	// Create a new cache
 	logger.Debug("Creating new cache", log.String("cacheName", cacheName), log.String("type", typeName))
-	newCache := newCache[T](cacheName)
-	cm.addCache(cacheKey, newCache)
+	newCacheInst := newCache[T](cm, cacheName)
+	cm.addCache(cacheKey, newCacheInst)
 
-	return newCache
+	return newCacheInst
 }
 
 // getCacheType retrieves the cache type from the configuration.

--- a/backend/internal/system/cache/manager_test.go
+++ b/backend/internal/system/cache/manager_test.go
@@ -57,33 +57,19 @@ func (suite *CacheManagerTestSuite) TearDownSuite() {
 	config.ResetServerRuntime()
 }
 
-func (suite *CacheManagerTestSuite) SetupTest() {
-	// Reset the singleton instance for each test
-	instance = nil
-	once = sync.Once{}
-}
-
-func (suite *CacheManagerTestSuite) TestGetCacheManager() {
+func (suite *CacheManagerTestSuite) TestInitialize() {
 	t := suite.T()
 
-	// Get cache manager instance
-	manager1 := GetCacheManager()
-	assert.NotNil(t, manager1, "Cache manager should not be nil")
-	assert.IsType(t, &CacheManager{}, manager1, "Cache manager should be of type *CacheManager")
-
-	// Get another instance to verify singleton pattern
-	manager2 := GetCacheManager()
-	assert.Same(t, manager1, manager2, "GetCacheManager should return the same instance (singleton)")
+	manager := Initialize()
+	assert.NotNil(t, manager, "Cache manager should not be nil")
+	assert.IsType(t, &CacheManager{}, manager, "Cache manager should be of type *CacheManager")
 }
 
 func (suite *CacheManagerTestSuite) TestCacheManagerInit() {
 	t := suite.T()
 
-	// Test with cache disabled
-	manager := &CacheManager{
-		caches: make(map[string]interface{}),
-	}
-	manager.Init()
+	// Test with cache disabled (default config has cache disabled)
+	manager := Initialize()
 	assert.False(t, manager.IsEnabled(), "Cache should be disabled")
 
 	// Test with cache enabled
@@ -100,12 +86,10 @@ func (suite *CacheManagerTestSuite) TestCacheManagerInit() {
 	err := config.InitializeServerRuntime("/test/thunderid/home", enabledConfig)
 	assert.NoError(t, err)
 
-	manager = &CacheManager{
-		caches: make(map[string]interface{}),
-	}
-	manager.Init()
+	manager = Initialize()
 	assert.True(t, manager.IsEnabled(), "Cache should be enabled")
-	assert.Equal(t, time.Duration(60)*time.Second, manager.cleanupInterval, "Cleanup interval should be set")
+	assert.Equal(t, time.Duration(60)*time.Second, manager.(*CacheManager).cleanupInterval,
+		"Cleanup interval should be set")
 }
 
 func (suite *CacheManagerTestSuite) TestGetMutex() {
@@ -150,18 +134,16 @@ func (suite *CacheManagerTestSuite) TestAddAndGetCache() {
 func (suite *CacheManagerTestSuite) TestGetCache() {
 	t := suite.T()
 
-	// Get a cache for string type
+	manager := Initialize()
 	cacheName := "testCache"
-	cache1 := GetCache[string](cacheName)
+	cache1 := GetCache[string](manager, cacheName)
 	assert.NotNil(t, cache1, "Cache should not be nil")
 
-	// Get the same cache again
-	cache2 := GetCache[string](cacheName)
+	cache2 := GetCache[string](manager, cacheName)
 	assert.Same(t, cache1, cache2, "GetCache should return the same instance for the same type and name")
 
-	// Test with a different cache name but same type
 	differentCacheName := "anotherCache"
-	cache3 := GetCache[string](differentCacheName)
+	cache3 := GetCache[string](manager, differentCacheName)
 	assert.NotNil(t, cache3, "Cache should not be nil")
 	assert.NotSame(t, cache1, cache3, "Different cache names should create different caches")
 }
@@ -169,51 +151,41 @@ func (suite *CacheManagerTestSuite) TestGetCache() {
 func (suite *CacheManagerTestSuite) TestGetCacheMultipleTypes() {
 	t := suite.T()
 
+	manager := Initialize()
 	cacheName := "testMultiTypeCache"
 
-	// Get caches for different types
-	cacheString := GetCache[string](cacheName)
-	cacheInt := GetCache[int](cacheName)
-	cacheTestString := GetCache[TestString](cacheName)
-	cacheTestInt := GetCache[TestInt](cacheName)
+	cacheString := GetCache[string](manager, cacheName)
+	cacheInt := GetCache[int](manager, cacheName)
+	cacheTestString := GetCache[TestString](manager, cacheName)
+	cacheTestInt := GetCache[TestInt](manager, cacheName)
 
-	// Verify all caches are not nil
 	assert.NotNil(t, cacheString, "String cache should not be nil")
 	assert.NotNil(t, cacheInt, "Int cache should not be nil")
 	assert.NotNil(t, cacheTestString, "TestString cache should not be nil")
 	assert.NotNil(t, cacheTestInt, "TestInt cache should not be nil")
 
-	// Verify different types create different instances even with the same cache name
 	assert.NotSame(t, cacheString, cacheInt, "Different types should create different caches")
 	assert.NotSame(t, cacheString, cacheTestString, "Different types should create different caches")
 	assert.NotSame(t, cacheInt, cacheTestInt, "Different types should create different caches")
 	assert.NotSame(t, cacheTestString, cacheTestInt, "Different types should create different caches")
 
-	// Verify same type returns same instance
-	cacheStringSame := GetCache[string](cacheName)
+	cacheStringSame := GetCache[string](manager, cacheName)
 	assert.Same(t, cacheString, cacheStringSame, "Same type and name should return the same cache")
 }
 
 func (suite *CacheManagerTestSuite) TestResetCacheManager() {
 	t := suite.T()
 
-	// Create a cache
+	manager := Initialize().(*CacheManager)
 	cacheName := "testResetCache"
-	cm := GetCache[string](cacheName)
+	cm := GetCache[string](manager, cacheName)
 	assert.NotNil(t, cm, "Cache should not be nil")
-
-	// Verify cache manager has an entry
-	manager := GetCacheManager().(*CacheManager)
 	assert.NotEmpty(t, manager.caches, "Cache map should not be empty after creating a cache")
 
-	// Reset the cache manager
 	manager.reset()
-
-	// Verify cache manager is now empty
 	assert.Empty(t, manager.caches, "Cache map should be empty after reset")
 
-	// Create a new cache and verify it's different
-	cmNew := GetCache[string](cacheName)
+	cmNew := GetCache[string](manager, cacheName)
 	assert.NotNil(t, cmNew, "New cache should not be nil")
 	assert.NotSame(t, cm, cmNew, "After reset, should get a new cache instance")
 }
@@ -261,9 +233,7 @@ func (suite *CacheManagerTestSuite) TestConcurrentAccess() {
 	err := config.InitializeServerRuntime("/test/thunderid/home", enabledConfig)
 	assert.NoError(t, err)
 
-	// Reset cache manager
-	instance = nil
-	once = sync.Once{}
+	cm := Initialize()
 
 	// Number of goroutines to use
 	numGoroutines := 10
@@ -277,7 +247,7 @@ func (suite *CacheManagerTestSuite) TestConcurrentAccess() {
 			defer wg.Done()
 			// Use different cache names to avoid collisions
 			cacheName := "concurrentCache" + string(rune('A'+index))
-			cache := GetCache[string](cacheName)
+			cache := GetCache[string](cm, cacheName)
 			assert.NotNil(t, cache, "Cache should not be nil even with concurrent access")
 			done <- true
 		}(i)
@@ -297,29 +267,24 @@ func (suite *CacheManagerTestSuite) TestConcurrentAccess() {
 	assert.Equal(t, numGoroutines, completedCount, "All goroutines should complete successfully")
 
 	// Verify manager has the expected number of entries
-	manager := GetCacheManager().(*CacheManager)
-	assert.Equal(t, numGoroutines, len(manager.caches), "Cache map should have an entry for each goroutine")
+	assert.Equal(t, numGoroutines, len(cm.(*CacheManager).caches), "Cache map should have an entry for each goroutine")
 }
 
 func (suite *CacheManagerTestSuite) TestTypeMismatch() {
 	t := suite.T()
 
 	cacheName := "typeMismatchCache"
-
-	// Create a cache manager and manually inject a cache with mismatched type
-	manager := GetCacheManager().(*CacheManager)
+	manager := Initialize().(*CacheManager)
 
 	var mockCache interface{} = &Cache[int]{} // Int type
 	typeName := "string"
 	cacheKey := cacheName + ":" + typeName
 
-	// Directly inject the mismatched type
 	manager.mu.Lock()
 	manager.caches[cacheKey] = mockCache
 	manager.mu.Unlock()
 
-	// Try to get a string cache
-	cache := GetCache[string](cacheName)
+	cache := GetCache[string](manager, cacheName)
 	assert.Nil(t, cache, "Should return nil when there's a type mismatch")
 }
 
@@ -345,7 +310,7 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err := config.InitializeServerRuntime("/test/thunderid/home", &disabledConfig)
 	assert.NoError(t, err)
 
-	cache1 := newCache[string]("testDisabledCache")
+	cache1 := newCache[string](Initialize(), "testDisabledCache")
 	assert.NotNil(t, cache1)
 	assert.False(t, cache1.IsEnabled())
 
@@ -365,7 +330,7 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &enabledConfig)
 	assert.NoError(t, err)
 
-	cache2 := newCache[string]("testSpecificDisabledCache")
+	cache2 := newCache[string](Initialize(), "testSpecificDisabledCache")
 	assert.NotNil(t, cache2)
 	assert.False(t, cache2.IsEnabled())
 
@@ -387,7 +352,7 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &inMemConfig)
 	assert.NoError(t, err)
 
-	cache3 := newCache[string]("testInMemCache")
+	cache3 := newCache[string](Initialize(), "testInMemCache")
 	assert.NotNil(t, cache3)
 	assert.True(t, cache3.IsEnabled())
 
@@ -402,7 +367,7 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &unknownTypeConfig)
 	assert.NoError(t, err)
 
-	cache4 := newCache[string]("testUnknownTypeCache")
+	cache4 := newCache[string](Initialize(), "testUnknownTypeCache")
 	assert.NotNil(t, cache4)
 	assert.True(t, cache4.IsEnabled())
 }

--- a/backend/tests/mocks/cachemock/CacheManagerInterface_mock.go
+++ b/backend/tests/mocks/cachemock/CacheManagerInterface_mock.go
@@ -71,39 +71,6 @@ func (_c *CacheManagerInterfaceMock_Close_Call) RunAndReturn(run func()) *CacheM
 	return _c
 }
 
-// Init provides a mock function for the type CacheManagerInterfaceMock
-func (_mock *CacheManagerInterfaceMock) Init() {
-	_mock.Called()
-	return
-}
-
-// CacheManagerInterfaceMock_Init_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Init'
-type CacheManagerInterfaceMock_Init_Call struct {
-	*mock.Call
-}
-
-// Init is a helper method to define mock.On call
-func (_e *CacheManagerInterfaceMock_Expecter) Init() *CacheManagerInterfaceMock_Init_Call {
-	return &CacheManagerInterfaceMock_Init_Call{Call: _e.mock.On("Init")}
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) Run(run func()) *CacheManagerInterfaceMock_Init_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) Return() *CacheManagerInterfaceMock_Init_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *CacheManagerInterfaceMock_Init_Call) RunAndReturn(run func()) *CacheManagerInterfaceMock_Init_Call {
-	_c.Run(run)
-	return _c
-}
-
 // IsEnabled provides a mock function for the type CacheManagerInterfaceMock
 func (_mock *CacheManagerInterfaceMock) IsEnabled() bool {
 	ret := _mock.Called()

--- a/backend/tests/mocks/flow/flowexecmock/flowStoreInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/flowStoreInterface_mock.go
@@ -164,16 +164,16 @@ func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx 
 }
 
 // StoreFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) StoreFlowContext(ctx context.Context, engineCtx flowexec.EngineContext, expirySeconds int64) error {
-	ret := _mock.Called(ctx, engineCtx, expirySeconds)
+func (_mock *flowStoreInterfaceMock) StoreFlowContext(ctx context.Context, dbModel flowexec.FlowContextDB, expirySeconds int64) error {
+	ret := _mock.Called(ctx, dbModel, expirySeconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StoreFlowContext")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, flowexec.EngineContext, int64) error); ok {
-		r0 = returnFunc(ctx, engineCtx, expirySeconds)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, flowexec.FlowContextDB, int64) error); ok {
+		r0 = returnFunc(ctx, dbModel, expirySeconds)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -187,21 +187,21 @@ type flowStoreInterfaceMock_StoreFlowContext_Call struct {
 
 // StoreFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - engineCtx flowexec.EngineContext
+//   - dbModel flowexec.FlowContextDB
 //   - expirySeconds int64
-func (_e *flowStoreInterfaceMock_Expecter) StoreFlowContext(ctx interface{}, engineCtx interface{}, expirySeconds interface{}) *flowStoreInterfaceMock_StoreFlowContext_Call {
-	return &flowStoreInterfaceMock_StoreFlowContext_Call{Call: _e.mock.On("StoreFlowContext", ctx, engineCtx, expirySeconds)}
+func (_e *flowStoreInterfaceMock_Expecter) StoreFlowContext(ctx interface{}, dbModel interface{}, expirySeconds interface{}) *flowStoreInterfaceMock_StoreFlowContext_Call {
+	return &flowStoreInterfaceMock_StoreFlowContext_Call{Call: _e.mock.On("StoreFlowContext", ctx, dbModel, expirySeconds)}
 }
 
-func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Run(run func(ctx context.Context, engineCtx flowexec.EngineContext, expirySeconds int64)) *flowStoreInterfaceMock_StoreFlowContext_Call {
+func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Run(run func(ctx context.Context, dbModel flowexec.FlowContextDB, expirySeconds int64)) *flowStoreInterfaceMock_StoreFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 flowexec.EngineContext
+		var arg1 flowexec.FlowContextDB
 		if args[1] != nil {
-			arg1 = args[1].(flowexec.EngineContext)
+			arg1 = args[1].(flowexec.FlowContextDB)
 		}
 		var arg2 int64
 		if args[2] != nil {
@@ -221,22 +221,22 @@ func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) Return(err error) *flowS
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) RunAndReturn(run func(ctx context.Context, engineCtx flowexec.EngineContext, expirySeconds int64) error) *flowStoreInterfaceMock_StoreFlowContext_Call {
+func (_c *flowStoreInterfaceMock_StoreFlowContext_Call) RunAndReturn(run func(ctx context.Context, dbModel flowexec.FlowContextDB, expirySeconds int64) error) *flowStoreInterfaceMock_StoreFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) UpdateFlowContext(ctx context.Context, engineCtx flowexec.EngineContext) error {
-	ret := _mock.Called(ctx, engineCtx)
+func (_mock *flowStoreInterfaceMock) UpdateFlowContext(ctx context.Context, dbModel flowexec.FlowContextDB) error {
+	ret := _mock.Called(ctx, dbModel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateFlowContext")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, flowexec.EngineContext) error); ok {
-		r0 = returnFunc(ctx, engineCtx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, flowexec.FlowContextDB) error); ok {
+		r0 = returnFunc(ctx, dbModel)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -250,20 +250,20 @@ type flowStoreInterfaceMock_UpdateFlowContext_Call struct {
 
 // UpdateFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - engineCtx flowexec.EngineContext
-func (_e *flowStoreInterfaceMock_Expecter) UpdateFlowContext(ctx interface{}, engineCtx interface{}) *flowStoreInterfaceMock_UpdateFlowContext_Call {
-	return &flowStoreInterfaceMock_UpdateFlowContext_Call{Call: _e.mock.On("UpdateFlowContext", ctx, engineCtx)}
+//   - dbModel flowexec.FlowContextDB
+func (_e *flowStoreInterfaceMock_Expecter) UpdateFlowContext(ctx interface{}, dbModel interface{}) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+	return &flowStoreInterfaceMock_UpdateFlowContext_Call{Call: _e.mock.On("UpdateFlowContext", ctx, dbModel)}
 }
 
-func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Run(run func(ctx context.Context, engineCtx flowexec.EngineContext)) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Run(run func(ctx context.Context, dbModel flowexec.FlowContextDB)) *flowStoreInterfaceMock_UpdateFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 flowexec.EngineContext
+		var arg1 flowexec.FlowContextDB
 		if args[1] != nil {
-			arg1 = args[1].(flowexec.EngineContext)
+			arg1 = args[1].(flowexec.FlowContextDB)
 		}
 		run(
 			arg0,
@@ -278,7 +278,7 @@ func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) Return(err error) *flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) RunAndReturn(run func(ctx context.Context, engineCtx flowexec.EngineContext) error) *flowStoreInterfaceMock_UpdateFlowContext_Call {
+func (_c *flowStoreInterfaceMock_UpdateFlowContext_Call) RunAndReturn(run func(ctx context.Context, dbModel flowexec.FlowContextDB) error) *flowStoreInterfaceMock_UpdateFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request introduces a consistent and centralized use of the `cacheManager` throughout the backend service initialization and internal modules. The main goal is to ensure that all cache-backed services receive their cache dependencies explicitly, improving testability, configurability, and maintainability. Additionally, there are some minor test and interface cleanups to align with these changes.

The most important changes are:

**Cache Management Refactoring:**

* Updated the `servicemanager.go` service registration to initialize a single `cacheManager` and pass it explicitly to all services that require caching, such as user schema, entity, flow, certificate, and inbound client services. This replaces ad-hoc or internal cache initialization with a consistent dependency injection approach. [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R59-R62) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R88-R97) [[3]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L137-R149) [[4]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L239-R244) [[5]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L252-R263) [[6]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L276-R282)
* Refactored the certificate and entity store initializers (`cert/init.go`, `entity/init.go`) to accept and use the provided `cacheManager` for cache creation, instead of creating caches internally. This change propagates down to their respective cache-backed store constructors. [[1]](diffhunk://#diff-09ae55dc692ef14b12321359cf9279720ebf902cc635b1bc67cdf45bd00a9512R22-R35) [[2]](diffhunk://#diff-1f1f9d70fda8bd68aa13ef4c5879430f6dff8bbc48e27b4d2b5aedd29925c56cL39-R44) [[3]](diffhunk://#diff-9f93cb6d42e04595c038e3a99970d6175a84515312a4664f637b626e8e2badb3R23) [[4]](diffhunk://#diff-9f93cb6d42e04595c038e3a99970d6175a84515312a4664f637b626e8e2badb3R34-R39) [[5]](diffhunk://#diff-9f93cb6d42e04595c038e3a99970d6175a84515312a4664f637b626e8e2badb3L47-R57) [[6]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277L38-R41)

**Flow Core and Execution Improvements:**

* Modified the flow core initialization (`flow/core/init.go`, `flow/core/graph_cache.go`) to use the shared `cacheManager` for graph caching, ensuring all flow-related caches are centrally managed. [[1]](diffhunk://#diff-1520be05a4f49d02e89396fbebeb18ff1e084cfc407c53d399b6f5699e6d0596R22-R28) [[2]](diffhunk://#diff-20b3a291127a566d1a4e3ed28647425f2da7993e9508ea806a20c5ee10285a4eL41-R43)
* Updated flow management and execution service initialization to accept and use the `cacheManager` and the runtime crypto service, ensuring all dependencies are explicitly provided. [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L252-R263) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L316-R322) [[3]](diffhunk://#diff-69d945087cae2a5b005a96256dad5c476c96106008d579db94a6ed0182b58935R28) [[4]](diffhunk://#diff-69d945087cae2a5b005a96256dad5c476c96106008d579db94a6ed0182b58935R43) [[5]](diffhunk://#diff-69d945087cae2a5b005a96256dad5c476c96106008d579db94a6ed0182b58935L60-R62)

**Test and Interface Consistency:**

* Updated mocks and test helpers in `flowexec/flowStoreInterface_mock_test.go` to reflect changes in method signatures (using `FlowContextDB` instead of `EngineContext`), maintaining test correctness after interface changes. [[1]](diffhunk://#diff-d521489613fc6e63ac091c3d52c58ee44d43ed5b8e9af8b2ae65d9eb7b41b50aL166-R175) [[2]](diffhunk://#diff-d521489613fc6e63ac091c3d52c58ee44d43ed5b8e9af8b2ae65d9eb7b41b50aL189-R203) [[3]](diffhunk://#diff-d521489613fc6e63ac091c3d52c58ee44d43ed5b8e9af8b2ae65d9eb7b41b50aL223-R238) [[4]](diffhunk://#diff-d521489613fc6e63ac091c3d52c58ee44d43ed5b8e9af8b2ae65d9eb7b41b50aL252-R265) [[5]](diffhunk://#diff-d521489613fc6e63ac091c3d52c58ee44d43ed5b8e9af8b2ae65d9eb7b41b50aL280-R280)

These changes collectively improve the clarity and reliability of cache usage across the backend, making the codebase more modular and easier to maintain.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2048
- https://github.com/asgardeo/thunder/issues/1631

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache manager wiring standardized across backend services so caches are provided centrally for consistent, configurable caching.
* **New Feature / Security**
  * Flow execution now uses an injected runtime crypto provider; flow contexts are encrypted when stored and decrypted when read.
* **Tests**
  * Test suites updated to reflect new cache-manager and runtime-crypto wiring and the switch to storing decrypted/encrypted flow context models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->