### PR TITLE
Remove unwanted Thunder references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Thunder is a lightweight user and identity management product. Go backend + Reac
 - For build and running - [Makefile](Makefile) and [README.md](README.md)
 - Documentation at [docs/content](docs/content)
 
-Thunder's login gate leverages v2 of the [Asgardeo JavaScript SDK](https://github.com/asgardeo/javascript), consumed via its published package in typical setups.
-Clone the SDK repository only if you are developing or debugging the SDK itself, or testing Thunder against unreleased SDK changes.
+Login Gate leverages v2 of the [Asgardeo JavaScript SDK](https://github.com/asgardeo/javascript), consumed via its published package in typical setups.
+Clone the SDK repository only if you are developing or debugging the SDK itself, or testing the product against unreleased SDK changes.
 
 ## General Rules
 
@@ -38,7 +38,7 @@ Clone the SDK repository only if you are developing or debugging the SDK itself,
 
 ## Agent Skills
 
-- [Thunder Console Navigator](.agent/skills/console/SKILL.md) — Browse and interact with the Thunder Console UI using `playwright-cli`. Use when asked to navigate the console, test UI changes, or create/edit resources through the browser.
+- [Console Navigator](.agent/skills/console/SKILL.md) — Browse and interact with the Console UI using `playwright-cli`. Use when asked to navigate the console, test UI changes, or create/edit resources through the browser.
 
 ## Contributing Guidelines
 

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -119,7 +119,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_BasicToke
 	claims := map[string]interface{}{
 		"sub":   "user123",
 		"iss":   "https://thunder.io",
-		"aud":   defaultAudience, // Use default audience for Thunder issuer
+		"aud":   defaultAudience, // Use default audience for the issuer
 		"exp":   float64(now + 3600),
 		"nbf":   float64(now - 60),
 		"scope": "read write",
@@ -171,7 +171,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithoutNb
 	claims := map[string]interface{}{
 		"sub": "user123",
 		"iss": "https://thunder.io",
-		"aud": defaultAudience, // Use default audience for Thunder issuer
+		"aud": defaultAudience, // Use default audience for the issuer
 		"exp": float64(now + 3600),
 	}
 	token := suite.createTestJWT(claims)
@@ -192,7 +192,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithEmpty
 	claims := map[string]interface{}{
 		"sub": "user123",
 		"iss": "https://thunder.io",
-		"aud": defaultAudience, // Use default audience for Thunder issuer
+		"aud": defaultAudience, // Use default audience for the issuer
 		"exp": float64(now + 3600),
 		// No scope claim
 	}
@@ -459,7 +459,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_DecodeBeforeVerify(
 	claims := map[string]interface{}{
 		"sub": "user123",
 		"iss": "https://thunder.io",
-		"aud": defaultAudience, // Use default audience for Thunder issuer
+		"aud": defaultAudience, // Use default audience for the issuer
 		"exp": float64(now + 3600),
 	}
 	token := suite.createTestJWT(claims)
@@ -593,7 +593,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_EdgeCase_VeryLong
 	largeClaims := map[string]interface{}{
 		"sub":   "user123",
 		"iss":   "https://thunder.io",
-		"aud":   defaultAudience, // Use default audience for Thunder issuer
+		"aud":   defaultAudience, // Use default audience for the issuer
 		"exp":   float64(now + 3600),
 		"large": string(make([]byte, 10000)), // 10KB of data
 	}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
 # Thunder Frontend ⚡
 
 Frontend workspace for **Thunder ⚡** - a modern identity management suite. This workspace is built with
-[Nx](https://nx.dev) and contains React applications and shared packages for the Thunder platform.
+[Nx](https://nx.dev) and contains React applications and shared packages for the platform.

--- a/frontend/packages/thunder-design/src/components/flow/__tests__/AuthCardLayout.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/__tests__/AuthCardLayout.test.tsx
@@ -37,7 +37,7 @@ describe('AuthCardLayout', () => {
   });
 
   describe('variant prop', () => {
-    it('applies Thunder CSS root class when variant is provided', () => {
+    it('applies product prefix CSS root class when variant is provided', () => {
       const {container} = renderWithProviders(
         <AuthCardLayout variant="SignInBox">
           <span>Content</span>
@@ -46,7 +46,7 @@ describe('AuthCardLayout', () => {
       expect(container.querySelector(`.${TEST_CN_PREFIX}SignInBox--root`)).toBeTruthy();
     });
 
-    it('applies Thunder CSS paper class when variant is provided', () => {
+    it('applies product prefix CSS paper class when variant is provided', () => {
       const {container} = renderWithProviders(
         <AuthCardLayout variant="SignInBox">
           <span>Content</span>
@@ -55,7 +55,7 @@ describe('AuthCardLayout', () => {
       expect(container.querySelector(`.${TEST_CN_PREFIX}SignInBox--paper`)).toBeTruthy();
     });
 
-    it('does not apply Thunder CSS classes when variant is not provided', () => {
+    it('does not apply product prefix CSS classes when variant is not provided', () => {
       const {container} = renderWithProviders(
         <AuthCardLayout>
           <span>Content</span>
@@ -80,7 +80,7 @@ describe('AuthCardLayout', () => {
       expect(img).toBeTruthy();
     });
 
-    it('applies Thunder CSS logo class when variant and logo are provided', () => {
+    it('applies product prefix CSS logo class when variant and logo are provided', () => {
       const logo = {
         src: {light: '/logo-light.svg', dark: '/logo-dark.svg'},
       };

--- a/frontend/packages/thunder-design/src/components/flow/__tests__/AuthPageLayout.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/__tests__/AuthPageLayout.test.tsx
@@ -76,7 +76,7 @@ describe('AuthPageLayout', () => {
       expect(main.classList.contains('ThunderSignIn--root')).toBe(true);
     });
 
-    it('does not apply Thunder CSS class when variant is not provided', () => {
+    it('does not apply product prefix CSS class when variant is not provided', () => {
       renderWithProviders(
         <AuthPageLayout isLoading={false}>
           <span>Content</span>

--- a/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/DividerAdapter.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/DividerAdapter.test.tsx
@@ -38,7 +38,7 @@ describe('DividerAdapter', () => {
     expect(screen.getByText('OR')).toBeTruthy();
   });
 
-  it('applies Thunder CSS class names', () => {
+  it('applies product prefix CSS class names', () => {
     const component: FlowComponent = {id: 'div-1', type: 'DIVIDER'};
     renderWithProviders(<DividerAdapter component={component} resolve={(s) => s} />);
     const divider = document.querySelector(`.${TEST_CN_PREFIX}Divider--root`);

--- a/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/TextAdapter.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/TextAdapter.test.tsx
@@ -45,7 +45,7 @@ describe('TextAdapter', () => {
     expect(screen.getByText('Resolved Text')).toBeTruthy();
   });
 
-  it('applies Thunder CSS class names', () => {
+  it('applies product prefix CSS class names', () => {
     renderWithProviders(<TextAdapter component={baseComponent} resolve={(s) => s} />);
     const el = screen.getByText('Hello World');
     expect(el.className).toContain('ThunderFlow--text');

--- a/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/TextInputAdapter.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/adapters/__tests__/TextInputAdapter.test.tsx
@@ -55,7 +55,7 @@ describe('TextInputAdapter', () => {
     expect(input?.getAttribute('type')).toBe('email');
   });
 
-  it('applies Thunder CSS class names', () => {
+  it('applies product prefix CSS class names', () => {
     renderWithProviders(<TextInputAdapter {...baseProps} />);
     const formControl = document.querySelector(`.${TEST_CN_PREFIX}Flow--textInput`);
     expect(formControl).toBeTruthy();

--- a/frontend/packages/thunder-eslint-plugin/README.md
+++ b/frontend/packages/thunder-eslint-plugin/README.md
@@ -38,7 +38,7 @@ export default [
 
 #### `recommended`
 
-General rules for all Thunder frontend projects:
+General rules for all frontend projects:
 
 - `@thunder/copyright-header`: Enforces WSO2 Apache 2.0 copyright headers
 - `@thunder/no-internal-imports`: Prevents importing from internal paths

--- a/frontend/packages/thunder-eslint-plugin/src/configs/javascript.ts
+++ b/frontend/packages/thunder-eslint-plugin/src/configs/javascript.ts
@@ -26,7 +26,7 @@ const javascriptConfig: Linter.Config[] = [
   {
     name: 'thunder/javascript-overrides',
     rules: {
-      // Disallow the use of console in-favor of the Thunder Logger.
+      // Disallow the use of console in-favor of the Logger.
       // https://eslint.org/docs/latest/rules/no-console
       'no-console': 'error',
       // Disallow new operators outside of assignments or comparisons

--- a/frontend/packages/thunder-i18n/README.md
+++ b/frontend/packages/thunder-i18n/README.md
@@ -7,7 +7,7 @@ Internationalization (i18n) package for Thunder applications using react-i18next
 - **Type-safe translations** - Full TypeScript support with autocomplete
 - **React hooks** - Easy-to-use hooks for translations
 - **Namespace organization** - Organized by app and feature for better maintainability
-- **Multiple apps support** - Shared translations for console, gate, and other Thunder apps
+- **Multiple apps support** - Shared translations for console, gate, and other apps
 
 ## Installation
 
@@ -162,7 +162,7 @@ const translations = {
 
 ### Namespace Details
 
-**`common`** - Shared translations across all Thunder applications:
+**`common`** - Shared translations across all applications:
 
 - `actions` - Action buttons (save, cancel, delete, etc.)
 - `status` - Status messages (loading, success, error, etc.)
@@ -188,15 +188,15 @@ const translations = {
 
 **`dashboard`** - Dashboard-specific content
 
-**`auth`** - Authentication flows (for Thunder Gate):
+**`auth`** - Authentication flows (for Gate):
 
 - Sign in, sign up, password flows
 
-**`mfa`** - Multi-factor authentication (for Thunder Gate)
+**`mfa`** - Multi-factor authentication (for Gate)
 
-**`social`** - Social login providers (for Thunder Gate)
+**`social`** - Social login providers (for Gate)
 
-**`consent`** - Consent management (for Thunder Gate)
+**`consent`** - Consent management (for Gate)
 
 **`errors`** - Error messages and error states
 
@@ -209,7 +209,7 @@ const translations = {
 
 ## Usage Examples
 
-### Example: Thunder Console - Users Page
+### Example: Console - Users Page
 
 ```tsx
 import {useTranslation} from 'react-i18next';
@@ -241,7 +241,7 @@ export function UsersPage() {
 }
 ```
 
-### Example: Thunder Gate - Sign In Page
+### Example: Gate - Sign In Page
 
 ```tsx
 import {useTranslation} from 'react-i18next';
@@ -423,7 +423,7 @@ pnpm lint
 
 ## Integration Guide
 
-### Thunder Console App
+### Console App
 
 Complete integration example for `apps/thunder-console/src/main.tsx`:
 
@@ -459,7 +459,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 );
 ```
 
-### Thunder Gate App
+### Gate App
 
 Similar integration for `apps/thunder-gate/src/main.tsx`:
 
@@ -644,7 +644,7 @@ When adding support for additional languages:
 2. Translate all namespaces
 3. Update `package.json` exports
 4. Update this README with the new language
-5. Test in all Thunder applications
+5. Test in all applications
 
 ## Resources
 

--- a/frontend/packages/thunder-logger/README.md
+++ b/frontend/packages/thunder-logger/README.md
@@ -1235,7 +1235,7 @@ logger.error('Failed to save', {error, userId: user.id});
 
 ## Package Structure
 
-The `@thunder/logger` package follows Thunder's standard coding practices with a clean, modular structure:
+The `@thunder/logger` package follows standard coding practices with a clean, modular structure:
 
 ```
 src/
@@ -1277,7 +1277,7 @@ src/
 2. **Single Responsibility** - Each file has one clear purpose
 3. **Type Organization** - All types in dedicated `models/` folder
 4. **React Isolation** - React-specific code in dedicated `react/` folder
-5. **Context Pattern** - React integration follows Thunder's standard Context/Provider/Hook pattern
+5. **Context Pattern** - React integration follows standard Context/Provider/Hook pattern
 
 ## Best Practices
 

--- a/frontend/packages/thunder-test-utils/README.md
+++ b/frontend/packages/thunder-test-utils/README.md
@@ -1,14 +1,14 @@
 # @thunder/test-utils
 
 Shared testing utilities for ⚡️ Thunder applications. Provides common test setup, render helpers, and mocks for
-consistent testing across all Thunder apps.
+consistent testing across all apps.
 
 ## Features
 
 - **Unified Test Setup** - Common test configuration for Vitest, jsdom, and React Testing Library
 - **Custom Render Functions** - Pre-configured render with all necessary providers (QueryClient, Router, Config, Logger,
   Theme)
-- **App Configuration** - Configurable settings for different Thunder apps (console, gate)
+- **App Configuration** - Configurable settings for different apps (console, gate)
 - **Ready-to-Use Mocks** - Common mocks for i18n, IntersectionObserver, ResizeObserver, and more
 - **Re-exported Utilities** - Convenient re-exports from @testing-library/react and user-event
 
@@ -179,7 +179,7 @@ await user.click(button);
 Import this in your test setup file. It provides:
 
 - **Jest-DOM matchers** - `toBeInTheDocument()`, `toHaveClass()`, etc.
-- **i18n initialization** - Pre-configured with all Thunder translations
+- **i18n initialization** - Pre-configured with all translations
 - **Automatic cleanup** - Cleanup after each test
 - **Browser API mocks**:
   - `IntersectionObserver`
@@ -335,13 +335,13 @@ The custom render functions wrap components with the following providers:
 
 1. **MemoryRouter** - React Router for navigation
 2. **QueryClientProvider** - TanStack Query with retry disabled for tests
-3. **ConfigProvider** - Thunder configuration context
-4. **LoggerProvider** - Thunder logger with ERROR level for minimal test output
+3. **ConfigProvider** - Configuration context
+4. **LoggerProvider** - Logger with ERROR level for minimal test output
 5. **OxygenUIThemeProvider** - WSO2 Oxygen UI theming
 
 ## App-Specific Setup
 
-### Thunder Console
+### Console
 
 ```typescript
 // src/test/setup.ts
@@ -349,7 +349,7 @@ import '@thunder/test-utils/setup';
 // Uses default config: base='/console', clientId='CONSOLE'
 ```
 
-### Thunder Gate
+### Gate
 
 ```typescript
 // src/test/setup.ts

--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -13,7 +13,7 @@ Individual authentication endpoints that can be used independently for specific 
 - **Asgardeo Login** - OAuth-based login with Asgardeo
 
 ### 2. Authenticate with Flow Native APIs
-Orchestrated authentication flows using Thunder's flow execution engine:
+Orchestrated authentication flows using flow execution engine:
 - **Login with Username & Password** - Basic username/password flow
 - **Login with Username & Password (Verbose)** - Detailed flow execution with frontend metadata
 - **Login with SMS OTP** - SMS OTP-based authentication flow
@@ -70,10 +70,10 @@ Import the `environment.json` file into Postman and fill in the required values.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `scheme` | Thunder server scheme | `https` |
-| `host` | Thunder server host | `localhost` |
-| `port` | Thunder server port | `8090` |
-| `baseUrl` | Thunder server base URL | `{{scheme}}://{{host}}:{{port}}` (`https://localhost:8090`) |
+| `scheme` | Server scheme | `https` |
+| `host` | Server host | `localhost` |
+| `port` | Server port | `8090` |
+| `baseUrl` | Server base URL | `{{scheme}}://{{host}}:{{port}}` (`https://localhost:8090`) |
 
 ### Management Token App (for obtaining access tokens)
 

--- a/samples/apps/react-api-based-sample/README.md
+++ b/samples/apps/react-api-based-sample/README.md
@@ -1,11 +1,11 @@
 # Thunder API-Based Authentication Sample Application
 
-This sample application demonstrates how to integrate Thunder authentication into a React application using direct API calls instead of SDK-based OAuth redirects. It showcases API-based user registration (sign-up) and authentication (sign-in) flows.
+This sample application demonstrates how to integrate authentication into a React application using direct API calls instead of SDK-based OAuth redirects. It showcases API-based user registration (sign-up) and authentication (sign-in) flows.
 
 ## Features
 
-- User registration via Thunder's User Management API
-- User authentication via Thunder's Credentials Authentication API
+- User registration via User Management API
+- User authentication via Credentials Authentication API
 - JWT assertion token handling and display
 - Dashboard with user list view
 - User profile modal with decoded token information
@@ -14,8 +14,8 @@ This sample application demonstrates how to integrate Thunder authentication int
 ## Prerequisites
 
 - Node.js 20+
-- A running Thunder server instance (default: `https://localhost:8090`)
-- Thunder server configured with appropriate CORS settings
+- A running server instance (default: `https://localhost:8090`)
+- Server configured with appropriate CORS settings
 - SSL certificates (`server.key` and `server.cert`) in the project root
 - The "Customer" user schema and "customers" organization unit created (via `02-sample-resources.sh` bootstrap script)
 
@@ -23,7 +23,7 @@ This sample application demonstrates how to integrate Thunder authentication int
 
 ### 1. Configure the Application
 
-Edit `public/config.json` with your Thunder server settings:
+Edit `public/config.json` with your server settings:
 
 ```json
 {
@@ -33,14 +33,14 @@ Edit `public/config.json` with your Thunder server settings:
 
 | Property | Description |
 |----------|-------------|
-| `baseUrl` | The base URL of your Thunder server |
+| `baseUrl` | The base URL of your server |
 
 ### 2. Set Up SSL Certificates
 
-The application runs on HTTPS. Copy the SSL certificates from your Thunder distribution:
+The application runs on HTTPS. Copy the SSL certificates from your distribution:
 
 ```bash
-# From Thunder distribution
+# From distribution
 cp /path/to/thunder/repository/resources/security/server.key .
 cp /path/to/thunder/repository/resources/security/server.cert .
 
@@ -83,7 +83,7 @@ The application will be available at [https://localhost:3000](https://localhost:
 
 ## Important: Sign-Up Requirements
 
-To use the sign-up functionality, you need to temporarily disable Thunder security by setting the following environment variable before starting the Thunder server:
+To use the sign-up functionality, you need to temporarily disable security by setting the following environment variable before starting the server:
 
 ```bash
 export SKIP_SECURITY=true
@@ -109,7 +109,7 @@ src/
 │   ├── SignUpPage.tsx       # User registration form
 │   └── DashboardPage.tsx    # Authenticated user dashboard
 ├── utils/
-│   ├── api.ts               # Thunder API utilities
+│   ├── api.ts               # API utilities
 │   └── jwt.ts               # JWT decoding utilities
 ├── config.ts                # Runtime configuration loader
 ├── router.tsx               # Application routes
@@ -118,7 +118,7 @@ src/
 
 ## API Endpoints Used
 
-This sample interacts with the following Thunder APIs:
+This sample interacts with the following APIs:
 
 ### Authentication
 - `POST /auth/credentials/authenticate` - Authenticate user with username/password
@@ -155,8 +155,8 @@ This sample interacts with the following Thunder APIs:
 ### Common Issues
 
 **Issue**: "Failed to fetch" errors
-- Ensure Thunder server is running and accessible at the configured base URL
-- Check CORS configuration in Thunder's `deployment.yaml`
+- Ensure server is running and accessible at the configured base URL
+- Check CORS configuration in `deployment.yaml`
 
 **Issue**: "User schema not found" error during sign-up
 - Run the `02-sample-resources.sh` bootstrap script to create the "Customer" user schema
@@ -165,10 +165,10 @@ This sample interacts with the following Thunder APIs:
 - Run the `02-sample-resources.sh` bootstrap script to create the "customers" organization unit
 
 **Issue**: Sign-up fails with authentication/authorization errors
-- Ensure `SKIP_SECURITY=true` is set when starting the Thunder server
+- Ensure `SKIP_SECURITY=true` is set when starting the server
 
 **Issue**: CORS errors
-- Add your application URL to "Allowed Origins" in Thunder's configuration:
+- Add your application URL to "Allowed Origins" in configuration:
   ```yaml
   cors:
     allowed_origins:

--- a/samples/apps/react-sdk-sample/README.md
+++ b/samples/apps/react-sdk-sample/README.md
@@ -1,10 +1,10 @@
 # Thunder React SDK Sample Application
 
-This sample application demonstrates how to integrate Thunder authentication into a React application using the `@asgardeo/react` SDK. It showcases OAuth 2.0/OIDC based user authentication, token management, and user profile display.
+This sample application demonstrates how to integrate authentication into a React application using the `@asgardeo/react` SDK. It showcases OAuth 2.0/OIDC based user authentication, token management, and user profile display.
 
 ## Features
 
-- 🔐 OAuth 2.0/OIDC authentication with Thunder
+- 🔐 OAuth 2.0/OIDC authentication
 - 👤 Display user profile information (name, username)
 - 🎫 View access tokens and decoded JWT components (header, payload, signature)
 - 🎨 Modern UI with Oxygen UI components
@@ -14,8 +14,8 @@ This sample application demonstrates how to integrate Thunder authentication int
 ## Prerequisites
 
 - Node.js 20+
-- A running Thunder server instance (default: `https://localhost:8090`)
-- An OAuth application registered in Thunder with appropriate redirect URIs
+- A running server instance (default: `https://localhost:8090`)
+- An OAuth application registered in with appropriate redirect URIs
 
 ## Quick Start (Pre-built Application)
 
@@ -23,7 +23,7 @@ If you have the pre-built distribution, you can run it directly:
 
 ### 1. Configure the Application
 
-Open `dist/runtime.json` and set your Thunder application credentials:
+Open `dist/runtime.json` and set your application credentials:
 
 ```json
 {
@@ -34,8 +34,8 @@ Open `dist/runtime.json` and set your Thunder application credentials:
 
 | Property | Description |
 |----------|-------------|
-| `clientId` | The OAuth client ID from your Thunder application |
-| `baseUrl` | The base URL of your Thunder server |
+| `clientId` | The OAuth client ID from your application |
+| `baseUrl` | The base URL of your server |
 
 ### 2. Start the Application
 
@@ -64,10 +64,10 @@ npm install
 
 ### 2. Set Up SSL Certificates
 
-For HTTPS support during development, copy the SSL certificates from your Thunder distribution to the project root:
+For HTTPS support during development, copy the SSL certificates from your distribution to the project root:
 
 ```bash
-# From Thunder distribution
+# From distribution
 cp /path/to/thunder/repository/resources/security/server.key .
 cp /path/to/thunder/repository/resources/security/server.cert .
 
@@ -100,13 +100,13 @@ The application will be available at [https://localhost:3000](https://localhost:
 ```json
 {
   "clientId": "string (required) - OAuth client ID",
-  "baseUrl": "string (required) - Thunder server base URL"
+  "baseUrl": "string (required) - Server base URL"
 }
 ```
 
-### Thunder Application Setup
+### Application Setup
 
-Before running the app, ensure your Thunder application is configured with:
+Before running the app, ensure your application is configured with:
 
 1. **Authorized Redirect URLs**: Add your application URL (e.g., `https://localhost:3000`)
 2. **Allowed Origins**: Add your application origin for CORS
@@ -117,16 +117,16 @@ Before running the app, ensure your Thunder application is configured with:
 ### Common Issues
 
 **Issue**: "Failed to fetch token"
-- Ensure Thunder server is running and accessible at the configured base URL
+- Ensure server is running and accessible at the configured base URL
 - Verify the client ID is correct
-- Check that redirect URLs are properly configured in Thunder
+- Check that redirect URLs are properly configured in the server
 
 **Issue**: "Invalid client" error
 - Double-check the `clientId` in your `runtime.json`
-- Ensure the application exists in Thunder and is enabled
+- Ensure the application exists in and is enabled
 
 **Issue**: CORS errors
-- Add your application URL to "Allowed Origins" in Thunder's `deployment.yaml`:
+- Add your application URL to "Allowed Origins" in  `deployment.yaml`:
   ```yaml
   cors:
     allowed_origins:
@@ -137,7 +137,7 @@ Before running the app, ensure your Thunder application is configured with:
 
 ### Authentication Flow
 
-1. **SDK Provider Setup**: The app wraps components with `AsgardeoProvider` configured with Thunder's base URL and client ID
+1. **SDK Provider Setup**: The app wraps components with `AsgardeoProvider` configured with base URL and client ID
 2. **Conditional Rendering**: Uses `SignedIn`/`SignedOut` components to show appropriate content based on auth state
 3. **Token Management**: Retrieves and decodes JWT tokens to display user information
 

--- a/samples/apps/react-vanilla-sample/.env.example
+++ b/samples/apps/react-vanilla-sample/.env.example
@@ -9,7 +9,7 @@
 
 ## General App Configuration
 
-# The redirect URI for OAuth flow (where Thunder redirects after authentication)
+# The redirect URI for OAuth flow (where the server redirects after authentication)
 # E.g., https://localhost:3000
 VITE_REACT_APP_REDIRECT_URI=https://localhost:3000
 
@@ -28,7 +28,7 @@ VITE_REACT_APPLICATIONS_ENDPOINT=https://localhost:8090/applications
 # E.g., https://localhost:8090/flow
 VITE_REACT_APP_SERVER_FLOW_ENDPOINT=https://localhost:8090/flow
 
-# Application ID registered in Thunder for Basic Authentication
+# Application ID registered in the server for Basic Authentication
 VITE_REACT_APP_AUTH_APP_ID=
 
 
@@ -46,7 +46,7 @@ VITE_REACT_APP_SERVER_TOKEN_ENDPOINT=https://localhost:8090/oauth2/token
 # E.g., https://localhost:8090/flow/authn
 VITE_REACT_AUTHENTICATION_ENDPOINT=https://localhost:8090/flow/authn
 
-# OAuth client ID (from your Thunder application)
+# OAuth client ID (from your application)
 VITE_REACT_APP_CLIENT_ID=
 
 # OAuth scopes

--- a/samples/apps/react-vanilla-sample/README.md
+++ b/samples/apps/react-vanilla-sample/README.md
@@ -1,15 +1,15 @@
 # React Vanilla Sample Application
 
-This sample React application demonstrates integrating Thunder authentication into your application. It supports two authentication approaches:
+This sample React application demonstrates integrating authentication into your application. It supports two authentication approaches:
 
-- **Native Flow**: App-native authentication using Thunder's flow orchestration API
+- **Native Flow**: App-native authentication using  flow orchestration API
 - **OAuth 2.0 / OIDC**: Standards-based authentication using OAuth 2.0 Authorization Code flow
 
 ## Prerequisites
 
 - Node.js 20+
-- A running Thunder server instance (default: `https://localhost:8090`)
-- An application registered in Thunder
+- A running server instance (default: `https://localhost:8090`)
+- An application registered in the server
 
 ## Quick Start (Pre-built Application)
 
@@ -21,7 +21,7 @@ Open `app/runtime.json` and configure the settings based on your preferred authe
 
 #### Option A: Native Flow Configuration
 
-For app-native authentication using Thunder's flow API:
+For app-native authentication using flow API:
 
 ```json
 {
@@ -34,10 +34,10 @@ For app-native authentication using Thunder's flow API:
 
 | Property | Description |
 |----------|-------------|
-| `flowEndpoint` | Thunder's flow orchestration endpoint |
-| `applicationsEndpoint` | Thunder's applications API endpoint |
+| `flowEndpoint` | Flow orchestration endpoint |
+| `applicationsEndpoint` | Applications API endpoint |
 | `redirectBasedLogin` | Set to `false` for native flow |
-| `applicationID` | The application ID registered in Thunder (obtained during Thunder setup) |
+| `applicationID` | The application ID registered in the server (obtained during server setup) |
 
 #### Option B: OAuth 2.0 / OIDC Configuration
 
@@ -60,7 +60,7 @@ For standards-based OAuth 2.0 authentication with redirect-based login:
 | `authorizationEndpoint` | OAuth 2.0 authorization endpoint |
 | `tokenEndpoint` | OAuth 2.0 token endpoint |
 | `clientId` | OAuth client ID for the application |
-| `redirectUri` | Callback URL where Thunder redirects after authentication |
+| `redirectUri` | Callback URL where the server redirects after authentication |
 | `scope` | OAuth scopes (e.g., `openid`, `profile`, `email`) |
 
 #### Expected Flow Node IDs
@@ -102,10 +102,10 @@ npm install
 
 ### 2. Set Up SSL Certificates
 
-For HTTPS support, copy the SSL certificates from your Thunder distribution to the project root:
+For HTTPS support, copy the SSL certificates from your server distribution to the project root:
 
 ```bash
-# From Thunder distribution
+# From distribution
 cp /path/to/thunder/repository/resources/security/server.key .
 cp /path/to/thunder/repository/resources/security/server.cert .
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,6 @@
 # Thunder Console E2E Tests
 
-End-to-end automation test suite for the Thunder Console, built with [Playwright](https://playwright.dev/).
+End-to-end automation test suite for the Console, built with [Playwright](https://playwright.dev/).
 
 ## 📋 Overview
 

--- a/tests/e2e/tests/sample-app-authentication/README-MFA.md
+++ b/tests/e2e/tests/sample-app-authentication/README-MFA.md
@@ -9,7 +9,7 @@ These tests verify the complete MFA authentication process:
 1. **First Factor**: Username and password authentication
 2. **Second Factor**: SMS OTP verification
 
-The tests use a mock SMS server to capture OTP messages sent by Thunder, eliminating the need for real SMS providers during testing.
+The tests use a mock SMS server to capture OTP messages sent by the server, eliminating the need for real SMS providers during testing.
 
 ## Test Files
 
@@ -47,21 +47,21 @@ The automated setup will:
 
 ### Minimal Requirements (with Automated Setup)
 
-1. ✅ **Thunder server running** at `https://localhost:8090`
+1. ✅ **Server running** at `https://localhost:8090`
 2. ✅ **Sample app running** (e.g., at `https://localhost:3000`)
-3. ✅ **Application ID** - Get from Thunder setup
+3. ✅ **Application ID** - Get from server setup
 
 ### Full Requirements (Manual Setup)
 
 If you prefer manual setup or `AUTO_SETUP_MFA=false`:
 
-1. ✅ **Thunder server running** at `https://localhost:8090`
+1. ✅ **Server running** at `https://localhost:8090`
 2. ✅ **Sample app running** (e.g., at `https://localhost:3000`)
 3. ✅ **Admin access token** available for configuration
 4. ✅ **Notification sender configured** to use mock SMS server
-5. ✅ **MFA authentication flow configured** in Thunder
-6. ✅ **Test user with mobile number** created in Thunder
-7. ✅ **Application created with MFA flow attached** in Thunder
+5. ✅ **MFA authentication flow configured** in server
+6. ✅ **Test user with mobile number** created in server
+7. ✅ **Application created with MFA flow attached** in server
 
 ## Setup Instructions
 
@@ -109,13 +109,13 @@ npm test tests/sample-app-authentication/sample-app-mfa-login.spec.ts
 
 That's it! The setup will be performed automatically before tests run.
 
-### Option 2: Manual Setup (Thunder Configuration)
+### Option 2: Manual Setup (Server Configuration)
 
 If you prefer manual configuration or need to troubleshoot, follow these steps:
 
 #### Admin Access Token
 
-Run the following command, replacing `<application_id>` with your sample app ID (created during Thunder setup).
+Run the following command, replacing `<application_id>` with your sample app ID (created during server setup).
 
 ```bash
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
@@ -533,7 +533,7 @@ USER_RESPONSE=$(curl --location 'https://localhost:8090/users' \
 ### Update the sample application
 
 Follow these steps:
-1. Fetch all applications from Thunder
+1. Fetch all applications from the server
 2. Find the "React SDK Sample" application
 3. Get its full configuration
 4. Update the `auth_flow_id` with the new MFA flow
@@ -569,10 +569,10 @@ curl -k -X PUT "https://localhost:8090/applications/$APP_ID" \
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `SAMPLE_APP_URL` | Yes | - | URL of the sample app (e.g., `https://localhost:3000`) |
-| `SAMPLE_APP_ID` | Yes* | - | Application ID in Thunder (*required for automated setup) |
-| `SERVER_URL` | No | `https://localhost:8090` | URL of Thunder server |
-| `ADMIN_USERNAME` | No | `admin` | Admin username for Thunder |
-| `ADMIN_PASSWORD` | No | `admin` | Admin password for Thunder |
+| `SAMPLE_APP_ID` | Yes* | - | Application ID in the server (*required for automated setup) |
+| `SERVER_URL` | No | `https://localhost:8090` | URL of the server |
+| `ADMIN_USERNAME` | No | `admin` | Admin username for the server |
+| `ADMIN_PASSWORD` | No | `admin` | Admin password for the server |
 | `SAMPLE_APP_USERNAME` | No | `e2e-test-user` | Test user username |
 | `SAMPLE_APP_PASSWORD` | No | `e2e-test-password` | Test user password |
 | `MOCK_SMS_SERVER_PORT` | No | `8098` | Port for mock SMS server |
@@ -731,10 +731,10 @@ The `MFASetup` utility (`utils/server-setup/mfa-setup.ts`) automates the complet
 
 The tests use a TypeScript-based mock SMS server that:
 
-- **Captures SMS messages** sent by Thunder
+- **Captures SMS messages** sent by the server
 - **Extracts OTP codes** automatically using pattern matching
 - **Provides HTTP endpoints** for test access:
-  - `POST /send-sms` - Receives SMS from Thunder
+  - `POST /send-sms` - Receives SMS from the server
   - `GET /messages` - Retrieve all messages
   - `GET /messages/last` - Get last message
   - `POST /clear` - Clear message history
@@ -837,7 +837,7 @@ The tests use a TypeScript-based mock SMS server that:
 
 **Solutions**:
 1. Ensure `SAMPLE_APP_ID` is set in `.env` file
-2. Get application ID from Thunder:
+2. Get application ID from the server:
    ```bash
    curl -k 'https://localhost:8090/applications' \
      -H "Authorization: Bearer <admin-token>"
@@ -849,22 +849,22 @@ The tests use a TypeScript-based mock SMS server that:
 **Issue**: `Admin authentication failed`
 
 **Solutions**:
-1. Verify Thunder server is running at `SERVER_URL`
+1. Verify server is running at `SERVER_URL`
 2. Check `ADMIN_USERNAME` and `ADMIN_PASSWORD` are correct
 3. Verify application has basic authentication flow configured
-4. Check Thunder logs for authentication errors
+4. Check server logs for authentication errors
 
 #### Setup Fails - Resource Creation Error
 
 **Issue**: Failed to create notification sender, flow, or user
 
 **Solutions**:
-1. Check Thunder server logs for detailed error messages
+1. Check server logs for detailed error messages
 2. Verify admin user has necessary permissions
 3. Check if resources already exist (setup handles this gracefully)
 4. Try manual cleanup and re-run:
    ```bash
-   # Delete existing resources via Thunder API
+   # Delete existing resources via API
    # Then re-run tests
    ```
 
@@ -874,7 +874,7 @@ The tests use a TypeScript-based mock SMS server that:
 
 **Explanation**: Cleanup errors are non-fatal and logged as warnings. This is expected behavior if resources were already deleted or don't exist.
 
-**If Persistent**: Manually delete resources via Thunder API if needed.
+**If Persistent**: Manually delete resources via API if needed.
 
 ### Tests Are Skipped
 
@@ -905,7 +905,7 @@ The tests use a TypeScript-based mock SMS server that:
 
 **Solutions**:
 1. Verify notification sender configuration points to `http://localhost:8098/send-sms`
-2. Check Thunder server logs for SMS sending errors
+2. Check server logs for SMS sending errors
 3. Verify MFA flow has correct `senderId` in OTP nodes
 4. Increase wait time: `await page.waitForTimeout(3000);`
 
@@ -927,14 +927,14 @@ The tests use a TypeScript-based mock SMS server that:
 1. Verify OTP executor has correct `senderId` in verify node
 2. Check OTP is being extracted correctly from SMS
 3. Verify test user has mobile number attribute
-4. Check Thunder server logs for OTP verification errors
+4. Check server logs for OTP verification errors
 
 ### Test User Issues
 
 **Issue**: User not found or authentication fails
 
 **Solutions**:
-1. Verify test user exists in Thunder
+1. Verify test user exists in the server
 2. Ensure user has `mobileNumber` attribute
 3. Check user is in correct organization unit
 4. Verify user credentials in `.env` file
@@ -944,22 +944,22 @@ The tests use a TypeScript-based mock SMS server that:
 1. **Always clear messages** between tests to avoid OTP conflicts
 2. **Use appropriate wait times** for SMS delivery (1-2 seconds)
 3. **Check mock server is running** before executing tests
-4. **Verify Thunder configuration** matches test expectations
+4. **Verify server configuration** matches test expectations
 5. **Use headed mode** for debugging: `npm run test:headed`
 6. **Check trace files** for detailed execution: `npm run test:trace`
 7. **Review screenshots** in `test-results/` after failures
 
 ## Additional Resources
 
-- [Thunder MFA Setup Guide](../../../../docs/guides/authentication/GUIDE-SMS-OTP-MFA-LOGIN.md)
+- [MFA Setup Guide](../../../../docs/guides/authentication/GUIDE-SMS-OTP-MFA-LOGIN.md)
 - [Sample App Documentation](../../../samples/apps/README.md)
 - [Playwright Documentation](https://playwright.dev/docs/intro)
-- [Thunder Flow Management API](../../../../docs/guides/flows/)
+- [Flow Management API](../../../../docs/guides/flows/)
 
 ## Support
 
 For issues or questions:
-1. Check Thunder server logs: `tail -f backend/server.log`
+1. Check server logs: `tail -f backend/server.log`
 2. Review test trace files: `test-results/*/trace.zip`
 3. Run tests in debug mode: `npm run test:debug`
 4. Check mock SMS server console output during test execution


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request standardizes product references and clarifies language across documentation, test descriptions, and configuration comments. The main focus is on making product names more generic and removing unnecessary branding, which improves clarity for contributors and users working with different applications or components.
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->


**Documentation and Naming Standardization:**

* Updated references from "Thunder" to more generic terms like "product," "platform," or simply removed branding in documentation files such as `AGENTS.md`, `frontend/README.md`, and multiple `README.md` files for shared frontend packages. This includes skills, integration guides, namespace descriptions, and usage examples. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L9-R10) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L41-R41) [[3]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L4-R4) [[4]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L10-R10) [[5]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L165-R165) [[6]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L191-R199) [[7]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L212-R212) [[8]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L244-R244) [[9]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L426-R426) [[10]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L462-R462) [[11]](diffhunk://#diff-031eeb3aa9926dd8b290ea19e3dfc1a9081fba3b45ddc4a48170d09d5885b284L647-R647) [[12]](diffhunk://#diff-6d247035a712b95d8ec5775d1e0956d091ac7f031c9a435232f7d3accd3a7b60L1238-R1238) [[13]](diffhunk://#diff-6d247035a712b95d8ec5775d1e0956d091ac7f031c9a435232f7d3accd3a7b60L1280-R1280) [[14]](diffhunk://#diff-aaf7b2ee5694b057fcc454029c02e1793cba4aaf6ef9dc055e60a45a3560b021L4-R11) [[15]](diffhunk://#diff-aaf7b2ee5694b057fcc454029c02e1793cba4aaf6ef9dc055e60a45a3560b021L182-R182) [[16]](diffhunk://#diff-aaf7b2ee5694b057fcc454029c02e1793cba4aaf6ef9dc055e60a45a3560b021L338-R352)

**Test Descriptions and Comments:**

* Changed test case descriptions and comments in frontend test files to use "product prefix" or generic terms instead of "Thunder" for CSS class references, improving reusability and clarity. [[1]](diffhunk://#diff-0c2e54bb78dc54f809888bb629ca93c2a76582778dc2711a677b512086b66ce0L40-R40) [[2]](diffhunk://#diff-0c2e54bb78dc54f809888bb629ca93c2a76582778dc2711a677b512086b66ce0L49-R49) [[3]](diffhunk://#diff-0c2e54bb78dc54f809888bb629ca93c2a76582778dc2711a677b512086b66ce0L58-R58) [[4]](diffhunk://#diff-0c2e54bb78dc54f809888bb629ca93c2a76582778dc2711a677b512086b66ce0L83-R83) [[5]](diffhunk://#diff-dc22d4aefd7750ad0a8ca318f6e3532d541a217105322901019c12a41cf823ecL79-R79) [[6]](diffhunk://#diff-4db0cc70938e519f7c5509aa9e92efe7080c4b57b1068f0343abf23f4741fc1bL41-R41) [[7]](diffhunk://#diff-a6f809974ebebe696d92f67eb8526d0a8b9b7e900308e64f5b9d7e78db990075L48-R48) [[8]](diffhunk://#diff-a4eb6ff8d3149685efe25735278d555f76c4c630e82e9b988cb9fdd4134972ecL58-R58)

**Configuration and Code Comments:**

* Updated ESLint and logger configuration comments to remove "Thunder" branding, making them applicable to any project using these shared tools. [[1]](diffhunk://#diff-38bf6c98ec2e4d322127fb8c481256c0769e28fea78a6d290c0963c47f024571L29-R29) [[2]](diffhunk://#diff-2c1fcfd50b567cec98913cf229df2e5ca09bec0f6f0d1ea9d197e46ea73c4899L41-R41)

**Minor Test Comment Fixes:**

* Clarified comments in backend token validator tests to use "the issuer" instead of "Thunder issuer," improving accuracy and reducing product-specific language. [[1]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aL122-R122) [[2]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aL174-R174) [[3]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aL195-R195) [[4]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aL462-R462) [[5]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aL596-R596)

These changes ensure that documentation, tests, and configurations are less tied to a specific product name, making the codebase and supporting materials more maintainable and reusable.


### Related Issues
- https://github.com/asgardeo/thunder/issues/2465

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
