### PR TITLE
Implement and migrate runtime signing flows to RuntimeCryptoProvider.Sign

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -133,7 +133,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 
 	// Generate a signed session token capturing the prompted purposes and their elements.
 	// This token should be verified in RecordConsent to ensure the user's decisions match what was prompted
-	sessionToken, err := s.createConsentSessionToken(promptData)
+	sessionToken, err := s.createConsentSessionToken(ctx, promptData)
 	if err != nil {
 		logger.Error("Failed to create consent session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -294,7 +294,9 @@ func (s *consentEnforcerService) createNewConsent(ctx context.Context, ouID, app
 // createConsentSessionToken creates a signed JWT containing the consent session data.
 // The session captures the purposes and their essential/optional elements from the resolve step,
 // so that the record step can verify completeness and enforce essential attribute rules.
-func (s *consentEnforcerService) createConsentSessionToken(promptData *ConsentPromptData) (string, error) {
+func (s *consentEnforcerService) createConsentSessionToken(
+	ctx context.Context, promptData *ConsentPromptData,
+) (string, error) {
 	sessionData := consentSessionData{
 		Purposes: make([]consentSessionPurpose, 0, len(promptData.Purposes)),
 	}
@@ -318,7 +320,7 @@ func (s *consentEnforcerService) createConsentSessionToken(promptData *ConsentPr
 
 	claims["aud"] = consentSessionTokenAudience
 	token, _, svcErr := s.jwtService.GenerateJWT(
-		"", issuer,
+		ctx, "", issuer,
 		consentSessionTokenValidityPeriod, claims, "", "")
 	if svcErr != nil {
 		return "", errors.New("failed to generate consent session token: " + svcErr.Error.DefaultValue)

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -248,7 +248,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PromptNeeded() {
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -281,7 +281,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_RequiredAttributesF
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	// Only request "email" — "phone" and "address" should be filtered out
@@ -317,7 +317,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_UserProfileFilter()
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -360,7 +360,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PartialConsentsExis
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(existingConsents, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "user1",
@@ -418,7 +418,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_CreateConsentSessio
 		Return(purposes, nil)
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},
@@ -437,13 +437,13 @@ func (s *ConsentEnforcerServiceTestSuite) TestCreateConsentSessionToken_Generate
 		Purposes: []ConsentPurposePrompt{{PurposeName: "purpose-1", Essential: []string{"email"}}},
 	}
 
-	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything,
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Error: core.I18nMessage{Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed"},
 		})
 
-	token, err := s.service.createConsentSessionToken(promptData)
+	token, err := s.service.createConsentSessionToken(context.Background(), promptData)
 
 	s.Empty(token)
 	s.Error(err)

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -176,8 +176,8 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 			OUID:       basicResult.OUID,
 			Attributes: authUserAttributesJSON,
 		}
-		svcErr = as.validateAndAppendAuthAssertion(authResponse, authenticatedUser, common.AuthenticatorCredentials,
-			existingAssertion, logger)
+		svcErr = as.validateAndAppendAuthAssertion(
+			ctx, authResponse, authenticatedUser, common.AuthenticatorCredentials, existingAssertion, logger)
 		if svcErr != nil {
 			return nil, svcErr
 		}
@@ -230,7 +230,7 @@ func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken str
 			OUID:       basicResult.OUID,
 			Attributes: nil, // Attributes not needed for assertion generation in OTP flow
 		}
-		svcErr = as.validateAndAppendAuthAssertion(authResponse, userForAssertion, common.AuthenticatorSMSOTP,
+		svcErr = as.validateAndAppendAuthAssertion(ctx, authResponse, userForAssertion, common.AuthenticatorSMSOTP,
 			existingAssertion, logger)
 		if svcErr != nil {
 			return nil, svcErr
@@ -282,7 +282,7 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 	}
 
 	// Generate session token
-	sessionToken, err := as.createSessionToken(idpID, identityProvider.Type)
+	sessionToken, err := as.createSessionToken(ctx, idpID, identityProvider.Type)
 	if err != nil {
 		logger.Error("Failed to create session token", log.String("idpId", idpID),
 			log.String("error", err.Error.DefaultValue))
@@ -363,7 +363,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 			return nil, &serviceerror.InternalServerError
 		}
 
-		svcErr = as.validateAndAppendAuthAssertion(authResponse, user, authenticatorName,
+		svcErr = as.validateAndAppendAuthAssertion(ctx, authResponse, user, authenticatorName,
 			existingAssertion, logger)
 		if svcErr != nil {
 			return nil, svcErr
@@ -374,9 +374,10 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 }
 
 // validateAndAppendAuthAssertion validates and appends a generated auth assertion to the authentication response.
-func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *common.AuthenticationResponse,
-	user *entityprovider.Entity, authenticator string, existingAssertion string,
-	logger *log.Logger) *serviceerror.ServiceError {
+func (as *authenticationService) validateAndAppendAuthAssertion(
+	ctx context.Context, authResponse *common.AuthenticationResponse, user *entityprovider.Entity, authenticator string,
+	existingAssertion string, logger *log.Logger,
+) *serviceerror.ServiceError {
 	logger.Debug("Generating auth assertion", log.MaskedString(log.LoggerKeyUserID, user.ID))
 
 	authenticatorRef := &common.AuthenticatorReference{
@@ -432,7 +433,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *co
 	// Generate auth assertion JWT
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	jwtClaims["aud"] = jwtConfig.Audience
-	token, _, err := as.jwtService.GenerateJWT(user.ID, jwtConfig.Issuer,
+	token, _, err := as.jwtService.GenerateJWT(ctx, user.ID, jwtConfig.Issuer,
 		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		logger.Error("Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
@@ -598,7 +599,7 @@ func (as *authenticationService) validateIDPType(requestedType, actualType idp.I
 }
 
 // createSessionToken creates a JWT session token with authentication session data.
-func (as *authenticationService) createSessionToken(idpID string, idpType idp.IDPType) (
+func (as *authenticationService) createSessionToken(ctx context.Context, idpID string, idpType idp.IDPType) (
 	string, *serviceerror.ServiceError) {
 	sessionData := AuthSessionData{
 		IDPID:   idpID,
@@ -610,7 +611,7 @@ func (as *authenticationService) createSessionToken(idpID string, idpType idp.ID
 
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	claims["aud"] = "auth-svc"
-	token, _, err := as.jwtService.GenerateJWT("auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT, "")
+	token, _, err := as.jwtService.GenerateJWT(ctx, "auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		return "", err
 	}
@@ -764,7 +765,7 @@ func (as *authenticationService) FinishPasskeyAuthentication(ctx context.Context
 			OUID: basicResult.OUID,
 		}
 
-		svcErr = as.validateAndAppendAuthAssertion(authResponse, userForAssertion, common.AuthenticatorPasskey,
+		svcErr = as.validateAndAppendAuthAssertion(ctx, authResponse, userForAssertion, common.AuthenticatorPasskey,
 			existingAssertion, logger)
 		if svcErr != nil {
 			return nil, svcErr

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -206,7 +206,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
@@ -242,7 +242,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
@@ -318,7 +318,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsJWTG
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -514,7 +514,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
@@ -543,7 +543,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
@@ -598,7 +598,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -620,7 +620,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSucce
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -641,7 +641,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -662,7 +662,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -727,7 +727,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
@@ -747,7 +747,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc",
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -854,7 +854,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT",
+				suite.mockJWTService.On("GenerateJWT", mock.Anything,
 					testUserID, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				).Return(testJWTToken, int64(3600), nil).Once()
 			},
@@ -889,7 +889,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+				suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(claims map[string]interface{}) bool {
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
@@ -1176,7 +1176,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionE
 
 	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).Return(nil).Once()
 
-	svcErr := suite.service.validateAndAppendAuthAssertion(
+	svcErr := suite.service.validateAndAppendAuthAssertion(context.Background(),
 		authResponse, testUser, common.AuthenticatorSMSOTP, invalidAssertion, logger)
 
 	suite.NotNil(svcErr)
@@ -1236,12 +1236,12 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testJWTToken, int64(3600), nil).Once()
 
 	// Test with empty existingAssertion
-	svcErr := suite.service.validateAndAppendAuthAssertion(
+	svcErr := suite.service.validateAndAppendAuthAssertion(context.Background(),
 		authResponse, testUser, common.AuthenticatorCredentials, "", logger)
 	suite.Nil(svcErr)
 	suite.Equal(testJWTToken, authResponse.Assertion)
@@ -1264,7 +1264,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 
 	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil)
 
-	svcErr := suite.service.validateAndAppendAuthAssertion(
+	svcErr := suite.service.validateAndAppendAuthAssertion(context.Background(),
 		authResponse, testUser, common.AuthenticatorSMSOTP, existingAssertion, log.GetLogger())
 
 	suite.NotNil(svcErr)
@@ -1433,7 +1433,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTPJWTGenerationError() {
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -1528,7 +1528,8 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionG
 		jwtService:             suite.mockJWTService,
 	}
 
-	err := service.validateAndAppendAuthAssertion(authResponse, testUser, common.AuthenticatorCredentials, "", logger)
+	err := service.validateAndAppendAuthAssertion(
+		context.Background(), authResponse, testUser, common.AuthenticatorCredentials, "", logger)
 
 	suite.NotNil(err)
 	suite.Equal("ASSERTION_ERROR", err.Code)
@@ -1569,8 +1570,8 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionU
 		jwtService:             suite.mockJWTService,
 	}
 
-	err := service.validateAndAppendAuthAssertion(authResponse, testUser, common.AuthenticatorSMSOTP,
-		existingAssertion, logger)
+	err := service.validateAndAppendAuthAssertion(
+		context.Background(), authResponse, testUser, common.AuthenticatorSMSOTP, existingAssertion, logger)
 
 	suite.NotNil(err)
 	suite.Equal("UPDATE_ERROR", err.Code)
@@ -1796,7 +1797,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Suc
 		return len(refs) == 1 && refs[0].Authenticator == common.AuthenticatorPasskey
 	})).Return(mockAssertionResult, nil).Once()
 
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["userType"] == "person" && claims["ouId"] == testOrgUnit
 		}), mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
@@ -1878,7 +1879,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Wit
 	suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).
 		Return(mockUpdatedResult, nil).Once()
 
-	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, testUserID, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -206,7 +206,8 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 	}
 
 	jwtClaims["aud"] = ctx.AppID
-	token, _, err := a.jwtService.GenerateJWT(tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
+	token, _, err := a.jwtService.GenerateJWT(
+		ctx.Context, tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		logger.Error("Failed to generate JWT token", log.String("error", err.Error.DefaultValue))
 		return "", errors.New("failed to generate JWT token: " + err.Error.DefaultValue)

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -160,7 +160,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 		Context: &authnassert.AssuranceContext{},
 	}, nil)
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
@@ -209,7 +209,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions(
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			perms, ok := claims["authorized_permissions"]
 			return ok && perms == "read:documents write:documents"
@@ -251,7 +251,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["email"] == testEmail && claims["phone"] == "1234567890"
 		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
@@ -278,7 +278,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
 		Type: serviceerror.ServerErrorType,
 		Code: "JWT_GENERATION_FAILED",
@@ -547,7 +547,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 		},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimUserType] == "EXTERNAL" && claims[oauth2const.ClaimOUID] == "ou-456"
 		}), mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
@@ -581,7 +581,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 		},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", "https://auth.example.com", int64(7200),
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", "https://auth.example.com", int64(7200),
 		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(7200), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -616,7 +616,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 		Handle: "eng",
 	}, nil)
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimOUID] == testAssertOUID &&
 				claims[oauth2const.ClaimOUName] == "Engineering" &&
@@ -690,7 +690,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 
 	existingUser.Attributes = attrsJSON
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -825,7 +825,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should contain the configured user attributes from the user store
 			hasEmail := claims["email"] == testEmail
@@ -868,7 +868,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 
 	suite.mockEntityProvider.On("GetTransitiveEntityGroups", "user-123").
 		Return(userGroups, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should contain groups claim
 			groups, ok := claims[oauth2const.UserAttributeGroups].([]string)
@@ -906,7 +906,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 
 	suite.mockEntityProvider.On("GetTransitiveEntityGroups", "user-123").
 		Return([]entityprovider.EntityGroup{}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should NOT contain groups claim when groups list is empty
 			_, ok := claims[oauth2const.UserAttributeGroups]
@@ -1077,7 +1077,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Should only have email and name (consented), NOT phone
 			_, hasPhone := claims["phone"]
@@ -1112,7 +1112,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithEmptyConsentedAttribut
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1136,7 +1136,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithoutConsentedAttributes
 		Application:      appmodel.Application{},
 	}
 
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1184,7 +1184,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_AttrsSt
 				cache.Attributes["phone"] == "1234567890"
 		})).Return(&attributecache.AttributeCache{ID: "cache-abc"}, nil)
 	// In the OAuth cache path, only aci goes into the JWT; individual attrs go to cache.
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
@@ -1235,7 +1235,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilUser
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
 	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
 		Return(&attributecache.AttributeCache{ID: "cache-xyz"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// aci present, but no individual attribute claims
 			_, hasEmail := claims["email"]
@@ -1288,7 +1288,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OnlyRes
 			return cache.Attributes["email"] == testEmail && !hasPhone
 		})).Return(&attributecache.AttributeCache{ID: "cache-def"}, nil)
 	// JWT should only contain aci, not individual attrs
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			_, hasPhone := claims["phone"]
@@ -1336,7 +1336,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAsse
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
 	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
 		Return(&attributecache.AttributeCache{ID: "cache-nil"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasEmail := claims["email"]
 			return claims["aci"] == "cache-nil" && !hasEmail
@@ -1562,7 +1562,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsI
 			groups, ok := cache.Attributes[oauth2const.UserAttributeGroups].([]string)
 			return ok && len(groups) == 2
 		})).Return(&attributecache.AttributeCache{ID: "cache-groups"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasGroups := claims[oauth2const.UserAttributeGroups]
 			return claims["aci"] == "cache-groups" && !hasGroups
@@ -1603,7 +1603,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTyp
 		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
 			return cache.Attributes[oauth2const.ClaimUserType] == "EXTERNAL"
 		})).Return(&attributecache.AttributeCache{ID: "cache-usertype"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserType := claims[oauth2const.ClaimUserType]
 			return claims["aci"] == "cache-usertype" && !hasUserType
@@ -1646,7 +1646,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OUDetai
 			return cache.Attributes[oauth2const.ClaimOUID] == testAuthOUID &&
 				cache.Attributes[oauth2const.ClaimOUName] == "Engineering"
 		})).Return(&attributecache.AttributeCache{ID: "cache-ou"}, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasOUID := claims[oauth2const.ClaimOUID]
 			return claims["aci"] == "cache-ou" && !hasOUID
@@ -1690,7 +1690,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithRuntimeRequiredEssenti
 	}
 
 	suite.mockEntityProvider.On("GetEntity", "user-123").Return(existingUser, nil)
