### PR TITLE
Improve application export: omit client secret for public clients, emit env values with JSON array support

### DIFF
--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -232,6 +232,31 @@ func (e *applicationExporter) GetResourceRules() *declarativeresource.ResourceRu
 	}
 }
 
+// GetResourceRulesForResource returns parameterization rules tailored to the specific application
+// instance. Public clients do not have a client secret, so the ClientSecret variable is excluded
+// from their export to avoid injecting an empty or invalid placeholder into the YAML template.
+func (e *applicationExporter) GetResourceRulesForResource(resource interface{}) *declarativeresource.ResourceRules {
+	app, ok := resource.(*model.Application)
+	if !ok {
+		return e.GetResourceRules()
+	}
+
+	for _, inbound := range app.InboundAuthConfig {
+		if inbound.OAuthAppConfig != nil && inbound.OAuthAppConfig.PublicClient {
+			return &declarativeresource.ResourceRules{
+				Variables: []string{
+					"InboundAuthConfig[].OAuthAppConfig.ClientID",
+				},
+				ArrayVariables: []string{
+					"InboundAuthConfig[].OAuthAppConfig.RedirectURIs",
+				},
+			}
+		}
+	}
+
+	return e.GetResourceRules()
+}
+
 // makeAppDeclarativeConfig creates the declarative loader config for loading application
 // identity data into the entity file store.
 func makeAppDeclarativeConfig(appService ApplicationServiceInterface) entity.DeclarativeLoaderConfig {

--- a/backend/internal/application/declarative_resource_test.go
+++ b/backend/internal/application/declarative_resource_test.go
@@ -180,3 +180,64 @@ func (s *ApplicationExporterTestSuite) TestValidateResource_EmptyName() {
 	assert.Equal(s.T(), "APP_VALIDATION_ERROR", err.Code)
 	assert.Contains(s.T(), err.Error, "name is empty")
 }
+
+func (s *ApplicationExporterTestSuite) TestGetResourceRulesForResource_PublicClient() {
+	pr, ok := s.exporter.(declarativeresource.PerResourceRuler)
+	assert.True(s.T(), ok, "exporter should implement PerResourceRuler")
+
+	app := &model.Application{
+		ID:   "app1",
+		Name: "Public App",
+		InboundAuthConfig: []model.InboundAuthConfigComplete{
+			{
+				OAuthAppConfig: &model.OAuthAppConfigComplete{
+					ClientID:     "client-id-1",
+					PublicClient: true,
+				},
+			},
+		},
+	}
+
+	rules := pr.GetResourceRulesForResource(app)
+
+	assert.NotNil(s.T(), rules)
+	assert.Contains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientID")
+	assert.NotContains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientSecret")
+	assert.Contains(s.T(), rules.ArrayVariables, "InboundAuthConfig[].OAuthAppConfig.RedirectURIs")
+}
+
+func (s *ApplicationExporterTestSuite) TestGetResourceRulesForResource_ConfidentialClient() {
+	pr, ok := s.exporter.(declarativeresource.PerResourceRuler)
+	assert.True(s.T(), ok, "exporter should implement PerResourceRuler")
+
+	app := &model.Application{
+		ID:   "app2",
+		Name: "Confidential App",
+		InboundAuthConfig: []model.InboundAuthConfigComplete{
+			{
+				OAuthAppConfig: &model.OAuthAppConfigComplete{
+					ClientID:     "client-id-2",
+					PublicClient: false,
+				},
+			},
+		},
+	}
+
+	rules := pr.GetResourceRulesForResource(app)
+
+	assert.NotNil(s.T(), rules)
+	assert.Contains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientID")
+	assert.Contains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientSecret")
+	assert.Contains(s.T(), rules.ArrayVariables, "InboundAuthConfig[].OAuthAppConfig.RedirectURIs")
+}
+
+func (s *ApplicationExporterTestSuite) TestGetResourceRulesForResource_NonApplicationType() {
+	pr, ok := s.exporter.(declarativeresource.PerResourceRuler)
+	assert.True(s.T(), ok, "exporter should implement PerResourceRuler")
+
+	rules := pr.GetResourceRulesForResource("not-an-application")
+
+	assert.NotNil(s.T(), rules)
+	assert.Contains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientID")
+	assert.Contains(s.T(), rules.Variables, "InboundAuthConfig[].OAuthAppConfig.ClientSecret")
+}

--- a/backend/internal/application/model/oauth_app.go
+++ b/backend/internal/application/model/oauth_app.go
@@ -46,7 +46,7 @@ type OAuthAppConfig struct {
 // OAuthAppConfigComplete represents the complete structure for OAuth application configuration.
 type OAuthAppConfigComplete struct {
 	ClientID                           string                              `json:"clientId" yaml:"client_id"`
-	ClientSecret                       string                              `json:"clientSecret,omitempty" yaml:"client_secret"`
+	ClientSecret                       string                              `json:"clientSecret,omitempty" yaml:"client_secret,omitempty"`
 	RedirectURIs                       []string                            `json:"redirectUris" yaml:"redirect_uris"`
 	GrantTypes                         []oauth2const.GrantType             `json:"grantTypes" yaml:"grant_types"`
 	ResponseTypes                      []oauth2const.ResponseType          `json:"responseTypes" yaml:"response_types"`

--- a/backend/internal/system/declarative_resource/exporter.go
+++ b/backend/internal/system/declarative_resource/exporter.go
@@ -56,6 +56,14 @@ type ResourceExporter interface {
 	GetResourceRules() *ResourceRules
 }
 
+// PerResourceRuler is an optional interface that an exporter can implement to provide
+// resource-instance-specific parameterization rules. When implemented, the export service
+// will call GetResourceRulesForResource instead of GetResourceRules, allowing the exporter
+// to tailor rules based on the resource's own data (e.g. omit client_secret for public clients).
+type PerResourceRuler interface {
+	GetResourceRulesForResource(resource interface{}) *ResourceRules
+}
+
 // ExportError represents errors that occurred during export.
 type ExportError struct {
 	ResourceType string `json:"resourceType"`

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -55,10 +55,11 @@ func newParameterizer(rules templatingRules) *parameterizer {
 	return &parameterizer{rules: rules}
 }
 
-// ToParameterizedYAML converts an object directly to parameterized YAML
-// This is the easiest method when you already have the object
+// ToParameterizedYAML converts an object directly to parameterized YAML.
+// It returns the template string and a map of variable names to their original values.
 func (p *parameterizer) ToParameterizedYAML(obj interface{},
-	resourceType string, resourceName string, rules *declarativeresource.ResourceRules) (string, error) {
+	resourceType string, resourceName string,
+	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
 	// Convert imported type to local type for compatibility
 	var localRules *resourceRules
 	if rules != nil {
@@ -73,7 +74,7 @@ func (p *parameterizer) ToParameterizedYAML(obj interface{},
 	// Pass rules so fields in parameterization rules bypass omitempty
 	var node yaml.Node
 	if err := p.structToNodeIgnoringOmitempty(obj, &node, localRules, "", resourceName); err != nil {
-		return "", fmt.Errorf("failed to convert object to node: %w", err)
+		return "", nil, fmt.Errorf("failed to convert object to node: %w", err)
 	}
 
 	if localRules == nil {
@@ -82,31 +83,238 @@ func (p *parameterizer) ToParameterizedYAML(obj interface{},
 		encoder := yaml.NewEncoder(&buf)
 		encoder.SetIndent(2)
 		if err := encoder.Encode(&node); err != nil {
-			return "", fmt.Errorf("failed to marshal data: %w", err)
+			return "", nil, fmt.Errorf("failed to marshal data: %w", err)
 		}
 		err := encoder.Close()
 		if err != nil {
-			return "", fmt.Errorf("failed to close encoder: %w", err)
+			return "", nil, fmt.Errorf("failed to close encoder: %w", err)
 		}
-		return buf.String(), nil
+		return buf.String(), nil, nil
 	}
 
 	// Convert struct field paths to YAML field paths
 	rulesWithYAMLPaths := p.convertStructPathsToYAMLPaths(obj, localRules)
 
+	// Capture original values before parameterization replaces them.
+	// Dynamic property values must be extracted from the original struct here because
+	// structToNodeIgnoringOmitempty already baked template placeholders into their nodes.
+	variableValues := p.extractValuesFromNode(&node, rulesWithYAMLPaths, resourceName)
+	for k, v := range p.extractDynamicPropertyValues(obj, localRules, resourceName) {
+		variableValues[k] = v
+	}
+
 	// Apply parameterization to the node tree
 	if err := p.parameterizeNode(&node, rulesWithYAMLPaths, resourceName); err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Marshal back to YAML with preserved indentation
 	// Use custom renderer to handle template syntax properly
 	var buf bytes.Buffer
 	if err := p.renderNode(&buf, &node, 0); err != nil {
-		return "", fmt.Errorf("failed to render parameterized YAML: %w", err)
+		return "", nil, fmt.Errorf("failed to render parameterized YAML: %w", err)
 	}
 
-	return buf.String(), nil
+	return buf.String(), variableValues, nil
+}
+
+// extractValuesFromNode reads the original values of parameterization variables from the node
+// tree before they are replaced with template placeholders.
+func (p *parameterizer) extractValuesFromNode(
+	node *yaml.Node, rules *resourceRules, resourceName string,
+) map[string]string {
+	values := make(map[string]string)
+	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+		return values
+	}
+	root := node.Content[0]
+
+	for _, path := range rules.Variables {
+		varName := p.pathToVariableName(resourceName, path)
+		if val := p.getScalarFromNode(root, path); val != "" {
+			values[varName] = val
+		}
+	}
+
+	for _, path := range rules.ArrayVariables {
+		varName := p.pathToVariableName(resourceName, path)
+		if vals := p.getArrayFromNode(root, path); vals != nil {
+			jsonBytes, err := json.Marshal(vals)
+			if err == nil {
+				values[varName] = string(jsonBytes)
+			}
+		}
+	}
+
+	return values
+}
+
+// extractDynamicPropertyValues reads actual property values from the original struct before
+// structToNodeIgnoringOmitempty converts them to template placeholders.
+// It navigates each DynamicPropertyFields path, iterates the []cmodels.Property slice found
+// there, and maps generatePropertyVarName(resourceName, propName) → actual value.
+func (p *parameterizer) extractDynamicPropertyValues(
+	obj interface{}, rules *resourceRules, resourceName string,
+) map[string]string {
+	values := make(map[string]string)
+	if rules == nil || len(rules.DynamicPropertyFields) == 0 {
+		return values
+	}
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return values
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return values
+	}
+
+	for _, fieldPath := range rules.DynamicPropertyFields {
+		field, found := p.findFieldByNameCaseInsensitive(v.Type(), fieldPath)
+		if !found {
+			continue
+		}
+		fieldVal := v.FieldByName(field.Name)
+		if !fieldVal.IsValid() || fieldVal.Kind() != reflect.Slice {
+			continue
+		}
+
+		for i := 0; i < fieldVal.Len(); i++ {
+			propVal := fieldVal.Index(i)
+			if propVal.CanAddr() {
+				propVal = propVal.Addr()
+			}
+
+			nameMethod := propVal.MethodByName("GetName")
+			if !nameMethod.IsValid() {
+				continue
+			}
+			nameResults := nameMethod.Call(nil)
+			if len(nameResults) == 0 {
+				continue
+			}
+			propName := nameResults[0].String()
+
+			valueMethod := propVal.MethodByName("GetValue")
+			if !valueMethod.IsValid() {
+				continue
+			}
+			valueResults := valueMethod.Call(nil)
+			// GetValue returns (string, error); skip on error
+			if len(valueResults) < 2 || !valueResults[1].IsNil() {
+				continue
+			}
+			propValue := valueResults[0].String()
+
+			varName := p.generatePropertyVarName(resourceName, propName)
+			values[varName] = propValue
+		}
+	}
+
+	return values
+}
+
+// getScalarFromNode traverses the YAML node tree and returns the scalar value at the given path.
+// Returns an empty string when the path does not exist or the target is not a scalar.
+func (p *parameterizer) getScalarFromNode(node *yaml.Node, path string) string {
+	parts := strings.Split(path, ".")
+	current := node
+
+	for i, part := range parts {
+		isArrayAccess := strings.HasSuffix(part, "[]")
+		fieldName := strings.TrimSuffix(part, "[]")
+
+		if current.Kind != yaml.MappingNode {
+			return ""
+		}
+
+		found := false
+		for j := 0; j < len(current.Content); j += 2 {
+			if current.Content[j].Value != fieldName {
+				continue
+			}
+			valueNode := current.Content[j+1]
+			if isArrayAccess {
+				if valueNode.Kind == yaml.SequenceNode && i < len(parts)-1 {
+					remainingPath := strings.Join(parts[i+1:], ".")
+					for _, elem := range valueNode.Content {
+						if val := p.getScalarFromNode(elem, remainingPath); val != "" {
+							return val
+						}
+					}
+				}
+				return ""
+			}
+			if i == len(parts)-1 {
+				if valueNode.Kind == yaml.ScalarNode {
+					return valueNode.Value
+				}
+				return ""
+			}
+			current = valueNode
+			found = true
+			break
+		}
+		if !found {
+			return ""
+		}
+	}
+	return ""
+}
+
+// getArrayFromNode traverses the YAML node tree and returns the values of the sequence at the
+// given path. Returns nil when the path does not exist or the target is not a sequence.
+func (p *parameterizer) getArrayFromNode(node *yaml.Node, path string) []string {
+	parts := strings.Split(path, ".")
+	current := node
+
+	for i, part := range parts {
+		isArrayAccess := strings.HasSuffix(part, "[]")
+		fieldName := strings.TrimSuffix(part, "[]")
+
+		if current.Kind != yaml.MappingNode {
+			return nil
+		}
+
+		for j := 0; j < len(current.Content); j += 2 {
+			if current.Content[j].Value != fieldName {
+				continue
+			}
+			valueNode := current.Content[j+1]
+			if isArrayAccess {
+				if valueNode.Kind == yaml.SequenceNode && i < len(parts)-1 {
+					remainingPath := strings.Join(parts[i+1:], ".")
+					var results []string
+					for _, elem := range valueNode.Content {
+						results = append(results, p.getArrayFromNode(elem, remainingPath)...)
+					}
+					return results
+				}
+				return nil
+			}
+			if i == len(parts)-1 {
+				if valueNode.Kind == yaml.SequenceNode {
+					vals := make([]string, 0)
+					for _, elem := range valueNode.Content {
+						if elem.Kind == yaml.ScalarNode && elem.Value != "" {
+							vals = append(vals, elem.Value)
+						}
+					}
+					return vals
+				}
+				if valueNode.Kind == yaml.ScalarNode && valueNode.Value != "" {
+					return []string{valueNode.Value}
+				}
+				return nil
+			}
+			current = valueNode
+			break
+		}
+	}
+	return nil
 }
 
 // structToNodeIgnoringOmitempty converts a struct to yaml.Node while preserving field order

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -226,7 +226,9 @@ func (p *parameterizer) isFieldInRules(rules *resourceRules, fieldPath string) b
 
 	// Check Variables
 	for _, varPath := range rules.Variables {
-		normalizedVarPath := strings.ToLower(varPath)
+		// Strip [] slice notation before comparing: rules use "Foo[].Bar" but traversal
+		// produces "Foo.Bar" (index not tracked in path).
+		normalizedVarPath := strings.ToLower(strings.ReplaceAll(varPath, "[]", ""))
 		if normalizedVarPath == normalizedPath {
 			return true
 		}
@@ -234,7 +236,7 @@ func (p *parameterizer) isFieldInRules(rules *resourceRules, fieldPath string) b
 
 	// Check ArrayVariables
 	for _, arrPath := range rules.ArrayVariables {
-		normalizedArrPath := strings.ToLower(arrPath)
+		normalizedArrPath := strings.ToLower(strings.ReplaceAll(arrPath, "[]", ""))
 		if normalizedArrPath == normalizedPath {
 			return true
 		}

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -84,7 +84,7 @@ func TestToParameterizedYAML_WithOmitemptyFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestToParameterizedYAML_MixedEmptyAndPopulated(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -317,7 +317,7 @@ func TestOmitempty_EmptyFieldsWithoutRules(t *testing.T) {
 
 	// No parameterization rules - omitempty should work normally
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -344,7 +344,7 @@ func TestOmitempty_EmptyArraysOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "grantTypes:", "Empty GrantTypes array should be omitted")
@@ -362,7 +362,7 @@ func TestOmitempty_NilSlicesOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "grantTypes:", "Nil GrantTypes should be omitted")
@@ -377,7 +377,7 @@ func TestOmitempty_NilPointersOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "oauth:", "Nil OAuth pointer should be omitted")
@@ -407,7 +407,7 @@ func TestParameterization_OverridesOmitemptyForVariables(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -437,7 +437,7 @@ func TestParameterization_OverridesOmitemptyForArrays(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -470,7 +470,7 @@ func TestParameterization_NestedFieldsWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -507,7 +507,7 @@ func TestParameterization_MixedRulesAndOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -547,7 +547,7 @@ func TestFieldOrder_TopLevelFieldsPreserved(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -575,7 +575,7 @@ func TestFieldOrder_WithOmittedFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -617,7 +617,7 @@ func TestFieldOrder_NestedFieldsPreserved(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -677,7 +677,7 @@ func TestEdgeCase_DeeplyNestedStructures(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, result, "level1:")
@@ -709,7 +709,7 @@ func TestEdgeCase_ArraysOfStructs(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, result, "items:")
@@ -732,7 +732,7 @@ func TestEdgeCase_EmptyStructWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -799,7 +799,7 @@ func TestIsEmptyValue_IntegerTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -822,7 +822,7 @@ func TestIsEmptyValue_UnsignedIntegerTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -842,7 +842,7 @@ func TestIsEmptyValue_FloatTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -858,7 +858,7 @@ func TestIsEmptyValue_BoolType(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -877,7 +877,7 @@ func TestIsEmptyValue_NonZeroValues(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1029,7 +1029,7 @@ func TestRenderNode_ComplexTemplateStructures(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1052,7 +1052,7 @@ func TestRenderNode_ArrayOfMaps(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1071,7 +1071,7 @@ func TestToParameterizedYAML_NilRules(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -1094,7 +1094,7 @@ func TestToParameterizedYAML_NilRulesWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1144,7 +1144,7 @@ func TestRenderNode_NestedArraysInSequence(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1164,7 +1164,7 @@ func TestFieldToNode_NilPointer(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1188,7 +1188,7 @@ func TestConvertPathToYAMLPath_NonStructType(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1211,7 +1211,7 @@ func TestFindFieldByNameCaseInsensitive_NotFound(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1230,7 +1230,7 @@ func TestToParameterizedYAML_InvalidStruct(t *testing.T) {
 	// Pass non-struct type
 	var notAStruct int = 42
 
-	_, err := p.ToParameterizedYAML(notAStruct, "Application", "Test", nil)
+	_, _, err := p.ToParameterizedYAML(notAStruct, "Application", "Test", nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to convert object to node")
@@ -1643,7 +1643,7 @@ func TestToParameterizedYAML_JSONRawMessageInvalid(t *testing.T) {
 	}
 
 	// Should return an error
-	result, err := p.ToParameterizedYAML(schema, "UserSchema", "TestSchema", nil)
+	result, _, err := p.ToParameterizedYAML(schema, "UserSchema", "TestSchema", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid JSON in RawMessage")
@@ -1675,7 +1675,7 @@ func TestToParameterizedYAML_NestedStructWithInvalidJSON(t *testing.T) {
 	}
 
 	// Should return an error from the nested structure
-	result, err := p.ToParameterizedYAML(obj, "Config", "TestConfig", nil)
+	result, _, err := p.ToParameterizedYAML(obj, "Config", "TestConfig", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid JSON in RawMessage")
@@ -1720,7 +1720,7 @@ func TestUserSchemaImportExportSymmetry(t *testing.T) {
 
 	// Export using the parameterizer
 	p := newParameterizer(templatingRules{})
-	yamlOutput, err := p.ToParameterizedYAML(originalSchema, "UserSchema", "Person", nil)
+	yamlOutput, _, err := p.ToParameterizedYAML(originalSchema, "UserSchema", "Person", nil)
 	require.NoError(t, err)
 
 	t.Logf("Exported YAML:\n%s", yamlOutput)
@@ -1782,7 +1782,7 @@ func TestUserSchemaExportFormat(t *testing.T) {
 	}
 
 	p := newParameterizer(templatingRules{})
-	yamlOutput, err := p.ToParameterizedYAML(schema, "UserSchema", "TestSchema", nil)
+	yamlOutput, _, err := p.ToParameterizedYAML(schema, "UserSchema", "TestSchema", nil)
 	require.NoError(t, err)
 
 	// Verify the schema field is a plain string in the YAML, not a structured object

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -319,8 +319,14 @@ func (es *exportService) exportResourcesWithExporter(
 
 func (es *exportService) generateTemplateFromStruct(data interface{},
 	paramResourceType string, resourceName string, exporter declarativeresource.ResourceExporter) (string, error) {
+	var rules *declarativeresource.ResourceRules
+	if pr, ok := exporter.(declarativeresource.PerResourceRuler); ok {
+		rules = pr.GetResourceRulesForResource(data)
+	} else {
+		rules = exporter.GetResourceRules()
+	}
 	template, err := es.parameterizer.ToParameterizedYAML(
-		data, paramResourceType, resourceName, exporter.GetResourceRules())
+		data, paramResourceType, resourceName, rules)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -57,7 +57,8 @@ const (
 // parameterizerInterface defines the interface for template parameterization.
 type parameterizerInterface interface {
 	ToParameterizedYAML(obj interface{},
-		resourceType string, resourceName string, rules *declarativeresource.ResourceRules) (string, error)
+		resourceType string, resourceName string,
+		rules *declarativeresource.ResourceRules) (string, map[string]string, error)
 }
 
 // ExportServiceInterface defines the interface for the export service.
@@ -111,6 +112,7 @@ func (es *exportService) ExportResources(
 
 	var exportFiles []ExportFile
 	var exportErrors []declarativeresource.ExportError
+	allVariables := make(map[string]string)
 	resourceCounts := make(map[string]int)
 
 	// Map resource types to their IDs from the request
@@ -140,8 +142,11 @@ func (es *exportService) ExportResources(
 			continue
 		}
 
-		files, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options)
+		files, vars, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options)
 		exportFiles = append(exportFiles, files...)
+		for k, v := range vars {
+			allVariables[k] = v
+		}
 		exportErrors = append(exportErrors, errors...)
 		resourceCounts[resourceType] = len(files)
 	}
@@ -160,7 +165,7 @@ func (es *exportService) ExportResources(
 		totalSize += exportFiles[i].Size
 	}
 
-	envFile := es.generateEnvFile(exportFiles)
+	envFile := es.generateEnvFile(exportFiles, allVariables)
 
 	totalFilesCount := len(exportFiles)
 	if envFile != nil {
@@ -183,8 +188,9 @@ func (es *exportService) ExportResources(
 	}, nil
 }
 
-// generateEnvFile extracts template variable names and builds a .env payload.
-func (es *exportService) generateEnvFile(files []ExportFile) *EnvironmentFile {
+// generateEnvFile extracts template variable names from exported files and builds a .env
+// payload, populating each entry with its original value where available.
+func (es *exportService) generateEnvFile(files []ExportFile, variables map[string]string) *EnvironmentFile {
 	variablesSet := make(map[string]struct{})
 
 	for _, file := range files {
@@ -203,16 +209,18 @@ func (es *exportService) generateEnvFile(files []ExportFile) *EnvironmentFile {
 		return nil
 	}
 
-	variables := make([]string, 0, len(variablesSet))
-	for variable := range variablesSet {
-		variables = append(variables, variable)
+	varNames := make([]string, 0, len(variablesSet))
+	for varName := range variablesSet {
+		varNames = append(varNames, varName)
 	}
-	sort.Strings(variables)
+	sort.Strings(varNames)
 
 	var contentBuilder strings.Builder
-	for _, variable := range variables {
-		contentBuilder.WriteString(variable)
-		contentBuilder.WriteString("=\n")
+	for _, varName := range varNames {
+		contentBuilder.WriteString(varName)
+		contentBuilder.WriteString("=")
+		contentBuilder.WriteString(variables[varName])
+		contentBuilder.WriteString("\n")
 	}
 
 	content := contentBuilder.String()
@@ -229,11 +237,12 @@ func (es *exportService) exportResourcesWithExporter(
 	exporter declarativeresource.ResourceExporter,
 	resourceIDs []string,
 	options *ExportOptions,
-) ([]ExportFile, []declarativeresource.ExportError) {
+) ([]ExportFile, map[string]string, []declarativeresource.ExportError) {
 	logger := log.GetLogger().With(log.String("component", "ExportService"))
 	resourceType := exporter.GetResourceType()
 	exportFiles := make([]ExportFile, 0, len(resourceIDs))
 	exportErrors := make([]declarativeresource.ExportError, 0, len(resourceIDs))
+	variableValues := make(map[string]string)
 	var resourceIDList []string
 	if len(resourceIDs) == 1 && resourceIDs[0] == "*" {
 		// Export all resources
@@ -241,7 +250,7 @@ func (es *exportService) exportResourcesWithExporter(
 		if err != nil {
 			logger.Warn("Failed to get all resources",
 				log.String("resourceType", resourceType), log.Any("error", err))
-			return []ExportFile{}, []declarativeresource.ExportError{}
+			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}
 		}
 		resourceIDList = ids
 	} else {
@@ -282,7 +291,7 @@ func (es *exportService) exportResourcesWithExporter(
 			options.Format = formatYAML
 		}
 
-		templateContent, err := es.generateTemplateFromStruct(
+		templateContent, vars, err := es.generateTemplateFromStruct(
 			resource, exporter.GetParameterizerType(), validatedName, exporter)
 		if err != nil {
 			logger.Warn("Failed to generate template from struct",
@@ -296,6 +305,9 @@ func (es *exportService) exportResourcesWithExporter(
 				Code:         "TemplateGenerationError",
 			})
 			continue
+		}
+		for k, v := range vars {
+			variableValues[k] = v
 		}
 		content = addResourceTypeComment(templateContent, resourceType)
 
@@ -314,23 +326,24 @@ func (es *exportService) exportResourcesWithExporter(
 		exportFiles = append(exportFiles, exportFile)
 	}
 
-	return exportFiles, exportErrors
+	return exportFiles, variableValues, exportErrors
 }
 
 func (es *exportService) generateTemplateFromStruct(data interface{},
-	paramResourceType string, resourceName string, exporter declarativeresource.ResourceExporter) (string, error) {
+	paramResourceType string, resourceName string,
+	exporter declarativeresource.ResourceExporter) (string, map[string]string, error) {
 	var rules *declarativeresource.ResourceRules
 	if pr, ok := exporter.(declarativeresource.PerResourceRuler); ok {
 		rules = pr.GetResourceRulesForResource(data)
 	} else {
 		rules = exporter.GetResourceRules()
 	}
-	template, err := es.parameterizer.ToParameterizedYAML(
+	template, vars, err := es.parameterizer.ToParameterizedYAML(
 		data, paramResourceType, resourceName, rules)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return template, nil
+	return template, vars, nil
 }
 
 func addResourceTypeComment(content, resourceType string) string {

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -277,9 +277,10 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 	assert.Contains(suite.T(), file.Content, "{{- range .O_AUTH_TEST_APP_REDIRECT_URIS}}")
 	assert.NotNil(suite.T(), result.EnvFile)
 	assert.Equal(suite.T(), ".env", result.EnvFile.FileName)
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_ID=\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_ID=client123\n")
 	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_SECRET=\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_REDIRECT_URIS=\n")
+	expectedRedirectURIs := "O_AUTH_TEST_APP_REDIRECT_URIS=[\"http://localhost:3000/callback\"]\n"
+	assert.Contains(suite.T(), result.EnvFile.Content, expectedRedirectURIs)
 
 	assert.Equal(suite.T(), 1, result.Summary.ResourceTypes["application"])
 	assert.Equal(suite.T(), int64(len(file.Content)), file.Size)
@@ -1150,12 +1151,13 @@ type MockParameterizer struct {
 }
 
 func (m *MockParameterizer) ToParameterizedYAML(obj interface{},
-	resourceType string, resourceName string, rules *declarativeresource.ResourceRules) (string, error) {
+	resourceType string, resourceName string,
+	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
 	if m.shouldFail {
-		return "", fmt.Errorf("%s", m.errorMsg)
+		return "", nil, fmt.Errorf("%s", m.errorMsg)
 	}
 	// Return minimal valid YAML
-	return "id: test\nname: test\n", nil
+	return "id: test\nname: test\n", nil, nil
 }
 
 // TestExportResources_TemplateGenerationError tests the error path in generateTemplateFromStruct.
@@ -1803,7 +1805,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 		Format: formatYAML,
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -1812,6 +1814,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 	assert.Equal(suite.T(), resourceTypeApplication, files[0].ResourceType)
 	assert.Equal(suite.T(), appID, files[0].ResourceID)
 	assert.Contains(suite.T(), files[0].Content, "name: Test Application")
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_MultipleResources tests exporting multiple resources.
@@ -1845,7 +1848,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{app1ID, app2ID, app3ID}, options)
 
 	assert.Len(suite.T(), files, 3)
@@ -1853,6 +1856,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	assert.Equal(suite.T(), "Application_One.yaml", files[0].FileName)
 	assert.Equal(suite.T(), "Application_Two.yaml", files[1].FileName)
 	assert.Equal(suite.T(), "Application_Three.yaml", files[2].FileName)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_ResourceNotFound tests when a resource is not found.
@@ -1868,7 +1872,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -1877,6 +1881,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	assert.Equal(suite.T(), appID, errors[0].ResourceID)
 	assert.Equal(suite.T(), "APP_NOT_FOUND", errors[0].Code)
 	assert.Equal(suite.T(), "Application not found", errors[0].Error)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_PartialSuccess tests when some resources succeed and some fail.
@@ -1901,7 +1906,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{validAppID, invalidAppID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -1909,6 +1914,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	assert.Equal(suite.T(), "Valid_Application.yaml", files[0].FileName)
 	assert.Equal(suite.T(), resourceTypeApplication, errors[0].ResourceType)
 	assert.Equal(suite.T(), invalidAppID, errors[0].ResourceID)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WildcardSuccess tests wildcard export.
@@ -1941,13 +1947,14 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardSuc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
 	assert.Equal(suite.T(), "App_One.yaml", files[0].FileName)
 	assert.Equal(suite.T(), "App_Two.yaml", files[1].FileName)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WildcardFailure tests wildcard when GetAllResourceIDs fails.
@@ -1962,11 +1969,12 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFai
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Returns empty slices on wildcard failure
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WildcardEmptyList tests wildcard with no resources.
@@ -1982,11 +1990,12 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardEmp
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WithGroupByType tests export with GroupByType option.
@@ -2008,12 +2017,13 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithGroupBy
 		},
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
 	assert.Equal(suite.T(), "applications", files[0].FolderPath)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WithCustomFileNaming tests export with custom file naming pattern.
@@ -2035,12 +2045,13 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithCustomF
 		},
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
 	assert.Equal(suite.T(), "My_Application_app-123.yaml", files[0].FileName)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_IdentityProvider tests export with IDP exporter.
@@ -2059,7 +2070,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{idpID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2067,6 +2078,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 	assert.Equal(suite.T(), "Test_IDP.yaml", files[0].FileName)
 	assert.Equal(suite.T(), resourceTypeIdentityProvider, files[0].ResourceType)
 	assert.Equal(suite.T(), idpID, files[0].ResourceID)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_NotificationSender tests export with notification sender exporter.
@@ -2087,7 +2099,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{senderID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2095,6 +2107,8 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 	assert.Equal(suite.T(), "Test_Sender.yaml", files[0].FileName)
 	assert.Equal(suite.T(), resourceTypeNotificationSender, files[0].ResourceType)
 	assert.Equal(suite.T(), senderID, files[0].ResourceID)
+	assert.NotEmpty(suite.T(), variables)
+	assert.Equal(suite.T(), "key1", variables["TEST_SENDER_API_KEY"])
 }
 
 // TestExportResourcesWithExporter_UserSchema tests export with user schema exporter.
@@ -2115,7 +2129,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_UserSchema(
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{schemaID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2123,6 +2137,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_UserSchema(
 	assert.Equal(suite.T(), "Test_Schema.yaml", files[0].FileName)
 	assert.Equal(suite.T(), resourceTypeUserSchema, files[0].ResourceType)
 	assert.Equal(suite.T(), schemaID, files[0].ResourceID)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_EmptyResourceIDs tests export with empty resource ID list.
@@ -2130,11 +2145,12 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EmptyResour
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{}, options)
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_JSONFormatFallback tests that JSON format falls back to YAML.
@@ -2153,7 +2169,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 		Format: formatJSON, // JSON not yet implemented
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2161,6 +2177,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 	// Should fall back to YAML format
 	assert.Equal(suite.T(), "Test_App.yaml", files[0].FileName)
 	assert.Contains(suite.T(), files[0].Content, "name: Test App")
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_Flow tests export with flow exporter.
@@ -2198,7 +2215,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2208,6 +2225,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 	assert.Equal(suite.T(), flowID, files[0].ResourceID)
 	assert.Contains(suite.T(), files[0].Content, "handle: basic-auth-flow")
 	assert.Contains(suite.T(), files[0].Content, "flowType: AUTHENTICATION")
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_FlowWithComplexMeta tests export with flow containing complex meta.
@@ -2292,7 +2310,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2302,6 +2320,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 	assert.Contains(suite.T(), files[0].Content, "meta:")
 	// Meta should be present in some form (either as JSON string or YAML structure)
 	assert.Contains(suite.T(), files[0].Content, "prompt")
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_MultipleFlows tests exporting multiple flows.
@@ -2337,13 +2356,14 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{testFlow1ID, testFlow2ID}, options)
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
 	assert.Equal(suite.T(), "Flow_One.yaml", files[0].FileName)
 	assert.Equal(suite.T(), "Flow_Two.yaml", files[1].FileName)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_FlowNotFound tests export when flow is not found.
@@ -2358,7 +2378,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -2366,6 +2386,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	assert.Equal(suite.T(), "flow", errors[0].ResourceType)
 	assert.Equal(suite.T(), flowID, errors[0].ResourceID)
 	assert.Contains(suite.T(), errors[0].Error, "Flow not found")
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WildcardFlows tests wildcard export for flows.
@@ -2423,11 +2444,12 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResourcesWithExporter_WildcardFlows_ListFailure tests wildcard when ListFlows fails.
@@ -2441,11 +2463,12 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
+	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Empty list on error
+	assert.Empty(suite.T(), variables)
 }
 
 // TestExportResources_FlowOnly tests exporting only flows via main ExportResources method.


### PR DESCRIPTION
### Purpose

This PR improves the application resource export in two areas:

1. **Public client secret leak** — Previously, the export included `client_secret` for public OAuth applications. Public clients do not use a client secret, so exporting it would cause import failures. The fix omits `client_secret` from the parameterization rules when the application is a public client.

2. **Empty `.env` values** — The generated `.env` file previously had blank values (`VAR=`). The export now captures actual field values and writes them into the `.env` file so it is immediately usable after export.

### Approach

- Added a `PerResourceRuler` optional interface to `declarative_resource/exporter.go`. When an exporter implements it, the export service calls `GetResourceRulesForResource(resource)` instead of the static `GetResourceRules()`, allowing per-instance rule customisation.
- `applicationExporter` implements `PerResourceRuler`: when any inbound OAuth config has `PublicClient: true`, it returns rules that exclude `ClientID` and include `RedirectURIs` but omit `ClientSecret`.
- Fixed `yaml:"client_secret,omitempty"` tag on `OAuthAppConfigComplete.ClientSecret` so the field is omitted from YAML output when empty.
- `ToParameterizedYAML` now returns `(string, map[string]string, error)`. Before template substitution, `extractValuesFromNode` walks the YAML AST and captures original scalar and array values keyed by variable name.
- Array values are marshalled with `json.Marshal` to produce a JSON array string in the `.env` file.
- `generateEnvFile` now accepts the variable values map and writes `KEY=value\n` lines.
- Fixed `isFieldInRules` to strip `[]` from rule paths before comparison, preventing array path rules from being silently skipped.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2497
- https://github.com/asgardeo/thunder/issues/1438

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesnt commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exports now tailor which OAuth credentials are included per application: public clients omit client secrets from YAML exports and relevant values are emitted into the generated .env file.
  * Export pipeline now returns and aggregates template variable values so .env entries contain concrete values.

* **Tests**
  * Added tests covering public vs confidential OAuth export behavior and .env generation of exported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->