### PR TITLE
Make system resource server handle and identifier configurable

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -52,6 +52,17 @@ $ErrorActionPreference = 'Stop'
 Log-Info "Creating default $PRODUCT_NAME resources..."
 Write-Host ""
 
+# System resource server configuration from environment variables.
+$SYSTEM_RS_HANDLE = if ($env:THUNDER_SYSTEM_RS_HANDLE) { $env:THUNDER_SYSTEM_RS_HANDLE } else { "" }
+$SYSTEM_RS_IDENTIFIER = if ($env:THUNDER_SYSTEM_RS_IDENTIFIER) { $env:THUNDER_SYSTEM_RS_IDENTIFIER } else { "system" }
+
+# Derive the system permission root based on the configured handle.
+if ($SYSTEM_RS_HANDLE) {
+    $SYSTEM_PERMISSION = "${SYSTEM_RS_HANDLE}:system"
+} else {
+    $SYSTEM_PERMISSION = "system"
+}
+
 # ============================================================================
 # Create Default Organization Unit
 # ============================================================================
@@ -277,7 +288,8 @@ if (-not $DEFAULT_OU_ID) {
 $resourceServerData = @{
     name = "System"
     description = "System resource server"
-    identifier = "system"
+    handle = $SYSTEM_RS_HANDLE
+    identifier = $SYSTEM_RS_IDENTIFIER
     ouId = $DEFAULT_OU_ID
 } | ConvertTo-Json -Depth 10
 
@@ -302,11 +314,17 @@ elseif ($response.StatusCode -eq 409) {
 
     if ($response.StatusCode -eq 200) {
         $body = $response.Body | ConvertFrom-Json
-        $systemRS = $body.resourceServers | Where-Object { $_.identifier -eq "system" } | Select-Object -First 1
+        $systemRS = $body.resourceServers | Where-Object { $_.name -eq "System" } | Select-Object -First 1
 
         if ($systemRS) {
             $SYSTEM_RS_ID = $systemRS.id
             Log-Success "Found resource server ID: $SYSTEM_RS_ID"
+            $existingHandle = if ($systemRS.handle) { $systemRS.handle } else { "" }
+            $existingIdentifier = if ($systemRS.identifier) { $systemRS.identifier } else { "" }
+            if ($existingHandle -ne $SYSTEM_RS_HANDLE -or $existingIdentifier -ne $SYSTEM_RS_IDENTIFIER) {
+                Log-Error "Existing system resource server has mismatched configuration. Expected handle='${SYSTEM_RS_HANDLE}', identifier='${SYSTEM_RS_IDENTIFIER}' but found handle='${existingHandle}', identifier='${existingIdentifier}'. Manual migration required."
+                exit 1
+            }
         }
         else {
             Log-Error "Could not find resource server ID in response"
@@ -790,7 +808,7 @@ Write-Host ""
 # Create Admin Role
 # ============================================================================
 
-Log-Info "Creating admin role with 'system' permission..."
+Log-Info "Creating admin role with '$SYSTEM_PERMISSION' permission..."
 
 if (-not $ADMIN_GROUP_ID) {
     Log-Error "Administrator group ID is not available. Cannot create role."
@@ -814,7 +832,7 @@ $roleData = @{
     permissions = @(
         @{
             resourceServerId = $SYSTEM_RS_ID
-            permissions = @("system")
+            permissions = @($SYSTEM_PERMISSION)
         }
     )
     assignments = @(
@@ -969,6 +987,18 @@ else {
         else {
             Log-Info "No registration flow files found"
         }
+    }
+
+    # Template user onboarding flow files with the dynamic system permission.
+    if ((Test-Path $USER_ONBOARDING_FLOWS_DIR) -and ($SYSTEM_PERMISSION -ne "system")) {
+        $TEMPLATED_ONBOARDING_DIR = Join-Path ([System.IO.Path]::GetTempPath()) "thunder-onboarding-flows-$([System.Guid]::NewGuid().ToString())"
+        New-Item -ItemType Directory -Path $TEMPLATED_ONBOARDING_DIR -Force | Out-Null
+        Get-ChildItem -Path $USER_ONBOARDING_FLOWS_DIR -Filter "*.json" -File | ForEach-Object {
+            $content = Get-Content -Path $_.FullName -Raw
+            $content = $content -replace '\["system"\]', "[`"$SYSTEM_PERMISSION`"]"
+            Set-Content -Path (Join-Path $TEMPLATED_ONBOARDING_DIR $_.Name) -Value $content
+        }
+        $USER_ONBOARDING_FLOWS_DIR = $TEMPLATED_ONBOARDING_DIR
     }
 
     # Process user onboarding flows
@@ -1400,5 +1430,5 @@ Write-Host ""
 Log-Info "👤 Admin credentials:"
 Log-Info "   Username: admin"
 Log-Info "   Password: admin"
-Log-Info "   Role: Administrator (system permission via Administrators group)"
+Log-Info "   Role: Administrator ($SYSTEM_PERMISSION permission via Administrators group)"
 Write-Host ""

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -43,6 +43,17 @@ source "${SCRIPT_DIR}/common.sh"
 log_info "Creating default ${PRODUCT_NAME} resources..."
 echo ""
 
+# System resource server configuration from environment variables.
+SYSTEM_RS_HANDLE="${THUNDER_SYSTEM_RS_HANDLE:-}"
+SYSTEM_RS_IDENTIFIER="${THUNDER_SYSTEM_RS_IDENTIFIER:-system}"
+
+# Derive the system permission root based on the configured handle.
+if [[ -n "$SYSTEM_RS_HANDLE" ]]; then
+    SYSTEM_PERMISSION="${SYSTEM_RS_HANDLE}:system"
+else
+    SYSTEM_PERMISSION="system"
+fi
+
 # ============================================================================
 # Create Default Organization Unit
 # ============================================================================
@@ -264,7 +275,8 @@ fi
 RESPONSE=$(api_call POST "/resource-servers" "{
   \"name\": \"System\",
   \"description\": \"System resource server\",
-  \"identifier\": \"system\",
+  \"handle\": \"${SYSTEM_RS_HANDLE}\",
+  \"identifier\": \"${SYSTEM_RS_IDENTIFIER}\",
   \"ouId\": \"${DEFAULT_OU_ID}\"
 }")
 
@@ -290,13 +302,20 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     if [[ "$HTTP_CODE" == "200" ]]; then
         SYSTEM_RS_ID=$(echo "$BODY" | grep -o '"id":"[^"]*","[^"]*":"System"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
-        # Fallback parsing
+        # Fallback parsing by name
         if [[ -z "$SYSTEM_RS_ID" ]]; then
-            SYSTEM_RS_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"identifier":"system"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+            SYSTEM_RS_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"name":"System"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
         fi
 
         if [[ -n "$SYSTEM_RS_ID" ]]; then
             log_success "Found resource server ID: $SYSTEM_RS_ID"
+            SYSTEM_LINE=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"name":"System"')
+            EXISTING_HANDLE=$(echo "$SYSTEM_LINE" | grep -o '"handle":"[^"]*"' | head -1 | cut -d'"' -f4)
+            EXISTING_IDENTIFIER=$(echo "$SYSTEM_LINE" | grep -o '"identifier":"[^"]*"' | head -1 | cut -d'"' -f4)
+            if [[ "$EXISTING_HANDLE" != "$SYSTEM_RS_HANDLE" ]] || [[ "$EXISTING_IDENTIFIER" != "$SYSTEM_RS_IDENTIFIER" ]]; then
+                log_error "Existing system resource server has mismatched configuration. Expected handle='${SYSTEM_RS_HANDLE}', identifier='${SYSTEM_RS_IDENTIFIER}' but found handle='${EXISTING_HANDLE}', identifier='${EXISTING_IDENTIFIER}'. Manual migration required."
+                exit 1
+            fi
         else
             log_error "Could not find resource server ID in response"
             exit 1
@@ -717,7 +736,7 @@ echo ""
 # Create Admin Role
 # ============================================================================
 
-log_info "Creating admin role with 'system' permission..."
+log_info "Creating admin role with '${SYSTEM_PERMISSION}' permission..."
 
 if [[ -z "$ADMIN_GROUP_ID" ]]; then
     log_error "Administrator group ID is not available. Cannot create role."
@@ -741,7 +760,7 @@ RESPONSE=$(api_call POST "/roles" "{
   \"permissions\": [
     {
       \"resourceServerId\": \"${SYSTEM_RS_ID}\",
-      \"permissions\": [\"system\"]
+      \"permissions\": [\"${SYSTEM_PERMISSION}\"]
     }
   ],
   \"assignments\": [
@@ -910,6 +929,16 @@ else
         else
             log_warning "No registration flow files found"
         fi
+    fi
+
+    # Template user onboarding flow files with the dynamic system permission.
+    if [[ -d "$USER_ONBOARDING_FLOWS_DIR" ]] && [[ "$SYSTEM_PERMISSION" != "system" ]]; then
+        TEMPLATED_ONBOARDING_DIR=$(mktemp -d)
+        for f in "$USER_ONBOARDING_FLOWS_DIR"/*.json; do
+            [[ ! -f "$f" ]] && continue
+            sed "s/\[\"system\"\]/[\"${SYSTEM_PERMISSION}\"]/g" "$f" > "$TEMPLATED_ONBOARDING_DIR/$(basename "$f")"
+        done
+        USER_ONBOARDING_FLOWS_DIR="$TEMPLATED_ONBOARDING_DIR"
     fi
 
     # Process user onboarding flows
@@ -1354,5 +1383,5 @@ echo ""
 log_info "👤 Admin credentials:"
 log_info "   Username: admin"
 log_info "   Password: admin"
-log_info "   Role: Administrator (system permission via Administrators group)"
+log_info "   Role: Administrator (${SYSTEM_PERMISSION} permission via Administrators group)"
 echo ""

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -74,6 +74,9 @@ func main() {
 	// Initialize the cache manager.
 	initCacheManager(logger)
 
+	// Initialize system permission strings before any service or middleware uses them.
+	security.InitSystemPermissions(cfg.Resource.SystemResourceServer.Handle)
+
 	// Create a new HTTP multiplexer.
 	mux := http.NewServeMux()
 	if mux == nil {

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -28,9 +28,12 @@ import (
 	"github.com/asgardeo/thunder/internal/system/security"
 )
 
-const (
-	defaultRequiredScope = "system"
-)
+func getDefaultRequiredScope() string {
+	if p := security.GetSystemPermissions(); p != nil {
+		return p.Root
+	}
+	return security.UninitializedPermissionSentinel
+}
 
 // permissionValidator validates that the request has the required permission/scope to access the next node.
 type permissionValidator struct {
@@ -99,7 +102,7 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 // getRequiredScopes retrieves the required scopes from the node context properties.
 func (e *permissionValidator) getRequiredScopes(ctx *core.NodeContext) []string {
-	requiredScopes := []string{defaultRequiredScope}
+	requiredScopes := []string{getDefaultRequiredScope()}
 
 	if ctx.NodeProperties != nil {
 		if val, exists := ctx.NodeProperties[propertyKeyRequiredScopes]; exists {

--- a/backend/internal/flow/executor/permission_validator_test.go
+++ b/backend/internal/flow/executor/permission_validator_test.go
@@ -38,6 +38,8 @@ type PermissionValidatorTestSuite struct {
 }
 
 func (suite *PermissionValidatorTestSuite) SetupTest() {
+	security.InitSystemPermissions("")
+
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	mockBaseExecutor := coremock.NewExecutorInterfaceMock(suite.T())
 

--- a/backend/internal/oauth/oauth2/dcr/handler.go
+++ b/backend/internal/oauth/oauth2/dcr/handler.go
@@ -20,7 +20,6 @@ package dcr
 
 import (
 	"net/http"
-	"slices"
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -76,7 +75,7 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 // checkDCRAuthorization verifies that the caller holds required permission.
 // Returns true if authorized, false (and writes an HTTP 401) otherwise.
 func (dh *dcrHandler) checkDCRAuthorization(r *http.Request, w http.ResponseWriter) bool {
-	if slices.Contains(security.GetPermissions(r.Context()), "system") {
+	if security.HasSystemPermission(security.GetPermissions(r.Context())) {
 		return true
 	}
 	sysutils.WriteJSONError(w, ErrorUnauthorized.Code,

--- a/backend/internal/oauth/oauth2/dcr/handler_test.go
+++ b/backend/internal/oauth/oauth2/dcr/handler_test.go
@@ -350,6 +350,8 @@ func TestHandleDCRRegistration_ClosedDCR_InsufficientPermissions(t *testing.T) {
 func TestHandleDCRRegistration_ClosedDCR_WithSystemPermission(t *testing.T) {
 	_ = config.InitializeServerRuntime("test", &config.Config{})
 	defer config.ResetServerRuntime()
+	security.InitSystemPermissions("")
+	defer security.InitSystemPermissions("")
 
 	mockService := NewDCRServiceInterfaceMock(t)
 	handler := newDCRHandler(mockService)

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -363,6 +363,12 @@ type UserConfig struct {
 	Store string `yaml:"store" json:"store"`
 }
 
+// SystemResourceServerConfig holds configuration for the built-in system resource server.
+type SystemResourceServerConfig struct {
+	Handle     string `yaml:"handle" json:"handle"`
+	Identifier string `yaml:"identifier" json:"identifier"`
+}
+
 // ResourceConfig holds the resource management configuration details.
 type ResourceConfig struct {
 	DefaultDelimiter string `yaml:"default_delimiter" json:"default_delimiter"`
@@ -371,7 +377,8 @@ type ResourceConfig struct {
 	// If not specified, falls back to global DeclarativeResources.Enabled setting:
 	//   - If DeclarativeResources.Enabled = true: behaves as "declarative"
 	//   - If DeclarativeResources.Enabled = false: behaves as "mutable"
-	Store string `yaml:"store" json:"store"`
+	Store                string                     `yaml:"store" json:"store"`
+	SystemResourceServer SystemResourceServerConfig `yaml:"system_resource_server" json:"system_resource_server"`
 }
 
 // OrganizationUnitConfig holds the organization unit service configuration.
@@ -635,6 +642,11 @@ func LoadConfig(configPath string, defaultPath string, serverHome string) (*Conf
 	// Derive JWT issuer from server config if not set
 	if cfg.JWT.Issuer == "" {
 		cfg.JWT.Issuer = GetServerURL(&cfg.Server)
+	}
+
+	// Default system resource server identifier to "system" if not set.
+	if cfg.Resource.SystemResourceServer.Identifier == "" {
+		cfg.Resource.SystemResourceServer.Identifier = "system"
 	}
 
 	if err := cfg.Server.SecurityConfig.Validate(); err != nil {

--- a/backend/internal/system/mcp/init.go
+++ b/backend/internal/system/mcp/init.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
+	"github.com/asgardeo/thunder/internal/system/log"
 	mcpauth "github.com/asgardeo/thunder/internal/system/mcp/auth"
+	"github.com/asgardeo/thunder/internal/system/security"
 )
 
 // Initialize initializes the MCP server and registers its routes with the provided mux.
@@ -45,6 +47,12 @@ func Initialize(
 	// Create MCP server and register standalone tools
 	mcpServer := newServer()
 
+	sysPerm := security.GetSystemPermissions()
+	if sysPerm == nil {
+		log.GetLogger().Fatal("System permissions not initialized before MCP initialization")
+	}
+	rootPerm := sysPerm.Root
+
 	tokenVerifier := mcpauth.NewTokenVerifier(jwtService, cfg.JWT.Issuer, mcpURL)
 	httpHandler := mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server {
 		return mcpServer
@@ -53,14 +61,14 @@ func Initialize(
 	// Secure MCP handler with bearer token authentication
 	securedHandler := auth.RequireBearerToken(tokenVerifier, &auth.RequireBearerTokenOptions{
 		ResourceMetadataURL: resourceMetadataURL,
-		Scopes:              []string{"system"},
+		Scopes:              []string{rootPerm},
 	})(httpHandler)
 
 	// Register protected resource metadata endpoint
 	metadata := &oauthex.ProtectedResourceMetadata{
 		Resource:             mcpURL,
 		AuthorizationServers: []string{cfg.JWT.Issuer},
-		ScopesSupported:      []string{"system"},
+		ScopesSupported:      []string{rootPerm},
 	}
 	mux.Handle(OAuthProtectedResourceMetadataPath, auth.ProtectedResourceMetadataHandler(metadata))
 

--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -20,9 +20,16 @@ package security
 
 import "strings"
 
-// maxPublicPathLength defines the maximum allowed length for a public path.
-// This prevents potential DoS attacks via excessively long paths (even with safe regex).
-const maxPublicPathLength = 4096
+const (
+	// maxPublicPathLength defines the maximum allowed length for a public path.
+	// This prevents potential DoS attacks via excessively long paths (even with safe regex).
+	maxPublicPathLength = 4096
+)
+
+// UninitializedPermissionSentinel is returned by permission-resolution functions when
+// InitSystemPermissions has not yet been called. It is intentionally unguessable so that
+// any permission check performed before initialization fails closed.
+const UninitializedPermissionSentinel = "__uninitialized__"
 
 // publicPaths defines the list of public paths using glob patterns.
 // - "*": Matches a single path segment (e.g., /a/*/b).
@@ -121,57 +128,144 @@ const (
 
 // ---- Permissions ----
 
-// SystemPermission is the root permission that implicitly covers all sub-permissions.
-// A caller holding "system" is a full admin and bypasses all fine-grained checks.
-const SystemPermission = "system"
+// SystemPermissions holds the runtime-resolved permission strings for the system resource server.
+// All values are set by InitSystemPermissions and must not be used before it is called.
+type SystemPermissions struct {
+	Root           string
+	OU             string
+	OUView         string
+	User           string
+	UserView       string
+	Group          string
+	GroupView      string
+	UserSchema     string
+	UserSchemaView string
+}
 
-// Fine-grained permissions. Each constant is a child scope of SystemPermission.
-// Hierarchy uses ":" as delimiter: "system:ou" covers "system:ou:view".
-const (
-	PermissionOU             = "system:ou"
-	PermissionOUView         = "system:ou:view"
-	PermissionUser           = "system:user"
-	PermissionUserView       = "system:user:view"
-	PermissionGroup          = "system:group"
-	PermissionGroupView      = "system:group:view"
-	PermissionUserSchema     = "system:userschema"
-	PermissionUserSchemaView = "system:userschema:view"
-)
+// sysPerms holds the active system permissions, initialized by InitSystemPermissions.
+var sysPerms *SystemPermissions
+
+// buildPermission constructs a permission string by joining non-empty parts with ":".
+func buildPermission(parts ...string) string {
+	var nonEmpty []string
+	for _, p := range parts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+	return strings.Join(nonEmpty, ":")
+}
+
+// InitSystemPermissions initializes the system permission strings using the given handle prefix.
+// When handle is empty, permissions match the legacy values ("system", "system:ou", etc.).
+// When handle is non-empty (e.g. "mgmt"), permissions are prefixed ("mgmt:system", "mgmt:system:ou", etc.).
+// This function must be called once at startup before any service or middleware uses permissions.
+func InitSystemPermissions(handle string) {
+	p := &SystemPermissions{
+		Root:           buildPermission(handle, "system"),
+		OU:             buildPermission(handle, "system", "ou"),
+		OUView:         buildPermission(handle, "system", "ou", "view"),
+		User:           buildPermission(handle, "system", "user"),
+		UserView:       buildPermission(handle, "system", "user", "view"),
+		Group:          buildPermission(handle, "system", "group"),
+		GroupView:      buildPermission(handle, "system", "group", "view"),
+		UserSchema:     buildPermission(handle, "system", "userschema"),
+		UserSchemaView: buildPermission(handle, "system", "userschema", "view"),
+	}
+	sysPerms = p
+
+	actionPermissionMap = map[Action]string{
+		// Organization unit actions.
+		ActionCreateOU:     p.OU,
+		ActionReadOU:       p.OUView,
+		ActionUpdateOU:     p.OU,
+		ActionDeleteOU:     p.OU,
+		ActionListOUs:      p.OUView,
+		ActionListChildOUs: p.OU,
+
+		// User actions.
+		ActionCreateUser: p.User,
+		ActionReadUser:   p.UserView,
+		ActionUpdateUser: p.User,
+		ActionDeleteUser: p.User,
+		ActionListUsers:  p.UserView,
+
+		// Group actions.
+		ActionCreateGroup: p.Group,
+		ActionReadGroup:   p.GroupView,
+		ActionUpdateGroup: p.Group,
+		ActionDeleteGroup: p.Group,
+		ActionListGroups:  p.GroupView,
+
+		// User schema actions.
+		ActionCreateUserSchema: p.UserSchema,
+		ActionReadUserSchema:   p.UserSchemaView,
+		ActionUpdateUserSchema: p.UserSchema,
+		ActionDeleteUserSchema: p.UserSchema,
+		ActionListUserSchemas:  p.UserSchemaView,
+	}
+
+	apiPermissionEntries = []apiPermissionEntry{
+		// Self-service paths — accessible to any authenticated user (empty permission).
+		// Listed before their parent wildcards so they always win on first-match.
+		{"GET /users/me", ""},
+		{"PUT /users/me", ""},
+		{"GET /users/me/**", ""},
+		{"PUT /users/me/**", ""},
+		{"POST /users/me/update-credentials", ""},
+		{"GET /register/passkey/**", ""},
+		{"POST /register/passkey/**", ""},
+
+		// Organization unit APIs — exact named paths before wildcards.
+		{"GET /organization-units/tree", p.OUView},
+		{"PUT /organization-units/tree", p.OU},
+		{"DELETE /organization-units/tree", p.OU},
+		{"GET /organization-units", p.OUView},
+		{"POST /organization-units", p.OU},
+		{"GET /organization-units/**", p.OUView},
+		{"PUT /organization-units/**", p.OU},
+		{"DELETE /organization-units/**", p.OU},
+
+		// User APIs.
+		{"GET /users", p.UserView},
+		{"POST /users", p.User},
+		{"GET /users/**", p.UserView},
+		{"PUT /users/**", p.User},
+		{"DELETE /users/**", p.User},
+
+		// Group APIs.
+		{"GET /groups", p.GroupView},
+		{"POST /groups", p.Group},
+		{"GET /groups/**", p.GroupView},
+		{"POST /groups/**", p.Group},
+		{"PUT /groups/**", p.Group},
+		{"DELETE /groups/**", p.Group},
+
+		// User schema APIs.
+		{"GET /user-schemas", p.UserSchemaView},
+		{"POST /user-schemas", p.UserSchema},
+		{"GET /user-schemas/**", p.UserSchemaView},
+		{"PUT /user-schemas/**", p.UserSchema},
+		{"DELETE /user-schemas/**", p.UserSchema},
+
+		// Import APIs.
+		{"POST /import", p.Root},
+		{"POST /import/delete", p.Root},
+	}
+}
+
+// GetSystemPermissions returns the active system permissions.
+// Returns nil if InitSystemPermissions has not been called.
+func GetSystemPermissions() *SystemPermissions {
+	return sysPerms
+}
 
 // ---- Action → Permission map ----
 
 // actionPermissionMap maps each system action to the minimum permission required to perform it.
-// Actions not present in this map default to requiring SystemPermission.
-var actionPermissionMap = map[Action]string{
-	// Organization unit actions.
-	ActionCreateOU:     PermissionOU,
-	ActionReadOU:       PermissionOUView,
-	ActionUpdateOU:     PermissionOU,
-	ActionDeleteOU:     PermissionOU,
-	ActionListOUs:      PermissionOUView,
-	ActionListChildOUs: PermissionOU,
-
-	// User actions.
-	ActionCreateUser: PermissionUser,
-	ActionReadUser:   PermissionUserView,
-	ActionUpdateUser: PermissionUser,
-	ActionDeleteUser: PermissionUser,
-	ActionListUsers:  PermissionUserView,
-
-	// Group actions.
-	ActionCreateGroup: PermissionGroup,
-	ActionReadGroup:   PermissionGroupView,
-	ActionUpdateGroup: PermissionGroup,
-	ActionDeleteGroup: PermissionGroup,
-	ActionListGroups:  PermissionGroupView,
-
-	// User schema actions.
-	ActionCreateUserSchema: PermissionUserSchema,
-	ActionReadUserSchema:   PermissionUserSchemaView,
-	ActionUpdateUserSchema: PermissionUserSchema,
-	ActionDeleteUserSchema: PermissionUserSchema,
-	ActionListUserSchemas:  PermissionUserSchemaView,
-}
+// Actions not present in this map default to requiring the root system permission.
+// Rebuilt by InitSystemPermissions at startup.
+var actionPermissionMap map[Action]string
 
 // ---- API → Permission map ----
 
@@ -189,61 +283,20 @@ type apiPermissionEntry struct {
 //   - "*"  matches exactly one path segment (e.g., a resource ID).
 //   - "**" matches zero or more path segments; only valid as the final component
 //     after "/" (e.g., "GET /users/me/**" covers all sub-paths of /users/me).
-var apiPermissionEntries = []apiPermissionEntry{
-	// Self-service paths — accessible to any authenticated user (empty permission).
-	// Listed before their parent wildcards so they always win on first-match.
-	{"GET /users/me", ""},
-	{"PUT /users/me", ""},
-	{"GET /users/me/**", ""},
-	{"PUT /users/me/**", ""},
-	{"POST /users/me/update-credentials", ""},
-	{"GET /register/passkey/**", ""},
-	{"POST /register/passkey/**", ""},
-
-	// Organization unit APIs — exact named paths before wildcards.
-	{"GET /organization-units/tree", PermissionOUView},
-	{"PUT /organization-units/tree", PermissionOU},
-	{"DELETE /organization-units/tree", PermissionOU},
-	{"GET /organization-units", PermissionOUView},
-	{"POST /organization-units", PermissionOU},
-	{"GET /organization-units/**", PermissionOUView},
-	{"PUT /organization-units/**", PermissionOU},
-	{"DELETE /organization-units/**", PermissionOU},
-
-	// User APIs.
-	{"GET /users", PermissionUserView},
-	{"POST /users", PermissionUser},
-	{"GET /users/**", PermissionUserView},
-	{"PUT /users/**", PermissionUser},
-	{"DELETE /users/**", PermissionUser},
-
-	// Group APIs.
-	{"GET /groups", PermissionGroupView},
-	{"POST /groups", PermissionGroup},
-	{"GET /groups/**", PermissionGroupView},
-	{"POST /groups/**", PermissionGroup},
-	{"PUT /groups/**", PermissionGroup},
-	{"DELETE /groups/**", PermissionGroup},
-
-	// User schema APIs.
-	{"GET /user-schemas", PermissionUserSchemaView},
-	{"POST /user-schemas", PermissionUserSchema},
-	{"GET /user-schemas/**", PermissionUserSchemaView},
-	{"PUT /user-schemas/**", PermissionUserSchema},
-	{"DELETE /user-schemas/**", PermissionUserSchema},
-
-	// Import APIs.
-	{"POST /import", SystemPermission},
-	{"POST /import/delete", SystemPermission},
-}
+//
+// Rebuilt by InitSystemPermissions at startup.
+var apiPermissionEntries []apiPermissionEntry
 
 // ---- Helper functions ----
 
-// HasSystemPermission returns true if the caller holds the root "system" permission.
+// HasSystemPermission returns true if the caller holds the root system permission.
 // This is a fast-path check used to grant unconditional access (skipping policy evaluation).
 func HasSystemPermission(permissions []string) bool {
+	if sysPerms == nil {
+		return false
+	}
 	for _, p := range permissions {
-		if p == SystemPermission {
+		if p == sysPerms.Root {
 			return true
 		}
 	}
@@ -271,10 +324,13 @@ func HasSufficientPermission(userPermissions []string, required string) bool {
 }
 
 // ResolveActionPermission returns the minimum permission required to perform the given
-// action. Falls back to SystemPermission for actions not listed in the action permission map.
+// action. Falls back to the root system permission for actions not listed in the action permission map.
 func ResolveActionPermission(action Action) string {
 	if perm, ok := actionPermissionMap[action]; ok {
 		return perm
 	}
-	return SystemPermission
+	if sysPerms != nil {
+		return sysPerms.Root
+	}
+	return UninitializedPermissionSentinel
 }

--- a/backend/internal/system/security/permissions_test.go
+++ b/backend/internal/system/security/permissions_test.go
@@ -31,6 +31,8 @@ import (
 // ---------------------------------------------------------------------------
 
 func (s *SecurityContextTestSuite) TestHasSystemPermission() {
+	InitSystemPermissions("")
+
 	tests := []struct {
 		name        string
 		permissions []string
@@ -197,35 +199,38 @@ func (s *SecurityContextTestSuite) TestHasSufficientPermission() {
 // ---------------------------------------------------------------------------
 
 func (s *SecurityContextTestSuite) TestResolveActionPermission() {
+	InitSystemPermissions("")
+	p := GetSystemPermissions()
+
 	tests := []struct {
 		name     string
 		action   Action
 		wantPerm string
 	}{
 		// OU actions.
-		{name: "CreateOU", action: ActionCreateOU, wantPerm: PermissionOU},
-		{name: "ReadOU", action: ActionReadOU, wantPerm: PermissionOUView},
-		{name: "UpdateOU", action: ActionUpdateOU, wantPerm: PermissionOU},
-		{name: "DeleteOU", action: ActionDeleteOU, wantPerm: PermissionOU},
-		{name: "ListOUs", action: ActionListOUs, wantPerm: PermissionOUView},
+		{name: "CreateOU", action: ActionCreateOU, wantPerm: p.OU},
+		{name: "ReadOU", action: ActionReadOU, wantPerm: p.OUView},
+		{name: "UpdateOU", action: ActionUpdateOU, wantPerm: p.OU},
+		{name: "DeleteOU", action: ActionDeleteOU, wantPerm: p.OU},
+		{name: "ListOUs", action: ActionListOUs, wantPerm: p.OUView},
 
 		// User actions.
-		{name: "CreateUser", action: ActionCreateUser, wantPerm: PermissionUser},
-		{name: "ReadUser", action: ActionReadUser, wantPerm: PermissionUserView},
-		{name: "UpdateUser", action: ActionUpdateUser, wantPerm: PermissionUser},
-		{name: "DeleteUser", action: ActionDeleteUser, wantPerm: PermissionUser},
-		{name: "ListUsers", action: ActionListUsers, wantPerm: PermissionUserView},
+		{name: "CreateUser", action: ActionCreateUser, wantPerm: p.User},
+		{name: "ReadUser", action: ActionReadUser, wantPerm: p.UserView},
+		{name: "UpdateUser", action: ActionUpdateUser, wantPerm: p.User},
+		{name: "DeleteUser", action: ActionDeleteUser, wantPerm: p.User},
+		{name: "ListUsers", action: ActionListUsers, wantPerm: p.UserView},
 
 		// Group actions.
-		{name: "CreateGroup", action: ActionCreateGroup, wantPerm: PermissionGroup},
-		{name: "ReadGroup", action: ActionReadGroup, wantPerm: PermissionGroupView},
-		{name: "UpdateGroup", action: ActionUpdateGroup, wantPerm: PermissionGroup},
-		{name: "DeleteGroup", action: ActionDeleteGroup, wantPerm: PermissionGroup},
-		{name: "ListGroups", action: ActionListGroups, wantPerm: PermissionGroupView},
+		{name: "CreateGroup", action: ActionCreateGroup, wantPerm: p.Group},
+		{name: "ReadGroup", action: ActionReadGroup, wantPerm: p.GroupView},
+		{name: "UpdateGroup", action: ActionUpdateGroup, wantPerm: p.Group},
+		{name: "DeleteGroup", action: ActionDeleteGroup, wantPerm: p.Group},
+		{name: "ListGroups", action: ActionListGroups, wantPerm: p.GroupView},
 
-		// Unmapped action falls back to SystemPermission.
-		{name: "UnmappedAction_FallsBackToSystem", action: Action("custom:unknown"), wantPerm: SystemPermission},
-		{name: "EmptyAction_FallsBackToSystem", action: Action(""), wantPerm: SystemPermission},
+		// Unmapped action falls back to Root (system).
+		{name: "UnmappedAction_FallsBackToSystem", action: Action("custom:unknown"), wantPerm: p.Root},
+		{name: "EmptyAction_FallsBackToSystem", action: Action(""), wantPerm: p.Root},
 	}
 
 	for _, tt := range tests {
@@ -238,6 +243,7 @@ func (s *SecurityContextTestSuite) TestResolveActionPermission() {
 // TestResolveActionPermission_CoversAllMappedActions ensures every entry in
 // actionPermissionMap is reachable and returns the expected permission.
 func (s *SecurityContextTestSuite) TestResolveActionPermission_CoversAllMappedActions() {
+	InitSystemPermissions("")
 	for action, expectedPerm := range actionPermissionMap {
 		s.Run(string(action), func() {
 			s.Equal(expectedPerm, ResolveActionPermission(action))
@@ -246,10 +252,68 @@ func (s *SecurityContextTestSuite) TestResolveActionPermission_CoversAllMappedAc
 }
 
 // ---------------------------------------------------------------------------
+// InitSystemPermissions
+// ---------------------------------------------------------------------------
+
+func TestInitSystemPermissions_EmptyHandle(t *testing.T) {
+	InitSystemPermissions("")
+	p := GetSystemPermissions()
+	require.NotNil(t, p)
+
+	assert.Equal(t, "system", p.Root)
+	assert.Equal(t, "system:ou", p.OU)
+	assert.Equal(t, "system:ou:view", p.OUView)
+	assert.Equal(t, "system:user", p.User)
+	assert.Equal(t, "system:user:view", p.UserView)
+	assert.Equal(t, "system:group", p.Group)
+	assert.Equal(t, "system:group:view", p.GroupView)
+	assert.Equal(t, "system:userschema", p.UserSchema)
+	assert.Equal(t, "system:userschema:view", p.UserSchemaView)
+}
+
+func TestInitSystemPermissions_NonEmptyHandle(t *testing.T) {
+	InitSystemPermissions("mgmt")
+	p := GetSystemPermissions()
+	require.NotNil(t, p)
+
+	assert.Equal(t, "mgmt:system", p.Root)
+	assert.Equal(t, "mgmt:system:ou", p.OU)
+	assert.Equal(t, "mgmt:system:ou:view", p.OUView)
+	assert.Equal(t, "mgmt:system:user", p.User)
+	assert.Equal(t, "mgmt:system:user:view", p.UserView)
+	assert.Equal(t, "mgmt:system:group", p.Group)
+	assert.Equal(t, "mgmt:system:group:view", p.GroupView)
+	assert.Equal(t, "mgmt:system:userschema", p.UserSchema)
+	assert.Equal(t, "mgmt:system:userschema:view", p.UserSchemaView)
+
+	// Restore default for other tests.
+	InitSystemPermissions("")
+}
+
+func TestInitSystemPermissions_RebuildsActionMap(t *testing.T) {
+	InitSystemPermissions("x")
+	assert.Equal(t, "x:system:ou", ResolveActionPermission(ActionCreateOU))
+
+	InitSystemPermissions("")
+	assert.Equal(t, "system:ou", ResolveActionPermission(ActionCreateOU))
+}
+
+func TestHasSystemPermission_WithCustomHandle(t *testing.T) {
+	InitSystemPermissions("mgmt")
+	defer InitSystemPermissions("")
+
+	assert.True(t, HasSystemPermission([]string{"mgmt:system"}))
+	assert.False(t, HasSystemPermission([]string{"system"}))
+}
+
+// ---------------------------------------------------------------------------
 // GetRequiredPermissionForAPI
 // ---------------------------------------------------------------------------
 
 func TestGetRequiredPermissionForAPI(t *testing.T) {
+	InitSystemPermissions("")
+	p := GetSystemPermissions()
+
 	svc, err := newSecurityService(nil, []string{}, apiPermissionEntries)
 	require.NoError(t, err)
 
@@ -262,16 +326,16 @@ func TestGetRequiredPermissionForAPI(t *testing.T) {
 		// ---- Exact matches ----
 		{
 			name:   "GET /organization-units exact",
-			method: http.MethodGet, path: "/organization-units", wantPerm: PermissionOUView,
+			method: http.MethodGet, path: "/organization-units", wantPerm: p.OUView,
 		},
 		{
 			name:   "POST /organization-units exact",
-			method: http.MethodPost, path: "/organization-units", wantPerm: PermissionOU,
+			method: http.MethodPost, path: "/organization-units", wantPerm: p.OU,
 		},
-		{name: "GET /users exact", method: http.MethodGet, path: "/users", wantPerm: PermissionUserView},
-		{name: "POST /users exact", method: http.MethodPost, path: "/users", wantPerm: PermissionUser},
-		{name: "GET /groups exact", method: http.MethodGet, path: "/groups", wantPerm: PermissionGroupView},
-		{name: "POST /groups exact", method: http.MethodPost, path: "/groups", wantPerm: PermissionGroup},
+		{name: "GET /users exact", method: http.MethodGet, path: "/users", wantPerm: p.UserView},
+		{name: "POST /users exact", method: http.MethodPost, path: "/users", wantPerm: p.User},
+		{name: "GET /groups exact", method: http.MethodGet, path: "/groups", wantPerm: p.GroupView},
+		{name: "POST /groups exact", method: http.MethodPost, path: "/groups", wantPerm: p.Group},
 
 		// ---- Self-service paths (empty permission = any authenticated user) ----
 		{name: "GET /users/me self-service", method: http.MethodGet, path: "/users/me", wantPerm: ""},
@@ -294,39 +358,38 @@ func TestGetRequiredPermissionForAPI(t *testing.T) {
 		// ---- Prefix match — dynamic path segments ----
 		{
 			name:   "GET /organization-units/{id} prefix",
-			method: http.MethodGet, path: "/organization-units/ou-123", wantPerm: PermissionOUView,
+			method: http.MethodGet, path: "/organization-units/ou-123", wantPerm: p.OUView,
 		},
 		{
 			name:   "PUT /organization-units/{id} prefix",
-			method: http.MethodPut, path: "/organization-units/ou-123", wantPerm: PermissionOU,
+			method: http.MethodPut, path: "/organization-units/ou-123", wantPerm: p.OU,
 		},
 		{
 			name:   "DELETE /organization-units/{id} prefix",
-			method: http.MethodDelete, path: "/organization-units/ou-123", wantPerm: PermissionOU,
+			method: http.MethodDelete, path: "/organization-units/ou-123", wantPerm: p.OU,
 		},
 		{
 			name:   "GET /users/{id} prefix",
-			method: http.MethodGet, path: "/users/user-456", wantPerm: PermissionUserView,
+			method: http.MethodGet, path: "/users/user-456", wantPerm: p.UserView,
 		},
 		{
 			name:   "PUT /users/{id} prefix",
-			method: http.MethodPut, path: "/users/user-456", wantPerm: PermissionUser,
+			method: http.MethodPut, path: "/users/user-456", wantPerm: p.User,
 		},
 		{
 			name:   "DELETE /users/{id} prefix",
-			method: http.MethodDelete, path: "/users/user-789", wantPerm: PermissionUser,
+			method: http.MethodDelete, path: "/users/user-789", wantPerm: p.User,
 		},
 		{
 			name:   "GET /groups/{id} prefix",
-			method: http.MethodGet, path: "/groups/grp-111", wantPerm: PermissionGroupView,
+			method: http.MethodGet, path: "/groups/grp-111", wantPerm: p.GroupView,
 		},
 		{
 			name:   "DELETE /groups/{id} prefix",
-			method: http.MethodDelete, path: "/groups/grp-222", wantPerm: PermissionGroup,
+			method: http.MethodDelete, path: "/groups/grp-222", wantPerm: p.Group,
 		},
 
 		// ---- Self-service wins over parent prefix ----
-		// /users/me must match "" even though /users/ would match PermissionUserView.
 		{name: "GET /users/me wins over /users/ prefix", method: http.MethodGet, path: "/users/me", wantPerm: ""},
 		{
 			name:   "GET /users/me/profile wins over /users/ prefix",
@@ -336,40 +399,36 @@ func TestGetRequiredPermissionForAPI(t *testing.T) {
 		// ---- OU tree paths ----
 		{
 			name:   "GET /organization-units/tree",
-			method: http.MethodGet, path: "/organization-units/tree", wantPerm: PermissionOUView,
+			method: http.MethodGet, path: "/organization-units/tree", wantPerm: p.OUView,
 		},
 		{
 			name:   "PUT /organization-units/tree",
-			method: http.MethodPut, path: "/organization-units/tree", wantPerm: PermissionOU,
+			method: http.MethodPut, path: "/organization-units/tree", wantPerm: p.OU,
 		},
 		{
 			name:   "DELETE /organization-units/tree",
-			method: http.MethodDelete, path: "/organization-units/tree", wantPerm: PermissionOU,
+			method: http.MethodDelete, path: "/organization-units/tree", wantPerm: p.OU,
 		},
 
-		// ---- Unmapped paths fall back to SystemPermission ----
+		// ---- Unmapped paths fall back to Root ----
 		{
 			name:   "Unmapped path falls back to system",
-			method: http.MethodGet, path: "/applications", wantPerm: SystemPermission,
+			method: http.MethodGet, path: "/applications", wantPerm: p.Root,
 		},
-		{name: "Root path falls back to system", method: http.MethodGet, path: "/", wantPerm: SystemPermission},
+		{name: "Root path falls back to system", method: http.MethodGet, path: "/", wantPerm: p.Root},
 		{
 			name:   "Unknown POST falls back to system",
-			method: http.MethodPost, path: "/configs", wantPerm: SystemPermission,
+			method: http.MethodPost, path: "/configs", wantPerm: p.Root,
 		},
 		{
-			// /users/menu has no explicit entry but matches the GET /users/** wildcard,
-			// so it requires PermissionUserView — the same as any other /users/<id> path.
-			// It previously returned "" (self-service) because the old string-prefix logic
-			// let "GET /users/me" accidentally act as a prefix of "GET /users/menu".
 			name:   "GET /users/menu matches users wildcard",
-			method: http.MethodGet, path: "/users/menu", wantPerm: PermissionUserView,
+			method: http.MethodGet, path: "/users/menu", wantPerm: p.UserView,
 		},
 
 		// ---- Wrong method does not match mapped path ----
 		{
 			name:   "PATCH /users unmapped method falls back to system",
-			method: http.MethodPatch, path: "/users", wantPerm: SystemPermission,
+			method: http.MethodPatch, path: "/users", wantPerm: p.Root,
 		},
 	}
 

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -152,7 +152,7 @@ func (s *securityService) authorize(r *http.Request) error {
 
 // getRequiredPermissionForAPI returns the minimum permission required to access the
 // given HTTP method + path combination. Returns an empty string for self-service paths
-// that any authenticated user may access. Falls back to SystemPermission for paths not
+// that any authenticated user may access. Falls back to the root system permission for paths not
 // covered by any entry in compiledAPIPermissions.
 //
 // Matching uses pre-compiled regular expressions evaluated in declaration order;
@@ -166,7 +166,10 @@ func (s *securityService) getRequiredPermissionForAPI(method, path string) strin
 			return entry.permission
 		}
 	}
-	return SystemPermission
+	if sysPerms != nil {
+		return sysPerms.Root
+	}
+	return UninitializedPermissionSentinel
 }
 
 // isPublicPath checks if the given request path matches any of the configured public path patterns.

--- a/backend/internal/system/security/service_test.go
+++ b/backend/internal/system/security/service_test.go
@@ -461,7 +461,7 @@ func (suite *SecurityServiceTestSuite) TestNewSecurityService_Error() {
 		{
 			name:        "invalid API permission entry pattern",
 			publicPaths: []string{},
-			apiPerms:    []apiPermissionEntry{{"GET /invalid/**/middle/**", PermissionUser}},
+			apiPerms:    []apiPermissionEntry{{"GET /invalid/**/middle/**", "system:user"}},
 			errContains: "invalid pattern",
 		},
 	}

--- a/backend/internal/system/security/utils_test.go
+++ b/backend/internal/system/security/utils_test.go
@@ -176,24 +176,24 @@ func TestCompileAPIPermissions(t *testing.T) {
 		{
 			name: "Valid entries compiled",
 			entries: []apiPermissionEntry{
-				{"GET /users", PermissionUserView},
-				{"GET /users/**", PermissionUserView},
-				{"POST /users", PermissionUser},
+				{"GET /users", "system:user:view"},
+				{"GET /users/**", "system:user:view"},
+				{"POST /users", "system:user"},
 			},
 			wantLen: 3,
 		},
 		{
 			name: "Single wildcard entry",
 			entries: []apiPermissionEntry{
-				{"GET /users/*/profile", PermissionUserView},
+				{"GET /users/*/profile", "system:user:view"},
 			},
 			wantLen: 1,
 		},
 		{
 			name: "Invalid pattern stops compilation",
 			entries: []apiPermissionEntry{
-				{"GET /valid/**", PermissionUserView},
-				{"GET /invalid/**/middle/**", PermissionUser},
+				{"GET /valid/**", "system:user:view"},
+				{"GET /invalid/**/middle/**", "system:user"},
 			},
 			wantError:   true,
 			errContains: "invalid pattern",
@@ -201,8 +201,8 @@ func TestCompileAPIPermissions(t *testing.T) {
 		{
 			name: "Invalid pattern as first entry",
 			entries: []apiPermissionEntry{
-				{"GET /invalid/**/middle/**", PermissionUser},
-				{"GET /valid/**", PermissionUserView},
+				{"GET /invalid/**/middle/**", "system:user"},
+				{"GET /valid/**", "system:user:view"},
 			},
 			wantError:   true,
 			errContains: "invalid pattern",

--- a/backend/internal/system/sysauthz/service_test.go
+++ b/backend/internal/system/sysauthz/service_test.go
@@ -36,6 +36,7 @@ import (
 // every logger.IsDebugEnabled() branch in service.go is exercised.
 func TestMain(m *testing.M) {
 	_ = os.Setenv("LOG_LEVEL", "debug")
+	security.InitSystemPermissions("")
 	os.Exit(m.Run())
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -237,6 +237,8 @@ function Read-Config {
             $script:PUBLIC_HOSTNAME = & yq eval '.server.public_hostname // ""' $CONFIG_FILE 2>$null
             $consentEnabled = & yq eval '.consent.enabled // true' $CONFIG_FILE 2>$null
             $script:CONSENT_ENABLED = ($consentEnabled -eq "true")
+            $script:SYSTEM_RS_HANDLE = & yq eval '.resource.system_resource_server.handle // ""' $CONFIG_FILE 2>$null
+            $script:SYSTEM_RS_IDENTIFIER = & yq eval '.resource.system_resource_server.identifier // ""' $CONFIG_FILE 2>$null
         }
         else {
             # Fallback: basic parsing with regex
@@ -280,6 +282,29 @@ function Read-Config {
             }
             else {
                 $script:CONSENT_ENABLED = $true
+            }
+
+            $uncommentedContent = ($content -split "`n" | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+            # Try to extract system resource server handle
+            if ($uncommentedContent -match '(?ms)system_resource_server:.*?handle:\s*[''"]([^''"]*)[''"]') {
+                $script:SYSTEM_RS_HANDLE = $matches[1]
+            }
+            elseif ($uncommentedContent -match '(?ms)system_resource_server:.*?handle:\s*([^\s#]+)') {
+                $script:SYSTEM_RS_HANDLE = $matches[1]
+            }
+            else {
+                $script:SYSTEM_RS_HANDLE = ""
+            }
+
+            # Try to extract system resource server identifier
+            if ($uncommentedContent -match '(?ms)system_resource_server:.*?identifier:\s*[''"]([^''"]*)[''"]') {
+                $script:SYSTEM_RS_IDENTIFIER = $matches[1]
+            }
+            elseif ($uncommentedContent -match '(?ms)system_resource_server:.*?identifier:\s*([^\s#]+)') {
+                $script:SYSTEM_RS_IDENTIFIER = $matches[1]
+            }
+            else {
+                $script:SYSTEM_RS_IDENTIFIER = ""
             }
         }
     }
@@ -1621,6 +1646,8 @@ function Run {
     
     # Run the bootstrap script directly with environment variable and arguments
     $env:API_BASE = $BASE_URL
+    $env:THUNDER_SYSTEM_RS_HANDLE = if ($script:SYSTEM_RS_HANDLE) { $script:SYSTEM_RS_HANDLE } else { "" }
+    $env:THUNDER_SYSTEM_RS_IDENTIFIER = if ($script:SYSTEM_RS_IDENTIFIER) { $script:SYSTEM_RS_IDENTIFIER } else { "" }
     $bootstrapScript = Join-Path $BACKEND_BASE_DIR "cmd/server/bootstrap/01-default-resources.ps1"
     & $bootstrapScript -ConsoleRedirectUris "https://localhost:${CONSOLE_APP_DEFAULT_PORT}/console"
 

--- a/build.sh
+++ b/build.sh
@@ -201,6 +201,20 @@ read_config() {
             HOSTNAME=${HOSTNAME:-localhost}
             PORT=${PORT:-8090}
         fi
+
+        # Read system resource server config (nested under resource:)
+        if command -v yq >/dev/null 2>&1; then
+            SYSTEM_RS_HANDLE=$(yq eval '.resource.system_resource_server.handle // ""' "$config_file" 2>/dev/null)
+            SYSTEM_RS_IDENTIFIER=$(yq eval '.resource.system_resource_server.identifier // ""' "$config_file" 2>/dev/null)
+        else
+            SYSTEM_RS_HANDLE=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*handle:' | awk -F':' '{gsub(/[[:space:]"'\'']/,""); s=""; for(i=2;i<=NF;i++) s=s (i>2?":":"") $i; print s}' | head -1)
+            SYSTEM_RS_IDENTIFIER=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*identifier:' | grep -o '"[^"]*"' | tr -d '"' | head -1)
+            if [ -z "$SYSTEM_RS_IDENTIFIER" ]; then
+                SYSTEM_RS_IDENTIFIER=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*identifier:' | awk -F':' '{gsub(/[[:space:]"'\'']/,""); s=""; for(i=2;i<=NF;i++) s=s (i>2?":":"") $i; print s}' | head -1)
+            fi
+        fi
+        SYSTEM_RS_HANDLE=${SYSTEM_RS_HANDLE:-}
+        SYSTEM_RS_IDENTIFIER=${SYSTEM_RS_IDENTIFIER:-}
     fi
 
     # Determine protocol
@@ -1030,6 +1044,8 @@ function run() {
     
     # Run the bootstrap script directly with environment variable and arguments
     API_BASE="$BASE_URL" \
+        THUNDER_SYSTEM_RS_HANDLE="$SYSTEM_RS_HANDLE" \
+        THUNDER_SYSTEM_RS_IDENTIFIER="$SYSTEM_RS_IDENTIFIER" \
         "$BACKEND_BASE_DIR/cmd/server/bootstrap/01-default-resources.sh" \
         --console-redirect-uris "https://localhost:$CONSOLE_APP_DEFAULT_PORT/console"
 

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -409,6 +409,67 @@ Authorization resource settings.
 |---------|---------|-------------|
 | `resource.default_delimiter` | `:` | Default delimiter for resource hierarchies |
 
+### System Resource Server
+
+The system resource server controls administrative permissions for Thunder Console operations such as managing users, groups, organization units, and user schemas. You can customize the handle and identifier to fit your deployment requirements.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `resource.system_resource_server.handle` | `""` (empty) | Prefix added before all system permission strings. When empty, permissions use their base names (for example, `system`, `system:ou`). When set, the handle is added before every permission (for example, `mgmt:system`, `mgmt:system:ou`) |
+| `resource.system_resource_server.identifier` | `system` | Identifier for the system resource server. Can be set to a URI for [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) resource indicator flows (for example, `https://api.example.com`) |
+
+**Example:**
+```yaml
+resource:
+  system_resource_server:
+    handle: "mgmt"
+    identifier: "https://api.example.com"
+```
+
+With the handle set to `mgmt`, all system permissions change as follows:
+
+| Default Permission | Custom Permission |
+|-------------------|-------------------|
+| `system` | `mgmt:system` |
+| `system:ou` | `mgmt:system:ou` |
+| `system:ou:view` | `mgmt:system:ou:view` |
+| `system:user` | `mgmt:system:user` |
+| `system:user:view` | `mgmt:system:user:view` |
+| `system:group` | `mgmt:system:group` |
+| `system:group:view` | `mgmt:system:group:view` |
+| `system:userschema` | `mgmt:system:userschema` |
+| `system:userschema:view` | `mgmt:system:userschema:view` |
+
+#### Update Console Scopes
+
+When you change the system resource server handle, you must also update the Thunder Console scopes to match the new permission strings. The scopes tell the Console which permissions to request during sign-in.
+
+Update the `scopes` array in the Console configuration file for your deployment mode:
+
+- **Local development** (`pnpm dev`): Update `frontend/apps/thunder-console/public/config.js`.
+- **Packaged build** (`build.sh` / `setup.sh` / `setup.ps1`): The setup scripts read the handle from `deployment.yaml` and pass the value to the bootstrap process automatically. Update `frontend/apps/thunder-console/public/config.js` for the Console scopes.
+- **Helm deployment**: Update `configuration.consoleClient.scopes` in your Helm values file (`install/helm/values.yaml`).
+
+For example, with the handle set to `mgmt`, update the Console `scopes` array to:
+
+```javascript
+scopes: [
+  'openid',
+  'profile',
+  'email',
+  'ou',
+  'mgmt:system',
+  'mgmt:system:user',
+  'mgmt:system:group',
+  'mgmt:system:ou:view',
+  'mgmt:system:userschema:view',
+],
+```
+
+:::warning
+If the Console scopes do not match the configured handle, the admin user token will lack the required `authorized_permissions` claim. All administrative API calls from the Console will then return `403 Forbidden`.
+:::
+
 ## Observability Configuration
 
 Monitoring and observability settings.

--- a/setup.ps1
+++ b/setup.ps1
@@ -296,6 +296,8 @@ function Read-Config {
         $script:PORT = & yq eval '.server.port // 8090' $configFile 2>$null
         $script:HTTP_ONLY = & yq eval '.server.http_only // false' $configFile 2>$null
         $script:PUBLIC_URL = & yq eval '.server.public_url // ""' $configFile 2>$null
+        $script:SYSTEM_RS_HANDLE = & yq eval '.resource.system_resource_server.handle // ""' $configFile 2>$null
+        $script:SYSTEM_RS_IDENTIFIER = & yq eval '.resource.system_resource_server.identifier // ""' $configFile 2>$null
     }
     else {
         # Fallback: basic parsing with Select-String
@@ -335,6 +337,28 @@ function Read-Config {
         else {
             $script:PUBLIC_URL = ""
         }
+
+        # Parse system resource server handle (under resource.system_resource_server)
+        if ($content -match '(?ms)system_resource_server:.*?handle:\s*[''"]([^''"]*)[''"]') {
+            $script:SYSTEM_RS_HANDLE = $matches[1]
+        }
+        elseif ($content -match '(?ms)system_resource_server:.*?handle:\s*([^\s#]+)') {
+            $script:SYSTEM_RS_HANDLE = $matches[1]
+        }
+        else {
+            $script:SYSTEM_RS_HANDLE = ""
+        }
+
+        # Parse system resource server identifier (under resource.system_resource_server)
+        if ($content -match '(?ms)system_resource_server:.*?identifier:\s*[''"]([^''"]*)[''"]') {
+            $script:SYSTEM_RS_IDENTIFIER = $matches[1]
+        }
+        elseif ($content -match '(?ms)system_resource_server:.*?identifier:\s*([^\s#]+)') {
+            $script:SYSTEM_RS_IDENTIFIER = $matches[1]
+        }
+        else {
+            $script:SYSTEM_RS_IDENTIFIER = ""
+        }
     }
 
     # Determine protocol
@@ -361,6 +385,8 @@ $PUBLIC_URL = if ($script:PUBLIC_URL) { $script:PUBLIC_URL.TrimEnd('/') } else {
 # Export environment variables for bootstrap scripts
 $env:API_BASE = $BASE_URL
 $env:PUBLIC_URL = $PUBLIC_URL
+$env:THUNDER_SYSTEM_RS_HANDLE = if ($script:SYSTEM_RS_HANDLE) { $script:SYSTEM_RS_HANDLE } else { "" }
+$env:THUNDER_SYSTEM_RS_IDENTIFIER = if ($script:SYSTEM_RS_IDENTIFIER) { $script:SYSTEM_RS_IDENTIFIER } else { "" }
 
 Write-Host ""
 Write-Host "========================================="

--- a/setup.sh
+++ b/setup.sh
@@ -192,6 +192,8 @@ read_config() {
         PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
         HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)
         PUBLIC_URL=$(yq eval '.server.public_url // ""' "$config_file" 2>/dev/null)
+        SYSTEM_RS_HANDLE=$(yq eval '.resource.system_resource_server.handle // ""' "$config_file" 2>/dev/null)
+        SYSTEM_RS_IDENTIFIER=$(yq eval '.resource.system_resource_server.identifier // ""' "$config_file" 2>/dev/null)
     else
         # Fallback: basic parsing with grep/awk
         HOSTNAME=$(grep -E '^\s*hostname:' "$config_file" | sed 's/#.*//' | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
@@ -212,7 +214,16 @@ read_config() {
         # Use defaults if not found
         HOSTNAME=${HOSTNAME:-localhost}
         PORT=${PORT:-8090}
+
+        # Read system resource server config (nested under resource:)
+        SYSTEM_RS_HANDLE=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*handle:' | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
+        SYSTEM_RS_IDENTIFIER=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*identifier:' | grep -o '"[^"]*"' | tr -d '"' | head -1)
+        if [ -z "$SYSTEM_RS_IDENTIFIER" ]; then
+            SYSTEM_RS_IDENTIFIER=$(grep -A5 'system_resource_server:' "$config_file" 2>/dev/null | grep -E '^\s*identifier:' | awk -F':' '{gsub(/[[:space:]"'\'']/,""); s=""; for(i=2;i<=NF;i++) s=s (i>2?":":"") $i; print s}' | head -1)
+        fi
     fi
+    SYSTEM_RS_HANDLE=${SYSTEM_RS_HANDLE:-}
+    SYSTEM_RS_IDENTIFIER=${SYSTEM_RS_IDENTIFIER:-}
 
     # Determine protocol
     if [ "$HTTP_ONLY" = "true" ]; then
@@ -386,6 +397,8 @@ fi
 # Export variables to be used in scripts
 export API_BASE="${BASE_URL}"
 export PUBLIC_URL="${PUBLIC_URL}"
+export THUNDER_SYSTEM_RS_HANDLE="${SYSTEM_RS_HANDLE}"
+export THUNDER_SYSTEM_RS_IDENTIFIER="${SYSTEM_RS_IDENTIFIER}"
 
 # Check if bootstrap directory exists
 if [ ! -d "$BOOTSTRAP_DIR" ]; then

--- a/tests/integration/group/group_authz_test.go
+++ b/tests/integration/group/group_authz_test.go
@@ -212,7 +212,7 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 	ts.targetGroupOU2ID = targetOU2ID
 
 	// ---- 5. Look up the system resource server seeded by bootstrap ----
-	systemRSID, err := testutils.GetResourceServerByIdentifier("system")
+	systemRSID, err := testutils.GetResourceServerByName("System")
 	ts.Require().NoError(err, "look up system resource server")
 
 	// ---- 6. Create a role with system:group permission and assign to the user-manager ----

--- a/tests/integration/ou/ou_authz_test.go
+++ b/tests/integration/ou/ou_authz_test.go
@@ -36,7 +36,7 @@ import (
 // The bootstrap script (01-default-resources.sh/.ps1) seeds the following
 // hierarchical permission structure under the "system" resource server:
 //
-//	system RS  (identifier: "system")
+//	system RS  (name: "System")
 //	└── Resource  "system"      → permission "system"
 //	    └── Resource  "ou"      → permission "system:ou"
 //	        └── Action "view"   → permission "system:ou:view"
@@ -155,7 +155,7 @@ func (ts *OUAuthzTestSuite) SetupSuite() {
 
 	// ---- 4. Look up the system resource server that was seeded by bootstrap ----
 	// We use the system RS ID to attach the correct permission to the test role.
-	systemRSID, err := testutils.GetResourceServerByIdentifier("system")
+	systemRSID, err := testutils.GetResourceServerByName("System")
 	ts.Require().NoError(err, "look up system resource server")
 
 	// ---- 5. Create a role with permission system:ou:view ----

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -982,6 +982,47 @@ func GetResourceServerByIdentifier(identifier string) (string, error) {
 	return "", fmt.Errorf("resource server with identifier %q not found", identifier)
 }
 
+// GetResourceServerByName lists all resource servers and returns the ID of
+// the first one whose name field matches the given name string.
+func GetResourceServerByName(name string) (string, error) {
+	client := GetHTTPClient()
+
+	req, err := http.NewRequest("GET", TestServerURL+"/resource-servers", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build list-resource-servers request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to list resource servers: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("list resource servers returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Minimal struct to extract from the paginated response
+	var listResp struct {
+		ResourceServers []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"resourceServers"`
+	}
+	if err := json.Unmarshal(body, &listResp); err != nil {
+		return "", fmt.Errorf("failed to unmarshal resource servers response: %w", err)
+	}
+
+	for _, rs := range listResp.ResourceServers {
+		if rs.Name == name {
+			return rs.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("resource server with name %q not found", name)
+}
+
 func DeleteResourceServer(rsID string) error {
 	client := GetHTTPClient()
 

--- a/tests/integration/user/user_authz_test.go
+++ b/tests/integration/user/user_authz_test.go
@@ -175,7 +175,7 @@ func (ts *UserAuthzTestSuite) SetupSuite() {
 	ts.targetUserOU2ID = targetOU2ID
 
 	// ---- 5. Look up the system resource server seeded by bootstrap ----
-	systemRSID, err := testutils.GetResourceServerByIdentifier("system")
+	systemRSID, err := testutils.GetResourceServerByName("System")
 	ts.Require().NoError(err, "look up system resource server")
 
 	// ---- 6. Create a role with system:user permission and assign to the user-manager ----

--- a/tests/integration/userschema/userschema_authz_test.go
+++ b/tests/integration/userschema/userschema_authz_test.go
@@ -36,7 +36,7 @@ import (
 // The bootstrap script seeds the following hierarchical permission structure
 // under the "system" resource server:
 //
-//	system RS  (identifier: "system")
+//	system RS  (name: "System")
 //	└── Resource  "system"           → permission "system"
 //	    └── Resource  "userschema"   → permission "system:userschema"
 //	        └── Action "view"        → permission "system:userschema:view"
@@ -178,7 +178,7 @@ func (ts *UserSchemaAuthzTestSuite) SetupSuite() {
 	ts.schemaAdminUserID = userID
 
 	// ---- 4. Look up the system resource server seeded by bootstrap ----
-	systemRSID, err := testutils.GetResourceServerByIdentifier("system")
+	systemRSID, err := testutils.GetResourceServerByName("System")
 	ts.Require().NoError(err, "look up system resource server")
 
 	// ---- 5. Create a role with system:userschema permission ----


### PR DESCRIPTION
### Purpose

Make the system resource server handle and identifier configurable via `deployment.yaml`. The handle prefixes all system permission strings (e.g., setting handle to `mgmt` changes `system` → `mgmt:system`). The identifier defaults to the server URL, enabling RFC 8707 resource indicator flows.


### Approach

- **Config**: Added `SystemResourceServerConfig` struct to `ResourceConfig`. Identifier defaults to server URL if empty.
- **Permissions**: Replaced hardcoded `const` permission strings with `InitSystemPermissions(handle)` called at startup. Builds all permission strings and rebuilds the action/API permission maps atomically.
- **Bootstrap scripts**: Read handle/identifier from env vars (set by setup scripts from `deployment.yaml`). Derive permission strings dynamically.
- **Setup scripts**: `build.sh`, `setup.sh`, `setup.ps1`, and `build.ps1` extended to read `resource.system_resource_server.*` from `deployment.yaml`.
- **Security**: DCR handler and flow permission validator updated to use dynamic permissions. Nil-safety guards added. Fail-closed sentinel for uninitialized state.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System resource server can be configured with a handle/identifier, producing dynamic system permission strings and templating onboarding flows when a custom handle is used.
* **Bug Fixes**
  * Startup and bootstrap now validate and fail-fast on mismatched system resource server configuration; admin outputs and role permissions reflect the configured permission root.
* **Documentation**
  * Added guide and examples for configuring the system resource server and updating OAuth scopes.
* **Tests**
  * Tests and utilities updated to initialize and resolve dynamic system permissions during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->