### PR TITLE
Allow boolean schema property to accept string "true"/"false" values

### DIFF
--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -48,13 +48,17 @@ func (p *boolean) isUnique() bool {
 }
 
 func (p *boolean) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
-	_, ok := value.(bool)
-	if !ok {
-		logger.Debug("Expected boolean but got different type",
-			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
-		return false, nil
+	switch v := value.(type) {
+	case bool:
+		return true, nil
+	case string:
+		if v == "true" || v == "false" {
+			return true, nil
+		}
 	}
-	return true, nil
+	logger.Debug("Expected boolean but got different type",
+		log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+	return false, nil
 }
 
 func (p *boolean) validateUniqueness(


### PR DESCRIPTION
### Purpose
Boolean schema properties only accepted native Go bool values during validation. When a boolean attribute was submitted as a string (e.g. from a JSON payload where the value was serialized as "true" or "false"), validation incorrectly rejected it. This fix allows boolean properties to accept both native booleans and the string representations "true" and "false".

### Approach
Updated validateValue on the boolean property type to use a type switch. Native bool values pass as before; strings are accepted only if they are exactly "true" or "false". All other types (numbers, arbitrary strings, nil) are rejected with a debug log, unchanged from prior behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced boolean schema validation to accept string representations "true" and "false" in addition to native boolean values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->