-	suite.mockJWTService.On("GenerateJWT", "user-123", mock.Anything, mock.Anything,
+	suite.mockJWTService.On("GenerateJWT", mock.Anything, "user-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasPhone := claims["phone"]
 			return claims["email"] == testEmail && claims["name"] == testNameValue && !hasPhone

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -115,7 +115,7 @@ func (s *otpService) SendOTP(
 		ExpiryTime: otp.ExpiryTimeInMillis,
 	}
 
-	sessionToken, err := s.createSessionToken(sessionData)
+	sessionToken, err := s.createSessionToken(ctx, sessionData)
 	if err != nil {
 		logger.Error("Failed to create session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -282,7 +282,7 @@ func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
 }
 
 // createSessionToken creates a JWT session token with OTP session data.
-func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (string, error) {
+func (s *otpService) createSessionToken(ctx context.Context, sessionData common.OTPSessionData) (string, error) {
 	claims := map[string]interface{}{
 		"otp_data": sessionData,
 	}
@@ -293,7 +293,7 @@ func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (stri
 
 	claims["aud"] = "otp-svc"
 	token, _, err := s.jwtService.GenerateJWT(
-		"otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT, "")
+		ctx, "otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %v", err)
 	}

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -330,7 +330,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
@@ -386,7 +386,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	suite.service.clientProvider = cp
 
 	suite.mockJWTService.EXPECT().GenerateJWT(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.InternalServerError).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
@@ -643,7 +643,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_TemplateRenderSuccess_UsesRendered
 	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything,
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("token", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -185,6 +185,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 
 	// Generate access token using tokenBuilder (attributes will be filtered in BuildAccessToken)
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
+		Context:          ctx,
 		Subject:          authCode.AuthorizedUserID,
 		Audiences:        accessTokenAudiences,
 		ClientID:         tokenRequest.ClientID,
@@ -215,6 +216,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	// Generate ID token if 'openid' scope is present
 	if slices.Contains(accessTokenScopes, constants.ScopeOpenID) {
 		idToken, err := h.tokenBuilder.BuildIDToken(&tokenservice.IDTokenBuildContext{
+			Context:        ctx,
 			Subject:        authCode.AuthorizedUserID,
 			Audience:       tokenRequest.ClientID,
 			Scopes:         accessTokenScopes,

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -161,6 +161,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	}
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
+		Context:          ctx,
 		Subject:          tokenRequest.ClientID,
 		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -181,6 +181,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	}
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
+		Context:          ctx,
 		Subject:          refreshTokenClaims.Sub,
 		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,
@@ -208,6 +209,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	// Generate ID token if 'openid' scope is present
 	if slices.Contains(newTokenScopes, constants.ScopeOpenID) {
 		idToken, idErr := h.tokenBuilder.BuildIDToken(&tokenservice.IDTokenBuildContext{
+			Context:        ctx,
 			Subject:        refreshTokenClaims.Sub,
 			Audience:       tokenRequest.ClientID,
 			Scopes:         newTokenScopes,
@@ -271,6 +273,7 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	attributeCacheID string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
+		Context:              ctx,
 		ClientID:             oauthApp.ClientID,
 		Scopes:               scopes,
 		GrantType:            grantType,

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -190,6 +190,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 
 	// Build access token using token builder
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
+		Context:        ctx,
 		Subject:        subjectClaims.Sub,
 		Audiences:      finalAudiences,
 		ClientID:       tokenRequest.ClientID,

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -19,6 +19,7 @@
 package tokenservice
 
 import (
+	"context"
 	"fmt"
 
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
@@ -27,6 +28,13 @@ import (
 	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 )
+
+func resolveContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
 
 // TokenBuilderInterface defines the interface for building OAuth2 tokens.
 type TokenBuilderInterface interface {
@@ -75,6 +83,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
+		resolveContext(ctx.Context),
 		ctx.Subject,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
@@ -236,6 +245,7 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 	claims["aud"] = tokenConfig.Issuer
 
 	token, iat, err := tb.jwtService.GenerateJWT(
+		resolveContext(ctx.Context),
 		ctx.ClientID,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
@@ -310,6 +320,7 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 	jwtClaims["aud"] = ctx.Audience
 
 	token, iat, err := tb.jwtService.GenerateJWT(
+		resolveContext(ctx.Context),
 		ctx.Subject,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -105,6 +105,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -154,6 +155,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -196,6 +198,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -227,6 +230,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -258,6 +262,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -289,6 +294,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType(
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -329,6 +335,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io", // Server-level issuer always used
 		int64(7200),
@@ -363,6 +370,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 	}
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -402,6 +410,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocal
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -449,6 +458,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -489,6 +499,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -520,6 +531,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -550,6 +562,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -588,6 +601,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -624,6 +638,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -659,6 +674,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 	}
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -698,6 +714,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLoca
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"test-client",
 		"https://thunder.io",
 		int64(3600),
@@ -737,6 +754,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_Basic() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -774,6 +792,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithNonce() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -804,6 +823,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithoutNonce() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -834,6 +854,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoAuthTime() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -877,6 +898,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -916,6 +938,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithStandardOIDCSco
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -946,6 +969,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoUserAttributes() 
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -984,6 +1008,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_EmptyUserAttributes
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),
@@ -1024,6 +1049,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 	expectedIat := time.Now().Unix()
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(7200),
@@ -1057,6 +1083,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_JWTGenerationFailed()
 	}
 
 	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
 		"user123",
 		"https://thunder.io",
 		int64(3600),

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -20,6 +20,8 @@
 package tokenservice
 
 import (
+	"context"
+
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 )
@@ -46,6 +48,7 @@ type TokenConfig struct {
 // The aud claim is serialized as a JSON array when Audiences has 2+ entries, and as a string
 // when it has a single entry.
 type AccessTokenBuildContext struct {
+	Context          context.Context
 	Subject          string
 	Audiences        []string
 	ClientID         string
@@ -62,6 +65,7 @@ type AccessTokenBuildContext struct {
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
 type RefreshTokenBuildContext struct {
+	Context              context.Context
 	ClientID             string
 	Scopes               []string
 	GrantType            string
@@ -75,6 +79,7 @@ type RefreshTokenBuildContext struct {
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
 type IDTokenBuildContext struct {
+	Context        context.Context
 	Subject        string
 	Audience       string
 	Scopes         []string

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -160,7 +160,7 @@ func (s *userInfoService) GetUserInfo(
 	case inboundmodel.UserInfoResponseTypeJWE:
 		return s.generateJWEUserInfo(ctx, response, userInfoCfg, certificate)
 	case inboundmodel.UserInfoResponseTypeJWS:
-		return s.generateJWSUserInfo(sub, tokenClaims, response, userInfoCfg)
+		return s.generateJWSUserInfo(ctx, sub, tokenClaims, response, userInfoCfg)
 	default:
 		return &UserInfoResponse{Type: inboundmodel.UserInfoResponseTypeJSON, JSONBody: response}, nil
 	}
@@ -310,7 +310,7 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 	cfg *inboundmodel.UserInfoConfig,
 	certificate *inboundmodel.Certificate,
 ) (*UserInfoResponse, *serviceerror.ServiceError) {
-	jwsResp, svcErr := s.generateJWSUserInfo(sub, tokenClaims, response, cfg)
+	jwsResp, svcErr := s.generateJWSUserInfo(ctx, sub, tokenClaims, response, cfg)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -338,6 +338,7 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 // generateJWSUserInfo creates a signed JWT UserInfo response
 // based on the application configuration.
 func (s *userInfoService) generateJWSUserInfo(
+	ctx context.Context,
 	sub string,
 	tokenClaims map[string]interface{},
 	response map[string]interface{},
@@ -360,6 +361,7 @@ func (s *userInfoService) generateJWSUserInfo(
 	}
 
 	signedJWT, _, err := s.jwtService.GenerateJWT(
+		ctx,
 		sub,
 		issuer,
 		validity,

--- a/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
@@ -288,7 +288,7 @@ func (s *JWEUserInfoTestSuite) TestGenerateNestedJWTUserInfo_Success() {
 
 	mockJWT := jwtmock.NewJWTServiceInterfaceMock(s.T())
 	mockJWT.On("GenerateJWT",
-		"user1", "test-issuer", int64(600),
+		mock.Anything, "user1", "test-issuer", int64(600),
 		mock.Anything, mock.Anything, "RS256",
 	).Return("signed.jwt.token", int64(0), (*serviceerror.ServiceError)(nil))
 
@@ -355,7 +355,7 @@ func (s *JWEUserInfoTestSuite) TestGenerateJWEUserInfo_EncryptErrorPropagated() 
 func (s *JWEUserInfoTestSuite) TestGenerateJWSUserInfo_UnsupportedAlg() {
 	mockJWT := jwtmock.NewJWTServiceInterfaceMock(s.T())
 	mockJWT.On("GenerateJWT",
-		"user1", "test-issuer", int64(600),
+		mock.Anything, "user1", "test-issuer", int64(600),
 		mock.Anything, mock.Anything, "ES256",
 	).Return("", int64(0), &jwt.ErrorUnsupportedJWSAlgorithm)
 
@@ -363,6 +363,7 @@ func (s *JWEUserInfoTestSuite) TestGenerateJWSUserInfo_UnsupportedAlg() {
 	cfg := &inboundmodel.UserInfoConfig{SigningAlg: "ES256"}
 
 	result, svcErr := svc.generateJWSUserInfo(
+		context.Background(),
 		"user1",
 		map[string]interface{}{"client_id": "client1"},
 		map[string]interface{}{"sub": "user1"},

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -1096,6 +1096,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 	// JWT generation
 	s.mockJWTService.On(
 		"GenerateJWT",
+		mock.Anything,
 		"user123",
 		issuer,
 		config.GetServerRuntime().Config.JWT.ValidityPeriod,
@@ -1156,6 +1157,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 	// Simulate signing failure
 	s.mockJWTService.On(
 		"GenerateJWT",
+		mock.Anything,
 		"user123",
 		issuer,
 		config.GetServerRuntime().Config.JWT.ValidityPeriod,

--- a/backend/internal/system/crypto/runtime/service.go
+++ b/backend/internal/system/crypto/runtime/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/crypto"
 	"github.com/asgardeo/thunder/internal/system/crypto/config"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
+	"github.com/asgardeo/thunder/internal/system/crypto/sign"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
@@ -61,6 +62,16 @@ func GetRuntimeCryptoService() crypto.RuntimeCryptoProvider {
 		}
 	})
 	return runtimeInstance
+}
+
+// NewRuntimeCryptoService creates a new RuntimeCryptoProvider backed by the given PKI service.
+// Use this instead of GetRuntimeCryptoService when you already hold a PKIServiceInterface instance.
+func NewRuntimeCryptoService(pkiService pki.PKIServiceInterface) crypto.RuntimeCryptoProvider {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RuntimeCryptoService"))
+	return &runtimeCryptoService{
+		pkiService: pkiService,
+		logger:     logger,
+	}
 }
 
 // Encrypt performs key establishment for the algorithm in params. Per-algorithm behavior:
@@ -327,9 +338,45 @@ func (s *runtimeCryptoService) getECDHDecryptKeys(
 	return ecdsaPriv, epk, nil
 }
 
-// Sign is not yet implemented.
-func (s *runtimeCryptoService) Sign(_ context.Context, _ crypto.KeyRef, _ crypto.Algorithm, _ []byte) ([]byte, error) {
-	return nil, errors.New("not implemented")
+// algorithmToSignAlg maps a crypto.Algorithm (JWA names) to the internal sign.SignAlgorithm.
+func algorithmToSignAlg(alg crypto.Algorithm) (sign.SignAlgorithm, error) {
+	switch alg {
+	case crypto.AlgorithmRS256:
+		return sign.RSASHA256, nil
+	case crypto.AlgorithmRS512:
+		return sign.RSASHA512, nil
+	case crypto.AlgorithmPS256:
+		return sign.RSAPSSSHA256, nil
+	case crypto.AlgorithmES256:
+		return sign.ECDSASHA256, nil
+	case crypto.AlgorithmES384:
+		return sign.ECDSASHA384, nil
+	case crypto.AlgorithmES512:
+		return sign.ECDSASHA512, nil
+	case crypto.AlgorithmEdDSA:
+		return sign.ED25519, nil
+	default:
+		return "", fmt.Errorf("unsupported signing algorithm: %s", alg)
+	}
+}
+
+// Sign signs content using the private key identified by keyRef.
+func (s *runtimeCryptoService) Sign(
+	_ context.Context, keyRef crypto.KeyRef, algorithm crypto.Algorithm, content []byte,
+) ([]byte, error) {
+	signAlg, err := algorithmToSignAlg(algorithm)
+	if err != nil {
+		return nil, err
+	}
+	if s.pkiService == nil {
+		return nil, errors.New("PKI service not initialized")
+	}
+	privKey, svcErr := s.pkiService.GetPrivateKey(keyRef.KeyID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("key not found for id %s: [%s] %s",
+			keyRef.KeyID, svcErr.Code, svcErr.Error.DefaultValue)
+	}
+	return sign.Generate(content, signAlg, privKey)
 }
 
 // GetPublicKeys is not yet implemented.

--- a/backend/internal/system/crypto/runtime/service_test.go
+++ b/backend/internal/system/crypto/runtime/service_test.go
@@ -21,6 +21,7 @@ package runtime
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -35,6 +36,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/crypto"
+	"github.com/asgardeo/thunder/internal/system/crypto/sign"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	i18ncore "github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -49,9 +51,12 @@ func resetSingleton() {
 
 type RuntimeCryptoServiceTestSuite struct {
 	suite.Suite
-	rsaKey  *rsa.PrivateKey
-	ecKey   *ecdsa.PrivateKey
-	pkiMock *pkimock.PKIServiceInterfaceMock
+	rsaKey     *rsa.PrivateKey
+	ecKey      *ecdsa.PrivateKey
+	ecKey384   *ecdsa.PrivateKey
+	ecKey521   *ecdsa.PrivateKey
+	ed25519Key ed25519.PrivateKey
+	pkiMock    *pkimock.PKIServiceInterfaceMock
 }
 
 func TestRuntimeCryptoServiceSuite(t *testing.T) {
@@ -66,6 +71,18 @@ func (suite *RuntimeCryptoServiceTestSuite) SetupSuite() {
 	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	assert.NoError(suite.T(), err)
 	suite.ecKey = ecKey
+
+	ecKey384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	assert.NoError(suite.T(), err)
+	suite.ecKey384 = ecKey384
+
+	ecKey521, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	assert.NoError(suite.T(), err)
+	suite.ecKey521 = ecKey521
+
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(suite.T(), err)
+	suite.ed25519Key = edPriv
 }
 
 func (suite *RuntimeCryptoServiceTestSuite) SetupTest() {
@@ -381,4 +398,152 @@ func (suite *RuntimeCryptoServiceTestSuite) TestECDHES_Decrypt_MissingEPK() {
 		nil)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "EPK required")
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_RSA_RS256_Success() {
+	suite.pkiMock.On("GetPrivateKey", "rsa-key-1").Return(suite.rsaKey, nil).Once()
+
+	svc := &runtimeCryptoService{
+		pkiService: suite.pkiMock,
+		logger:     log.GetLogger(),
+	}
+
+	data := []byte("header.payload")
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "rsa-key-1"}, crypto.AlgorithmRS256, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+
+	verifyErr := sign.Verify(data, sig, sign.RSASHA256, &suite.rsaKey.PublicKey)
+	assert.NoError(suite.T(), verifyErr)
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_ECDSA_ES256_Success() {
+	suite.pkiMock.On("GetPrivateKey", "ec-key-1").Return(suite.ecKey, nil).Once()
+
+	svc := &runtimeCryptoService{
+		pkiService: suite.pkiMock,
+		logger:     log.GetLogger(),
+	}
+
+	data := []byte("header.payload")
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "ec-key-1"}, crypto.AlgorithmES256, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+
+	verifyErr := sign.Verify(data, sig, sign.ECDSASHA256, &suite.ecKey.PublicKey)
+	assert.NoError(suite.T(), verifyErr)
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_PKINotInitialized() {
+	svc := &runtimeCryptoService{
+		pkiService: nil,
+		logger:     log.GetLogger(),
+	}
+
+	_, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "rsa-key-1"}, crypto.AlgorithmRS256, []byte("data"))
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "PKI service not initialized")
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_KeyNotFound() {
+	suite.pkiMock.On("GetPrivateKey", "missing-key").Return(nil, suite.newKeyNotFoundErr()).Once()
+
+	svc := &runtimeCryptoService{
+		pkiService: suite.pkiMock,
+		logger:     log.GetLogger(),
+	}
+
+	_, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "missing-key"}, crypto.AlgorithmRS256, []byte("data"))
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "missing-key")
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_UnsupportedAlgorithm() {
+	svc := &runtimeCryptoService{
+		pkiService: suite.pkiMock,
+		logger:     log.GetLogger(),
+	}
+
+	_, err := svc.Sign(
+		context.Background(), crypto.KeyRef{KeyID: "rsa-key-1"}, crypto.Algorithm("UNKNOWN"), []byte("data"))
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "unsupported signing algorithm")
+
+	suite.pkiMock.AssertNotCalled(suite.T(), "GetPrivateKey", "rsa-key-1")
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_RSA_RS512_Success() {
+	suite.pkiMock.On("GetPrivateKey", "rsa-key-1").Return(suite.rsaKey, nil).Once()
+
+	svc := &runtimeCryptoService{pkiService: suite.pkiMock, logger: log.GetLogger()}
+	data := []byte("header.payload")
+
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "rsa-key-1"}, crypto.AlgorithmRS512, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+	assert.NoError(suite.T(), sign.Verify(data, sig, sign.RSASHA512, &suite.rsaKey.PublicKey))
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_RSA_PS256_Success() {
+	suite.pkiMock.On("GetPrivateKey", "rsa-key-1").Return(suite.rsaKey, nil).Once()
+
+	svc := &runtimeCryptoService{pkiService: suite.pkiMock, logger: log.GetLogger()}
+	data := []byte("header.payload")
+
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "rsa-key-1"}, crypto.AlgorithmPS256, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+	assert.NoError(suite.T(), sign.Verify(data, sig, sign.RSAPSSSHA256, &suite.rsaKey.PublicKey))
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_ECDSA_ES384_Success() {
+	suite.pkiMock.On("GetPrivateKey", "ec-key-384").Return(suite.ecKey384, nil).Once()
+
+	svc := &runtimeCryptoService{pkiService: suite.pkiMock, logger: log.GetLogger()}
+	data := []byte("header.payload")
+
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "ec-key-384"}, crypto.AlgorithmES384, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+	assert.NoError(suite.T(), sign.Verify(data, sig, sign.ECDSASHA384, &suite.ecKey384.PublicKey))
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_ECDSA_ES512_Success() {
+	suite.pkiMock.On("GetPrivateKey", "ec-key-521").Return(suite.ecKey521, nil).Once()
+
+	svc := &runtimeCryptoService{pkiService: suite.pkiMock, logger: log.GetLogger()}
+	data := []byte("header.payload")
+
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "ec-key-521"}, crypto.AlgorithmES512, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+	assert.NoError(suite.T(), sign.Verify(data, sig, sign.ECDSASHA512, &suite.ecKey521.PublicKey))
+
+	suite.pkiMock.AssertExpectations(suite.T())
+}
+
+func (suite *RuntimeCryptoServiceTestSuite) TestSign_EdDSA_Success() {
+	suite.pkiMock.On("GetPrivateKey", "ed-key-1").Return(suite.ed25519Key, nil).Once()
+
+	svc := &runtimeCryptoService{pkiService: suite.pkiMock, logger: log.GetLogger()}
+	data := []byte("header.payload")
+
+	sig, err := svc.Sign(context.Background(), crypto.KeyRef{KeyID: "ed-key-1"}, crypto.AlgorithmEdDSA, data)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), sig)
+	assert.NoError(suite.T(), sign.Verify(data, sig, sign.ED25519, suite.ed25519Key.Public()))
+
+	suite.pkiMock.AssertExpectations(suite.T())
 }

--- a/backend/internal/system/jose/jwt/init.go
+++ b/backend/internal/system/jose/jwt/init.go
@@ -23,11 +23,12 @@ import (
 	"time"
 
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
+	"github.com/asgardeo/thunder/internal/system/crypto/runtime"
 	httpservice "github.com/asgardeo/thunder/internal/system/http"
 )
 
 // Initialize initializes the JWT service.
 func Initialize(pkiService pki.PKIServiceInterface) (JWTServiceInterface, error) {
 	httpClient := httpservice.NewHTTPClientWithTimeout(10 * time.Second)
-	return newJWTService(pkiService, httpClient)
+	return newJWTService(pkiService, httpClient, runtime.NewRuntimeCryptoService(pkiService))
 }

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -20,6 +20,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -34,6 +35,7 @@ import (
 	"time"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	syscrypto "github.com/asgardeo/thunder/internal/system/crypto"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/crypto/sign"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -45,8 +47,8 @@ import (
 
 // JWTServiceInterface defines the interface for JWT operations.
 type JWTServiceInterface interface {
-	GenerateJWT(sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string) (
-		string, int64, *serviceerror.ServiceError)
+	GenerateJWT(ctx context.Context, sub, iss string, validityPeriod int64,
+		claims map[string]interface{}, typ, alg string) (string, int64, *serviceerror.ServiceError)
 	VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError
 	VerifyJWTWithPublicKey(jwtToken string, jwtPublicKey crypto.PublicKey, expectedAud,
 		expectedIss string) *serviceerror.ServiceError
@@ -64,18 +66,22 @@ type jwksCacheEntry struct {
 
 // jwtService implements the JWTServiceInterface for generating and managing JWT tokens.
 type jwtService struct {
-	privateKey crypto.PrivateKey
-	signAlg    sign.SignAlgorithm
-	jwsAlg     jws.Algorithm
-	kid        string
-	logger     *log.Logger
-	jwksCache  sync.Map
-	httpClient httpservice.HTTPClientInterface
+	cryptoProvider syscrypto.RuntimeCryptoProvider
+	keyRef         syscrypto.KeyRef
+	publicKey      crypto.PublicKey
+	signAlg        sign.SignAlgorithm
+	jwsAlg         jws.Algorithm
+	kid            string
+	logger         *log.Logger
+	jwksCache      sync.Map
+	httpClient     httpservice.HTTPClientInterface
 }
 
 // newJWTService creates a new JWT service instance.
-func newJWTService(pkiService pki.PKIServiceInterface,
-	httpClient httpservice.HTTPClientInterface) (JWTServiceInterface, error) {
+func newJWTService(
+	pkiService pki.PKIServiceInterface,
+	httpClient httpservice.HTTPClientInterface, cryptoProvider syscrypto.RuntimeCryptoProvider,
+) (JWTServiceInterface, error) {
 	preferredKid := config.GetServerRuntime().Config.JWT.PreferredKeyID
 
 	privateKey, err := pkiService.GetPrivateKey(preferredKid)
@@ -84,18 +90,21 @@ func newJWTService(pkiService pki.PKIServiceInterface,
 	}
 
 	kid := pkiService.GetCertThumbprint(preferredKid)
+	keyRef := syscrypto.KeyRef{KeyID: preferredKid}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService"))
 
 	// Get algorithm based on the type of private key
 	switch k := privateKey.(type) {
 	case *rsa.PrivateKey:
 		return &jwtService{
-			privateKey: k,
-			signAlg:    sign.RSASHA256,
-			jwsAlg:     jws.RS256,
-			kid:        kid,
-			logger:     logger,
-			httpClient: httpClient,
+			cryptoProvider: cryptoProvider,
+			keyRef:         keyRef,
+			publicKey:      &k.PublicKey,
+			signAlg:        sign.RSASHA256,
+			jwsAlg:         jws.RS256,
+			kid:            kid,
+			logger:         logger,
+			httpClient:     httpClient,
 		}, nil
 	case *ecdsa.PrivateKey:
 		// Determine ECDSA algorithm based on curve
@@ -103,42 +112,50 @@ func newJWTService(pkiService pki.PKIServiceInterface,
 		switch crvName {
 		case jws.P256:
 			return &jwtService{
-				privateKey: k,
-				signAlg:    sign.ECDSASHA256,
-				jwsAlg:     jws.ES256,
-				kid:        kid,
-				logger:     logger,
-				httpClient: httpClient,
+				cryptoProvider: cryptoProvider,
+				keyRef:         keyRef,
+				publicKey:      &k.PublicKey,
+				signAlg:        sign.ECDSASHA256,
+				jwsAlg:         jws.ES256,
+				kid:            kid,
+				logger:         logger,
+				httpClient:     httpClient,
 			}, nil
 		case jws.P384:
 			return &jwtService{
-				privateKey: k,
-				signAlg:    sign.ECDSASHA384,
-				jwsAlg:     jws.ES384,
-				kid:        kid,
-				logger:     logger,
-				httpClient: httpClient,
+				cryptoProvider: cryptoProvider,
+				keyRef:         keyRef,
+				publicKey:      &k.PublicKey,
+				signAlg:        sign.ECDSASHA384,
+				jwsAlg:         jws.ES384,
+				kid:            kid,
+				logger:         logger,
+				httpClient:     httpClient,
 			}, nil
 		case jws.P521:
 			return &jwtService{
-				privateKey: k,
-				signAlg:    sign.ECDSASHA512,
-				jwsAlg:     jws.ES512,
-				kid:        kid,
-				logger:     logger,
-				httpClient: httpClient,
+				cryptoProvider: cryptoProvider,
+				keyRef:         keyRef,
+				publicKey:      &k.PublicKey,
+				signAlg:        sign.ECDSASHA512,
+				jwsAlg:         jws.ES512,
+				kid:            kid,
+				logger:         logger,
+				httpClient:     httpClient,
 			}, nil
 		default:
 			return nil, errors.New("unsupported EC curve: " + crvName + " only P-256, P-384 and P-521 are supported")
 		}
 	case ed25519.PrivateKey:
 		return &jwtService{
-			privateKey: k,
-			signAlg:    sign.ED25519,
-			jwsAlg:     jws.EdDSA,
-			kid:        kid,
-			logger:     logger,
-			httpClient: httpClient,
+			cryptoProvider: cryptoProvider,
+			keyRef:         keyRef,
+			publicKey:      k.Public(),
+			signAlg:        sign.ED25519,
+			jwsAlg:         jws.EdDSA,
+			kid:            kid,
+			logger:         logger,
+			httpClient:     httpClient,
 		}, nil
 	default:
 		return nil, errors.New("unsupported private key type")
@@ -153,8 +170,12 @@ func newJWTService(pkiService pki.PKIServiceInterface,
 // claims["aud"] must be set by the caller as either a string or []string; omitting it
 // or providing another type is a programmer error and returns InternalServerError.
 func (js *jwtService) GenerateJWT(
-	sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string,
+	ctx context.Context, sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string,
 ) (string, int64, *serviceerror.ServiceError) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	jwsAlg := js.jwsAlg
 	if alg != "" {
 		mapped, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(alg))
@@ -163,8 +184,8 @@ func (js *jwtService) GenerateJWT(
 		}
 		jwsAlg = jws.Algorithm(alg)
 	}
-	if js.privateKey == nil {
-		js.logger.Error("Private key not found for JWT generation")
+	if js.cryptoProvider == nil {
+		js.logger.Error("Crypto provider not initialized for JWT generation")
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -245,9 +266,9 @@ func (js *jwtService) GenerateJWT(
 	headerBase64 := base64.RawURLEncoding.EncodeToString(headerJSON)
 	payloadBase64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
 
-	// Create the signing input and sign it with the private key.
+	// Create the signing input and sign it with the crypto provider.
 	signingInput := headerBase64 + "." + payloadBase64
-	signature, err := sign.Generate([]byte(signingInput), js.signAlg, js.privateKey)
+	signature, err := js.cryptoProvider.Sign(ctx, js.keyRef, syscrypto.Algorithm(jwsAlg), []byte(signingInput))
 	if err != nil {
 		js.logger.Error("Failed to sign JWT: " + err.Error())
 		return "", 0, &serviceerror.InternalServerError
@@ -261,8 +282,8 @@ func (js *jwtService) GenerateJWT(
 
 // VerifyJWT verifies the JWT token using the server's public key.
 func (js *jwtService) VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError {
-	if js.privateKey == nil {
-		js.logger.Error("Private key not found for JWT verification")
+	if js.publicKey == nil {
+		js.logger.Error("Public key not found for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 
@@ -321,21 +342,8 @@ func (js *jwtService) VerifyJWTSignature(jwtToken string) *serviceerror.ServiceE
 	// Create the signing input
 	signingInput := parts[0] + "." + parts[1]
 
-	// Derive public key from configured private key
-	var pubKey crypto.PublicKey
-	switch k := js.privateKey.(type) {
-	case *rsa.PrivateKey:
-		pubKey = &k.PublicKey
-	case *ecdsa.PrivateKey:
-		pubKey = &k.PublicKey
-	case ed25519.PrivateKey:
-		pubKey = k.Public()
-	default:
-		return &ErrorUnsupportedJWSAlgorithm
-	}
-
 	// Verify the signature using the configured algorithm
-	err = sign.Verify([]byte(signingInput), signature, js.signAlg, pubKey)
+	err = sign.Verify([]byte(signingInput), signature, js.signAlg, js.publicKey)
 	if err != nil {
 		return &ErrorInvalidTokenSignature
 	}

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -19,6 +19,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -29,6 +30,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -43,12 +45,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	syscrypto "github.com/asgardeo/thunder/internal/system/crypto"
 	"github.com/asgardeo/thunder/internal/system/crypto/sign"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	httpservice "github.com/asgardeo/thunder/internal/system/http"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/jose/jws"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/tests/mocks/crypto/cryptomock"
 	"github.com/asgardeo/thunder/tests/mocks/crypto/pki/pkimock"
 )
 
@@ -124,12 +128,23 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 	// Create PKI mock
 	suite.pkiMock = pkimock.NewPKIServiceInterfaceMock(suite.T())
 
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	cryptoMock.EXPECT().
+		Sign(mock.Anything, syscrypto.KeyRef{KeyID: "test-kid"}, syscrypto.Algorithm(jws.RS256), mock.Anything).
+		RunAndReturn(func(
+			_ context.Context, _ syscrypto.KeyRef, _ syscrypto.Algorithm, content []byte,
+		) ([]byte, error) {
+			return sign.Generate(content, sign.RSASHA256, suite.testPrivateKey)
+		}).Maybe()
+
 	suite.jwtService = &jwtService{
-		privateKey: suite.testPrivateKey,
-		signAlg:    sign.RSASHA256,
-		jwsAlg:     jws.RS256,
-		kid:        "test-kid",
-		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+		cryptoProvider: cryptoMock,
+		keyRef:         syscrypto.KeyRef{KeyID: "test-kid"},
+		publicKey:      &suite.testPrivateKey.PublicKey,
+		signAlg:        sign.RSASHA256,
+		jwsAlg:         jws.RS256,
+		kid:            "test-kid",
+		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
 	}
 
 	testConfig := &config.Config{
@@ -407,7 +422,7 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 			expectError: false,
 		},
 		{
-			name:      "NilPrivateKey",
+			name:      "NilCryptoProvider",
 			sub:       "sub",
 			iss:       "iss",
 			validity:  3600,
@@ -415,8 +430,8 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 			setupMock: func() func() { return func() {} },
 			setupService: func() *jwtService {
 				return &jwtService{
-					privateKey: nil,
-					logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+					cryptoProvider: nil,
+					logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
 				}
 			},
 			expectError: true,
@@ -432,9 +447,13 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 				return func() {}
 			},
 			setupService: func() *jwtService {
+				cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+				cryptoMock.EXPECT().Sign(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, errors.New("signing failed"))
 				return &jwtService{
-					privateKey: &rsa.PrivateKey{}, // Invalid private key
-					logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+					cryptoProvider: cryptoMock,
+					keyRef:         syscrypto.KeyRef{KeyID: "test-kid"},
+					logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
 				}
 			},
 			expectError: true,
@@ -569,7 +588,8 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 
 			jwtService := tc.setupService()
 
-			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.iss, tc.validity, tc.claims, TokenTypeJWT, "")
+			token, iat, err := jwtService.GenerateJWT(
+				context.Background(), tc.sub, tc.iss, tc.validity, tc.claims, TokenTypeJWT, "")
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -783,8 +803,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWT() {
 			jwtSvc := suite.jwtService
 			if tc.name == "PublicKeyNotAvailable" {
 				jwtSvc = &jwtService{
-					privateKey: nil,
-					logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+					publicKey: nil,
+					logger:    log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
 				}
 			}
 
@@ -1386,7 +1406,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 		{
 			name: "ValidToken",
 			setupFunc: func() string {
-				token, _, err := suite.jwtService.GenerateJWT(
+				token, _, err := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				assert.Nil(suite.T(), err)
 				return token
@@ -1415,7 +1435,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 		{
 			name: "PublicKeyNotAvailable",
 			setupFunc: func() string {
-				token, _, err := suite.jwtService.GenerateJWT(
+				token, _, err := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				assert.Nil(suite.T(), err)
 				return token
@@ -1431,7 +1451,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			jwtSvc := suite.jwtService
 			if tc.name == "PublicKeyNotAvailable" {
 				jwtSvc = &jwtService{
-					privateKey: nil,
+					publicKey: nil,
 				}
 			}
 
@@ -1446,7 +1466,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
-	validToken, _, err := suite.jwtService.GenerateJWT(
+	validToken, _, err := suite.jwtService.GenerateJWT(context.Background(),
 		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
@@ -1484,7 +1504,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKS() {
-	token, _, err := suite.jwtService.GenerateJWT(
+	token, _, err := suite.jwtService.GenerateJWT(context.Background(),
 		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
@@ -1544,7 +1564,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSUsesCache() {
 	serverB := makeServer(&fetchCountB)
 	defer serverB.Close()
 
-	token, _, genErr := suite.jwtService.GenerateJWT(
+	token, _, genErr := suite.jwtService.GenerateJWT(context.Background(),
 		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), genErr)
 
@@ -1643,7 +1663,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT(
+				token, _, _ := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
@@ -1661,7 +1681,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT(
+				token, _, _ := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
@@ -1691,7 +1711,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT(
+				token, _, _ := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
@@ -1720,7 +1740,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT(
+				token, _, _ := suite.jwtService.GenerateJWT(context.Background(),
 					"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 				return token
 			},
@@ -1763,7 +1783,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSNetworkError() {
 	// Test with invalid URL to trigger network error
-	token, _, err := suite.jwtService.GenerateJWT(
+	token, _, err := suite.jwtService.GenerateJWT(context.Background(),
 		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), err)
 
@@ -1994,12 +2014,12 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 			// Cast to access internal fields for testing
 			jwtSvc, ok := service.(*jwtService)
 			assert.True(t, ok)
-			assert.NotNil(t, jwtSvc.privateKey)
+			assert.NotNil(t, jwtSvc.publicKey)
 			assert.Equal(t, tc.expectedSignAlg, jwtSvc.signAlg)
 			assert.Equal(t, tc.expectedAlg, jwtSvc.jwsAlg)
 
 			// Test JWT generation with ECDSA key
-			token, _, svcErr := service.GenerateJWT(
+			token, _, svcErr := service.GenerateJWT(context.Background(),
 				"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 			assert.Nil(t, svcErr)
 			assert.NotEmpty(t, token)
@@ -2057,12 +2077,12 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 	// Cast to access internal fields for testing
 	jwtSvc, ok := service.(*jwtService)
 	assert.True(suite.T(), ok)
-	assert.NotNil(suite.T(), jwtSvc.privateKey)
+	assert.NotNil(suite.T(), jwtSvc.publicKey)
 	assert.Equal(suite.T(), sign.ED25519, jwtSvc.signAlg)
 	assert.Equal(suite.T(), jws.EdDSA, jwtSvc.jwsAlg)
 
 	// Test JWT generation with Ed25519 key
-	token, _, svcErr := service.GenerateJWT(
+	token, _, svcErr := service.GenerateJWT(context.Background(),
 		"test-subject", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 	assert.Nil(suite.T(), svcErr)
 	assert.NotEmpty(suite.T(), token)
@@ -2326,14 +2346,24 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyAlgorithmDe
 	for _, tc := range testCases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			priv, pub, signAlg, jwsAlg := tc.setupKey()
+			cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(t)
+			keyRef := syscrypto.KeyRef{KeyID: "test-sign-key"}
+			cryptoMock.EXPECT().Sign(mock.Anything, keyRef, syscrypto.Algorithm(jwsAlg), mock.Anything).
+				RunAndReturn(func(
+					_ context.Context, _ syscrypto.KeyRef, _ syscrypto.Algorithm, content []byte,
+				) ([]byte, error) {
+					return sign.Generate(content, signAlg, priv)
+				}).Maybe()
 			jwtService := &jwtService{
-				privateKey: priv,
-				signAlg:    signAlg,
-				jwsAlg:     jwsAlg,
+				cryptoProvider: cryptoMock,
+				keyRef:         keyRef,
+				publicKey:      pub,
+				signAlg:        signAlg,
+				jwsAlg:         jwsAlg,
 			}
 
 			// Generate token
-			token, _, err := jwtService.GenerateJWT(
+			token, _, err := jwtService.GenerateJWT(context.Background(),
 				"test-sub", "test-iss", 3600, map[string]interface{}{"aud": "test-aud"}, TokenTypeJWT, "")
 			assert.Nil(t, err)
 

--- a/backend/internal/system/mcp/auth/token_verifier_test.go
+++ b/backend/internal/system/mcp/auth/token_verifier_test.go
@@ -56,12 +56,13 @@ func (m *MockJWTService) GetPublicKey() crypto.PublicKey {
 }
 
 func (m *MockJWTService) GenerateJWT(
+	ctx context.Context,
 	sub, iss string,
 	validityPeriod int64,
 	claims map[string]interface{},
 	typ, alg string,
 ) (string, int64, *serviceerror.ServiceError) {
-	args := m.Called(sub, iss, validityPeriod, claims, typ, alg)
+	args := m.Called(ctx, sub, iss, validityPeriod, claims, typ, alg)
 	return args.String(0), args.Get(1).(int64), args.Get(2).(*serviceerror.ServiceError)
 }
 

--- a/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
@@ -5,6 +5,7 @@
 package jwtmock
 
 import (
+	"context"
 	"crypto"
 
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -39,8 +40,8 @@ func (_m *JWTServiceInterfaceMock) EXPECT() *JWTServiceInterfaceMock_Expecter {
 }
 
 // GenerateJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError) {
-	ret := _mock.Called(sub, iss, validityPeriod, claims, typ, alg)
+func (_mock *JWTServiceInterfaceMock) GenerateJWT(ctx context.Context, sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sub, iss, validityPeriod, claims, typ, alg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateJWT")
@@ -49,21 +50,21 @@ func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, iss string, validi
 	var r0 string
 	var r1 int64
 	var r2 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string, string) (string, int64, *serviceerror.ServiceError)); ok {
-		return returnFunc(sub, iss, validityPeriod, claims, typ, alg)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int64, map[string]interface{}, string, string) (string, int64, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sub, iss, validityPeriod, claims, typ, alg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, int64, map[string]interface{}, string, string) string); ok {
-		r0 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int64, map[string]interface{}, string, string) string); ok {
+		r0 = returnFunc(ctx, sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, int64, map[string]interface{}, string, string) int64); ok {
-		r1 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, int64, map[string]interface{}, string, string) int64); ok {
+		r1 = returnFunc(ctx, sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(string, string, int64, map[string]interface{}, string, string) *serviceerror.ServiceError); ok {
-		r2 = returnFunc(sub, iss, validityPeriod, claims, typ, alg)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, int64, map[string]interface{}, string, string) *serviceerror.ServiceError); ok {
+		r2 = returnFunc(ctx, sub, iss, validityPeriod, claims, typ, alg)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).(*serviceerror.ServiceError)
@@ -78,41 +79,46 @@ type JWTServiceInterfaceMock_GenerateJWT_Call struct {
 }
 
 // GenerateJWT is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sub string
 //   - iss string
 //   - validityPeriod int64
 //   - claims map[string]interface{}
 //   - typ string
 //   - alg string
-func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}, alg interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
-	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, iss, validityPeriod, claims, typ, alg)}
+func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(ctx interface{}, sub interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}, alg interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
+	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", ctx, sub, iss, validityPeriod, claims, typ, alg)}
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(ctx context.Context, sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 int64
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(int64)
+			arg2 = args[2].(string)
 		}
-		var arg3 map[string]interface{}
+		var arg3 int64
 		if args[3] != nil {
-			arg3 = args[3].(map[string]interface{})
+			arg3 = args[3].(int64)
 		}
-		var arg4 string
+		var arg4 map[string]interface{}
 		if args[4] != nil {
-			arg4 = args[4].(string)
+			arg4 = args[4].(map[string]interface{})
 		}
 		var arg5 string
 		if args[5] != nil {
 			arg5 = args[5].(string)
+		}
+		var arg6 string
+		if args[6] != nil {
+			arg6 = args[6].(string)
 		}
 		run(
 			arg0,
@@ -121,6 +127,7 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, iss
 			arg3,
 			arg4,
 			arg5,
+			arg6,
 		)
 	})
 	return _c
@@ -131,7 +138,7 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Return(s string, n int64, se
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(ctx context.Context, sub string, iss string, validityPeriod int64, claims map[string]interface{}, typ string, alg string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

Migrate JWT signing to use the runtime crypto provider instead of signing directly with private keys inside the JWT service.

This enables JWT generation to go through the common runtime crypto abstraction, aligning token signing with the newer crypto provider model.

### Approach

- Added signing support to `RuntimeCryptoProvider` using PKI-backed private keys.
- Added support for RSA, RSA-PSS, ECDSA, and EdDSA signing algorithms.
- Updated the JWT service to:
  - use `RuntimeCryptoProvider.Sign(...)` for JWT signing,
  - retain only the public key for verification,
  - accept `context.Context` during JWT generation.
- Added runtime crypto signing tests for supported algorithms and error cases.

### Related Issues

- https://github.com/asgardeo/thunder/issues/2348

### Related PRs

- https://github.com/asgardeo/thunder/pull/2403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request context is now propagated through token/JWT generation for better cancellation, timeouts, and request-scoped behavior.

* **Refactor**
  * JWT signing now uses a runtime crypto provider with broader algorithm support (RS, PS, ECDSA, EdDSA) and context-aware signing.
  * Token-building flows updated across OAuth2, authentication, OTP, and userinfo to carry request context.

* **Tests**
  * Unit tests and mocks updated to match context-aware JWT signing and new crypto provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->