### PR TITLE
Improve hardening cors origin matching and preflight handling

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/cors"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -61,6 +62,13 @@ func main() {
 	cfg := initThunderConfigurations(logger, thunderHome)
 	if cfg == nil {
 		logger.Fatal("Failed to initialize configurations")
+	}
+
+	// Install the CORS allowed-origins matcher used by the HTTP middleware.
+	// Compilation errors are already surfaced by config validation; this call
+	// rebuilds the rules and installs them as the cors package singleton.
+	if err := cors.InitializeMatcher(cfg.CORS.AllowedOrigins); err != nil {
+		logger.Fatal("Failed to initialize CORS matcher", log.Error(err))
 	}
 
 	// Initialize the cache manager.

--- a/backend/internal/flow/mgt/init_test.go
+++ b/backend/internal/flow/mgt/init_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
@@ -61,6 +62,11 @@ type InitTestSuite struct {
 func (s *InitTestSuite) SetupTest() {
 	s.mockService = NewFlowMgtServiceInterfaceMock(s.T())
 
+	var allowedOrigins cors.OriginEntries
+	s.Require().NoError(yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
 		Database: config.DatabaseConfig{
 			Config: config.DataSource{
@@ -75,20 +81,14 @@ func (s *InitTestSuite) SetupTest() {
 		Server: config.ServerConfig{
 			Identifier: "test-deployment",
 		},
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	s.Require().NoError(cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	_ = config.InitializeThunderRuntime("test", testConfig)
 }
 
 func (s *InitTestSuite) TearDownTest() {
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
 }
 
 func TestInitTestSuite(t *testing.T) {

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/cors"
@@ -49,6 +50,10 @@ func TestInitTestSuite(t *testing.T) {
 
 func (suite *InitTestSuite) SetupTest() {
 	// Initialize Runtime config with basic test config
+	var allowedOrigins cors.OriginEntries
+	suite.Require().NoError(yaml.Unmarshal([]byte(`
+- https://example.com
+`), &allowedOrigins))
 	testConfig := &config.Config{
 		Database: config.DatabaseConfig{
 			Config: config.DataSource{
@@ -67,13 +72,9 @@ func (suite *InitTestSuite) SetupTest() {
 			LoginPath: "/login",
 			ErrorPath: "/error",
 		},
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	suite.Require().NoError(cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	_ = config.InitializeThunderRuntime("", testConfig)
 
 	suite.mockInboundClient = inboundclientmock.NewInboundClientServiceInterfaceMock(suite.T())
@@ -84,7 +85,6 @@ func (suite *InitTestSuite) SetupTest() {
 
 func (suite *InitTestSuite) TearDownTest() {
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
 }
 
 func (suite *InitTestSuite) TestInitialize() {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -294,12 +294,12 @@ type CORSConfig struct {
 
 // Validate checks every allowed-origins entry so configuration errors —
 // invalid literals, malformed regexes, the unsupported "*" wildcard — are
-// surfaced at server start rather than on the first cross-origin request,
-// and installs the resulting matcher as the cors package's process-wide
-// singleton. The middleware reads that singleton via cors.GetMatcher; this
-// config layer only owns YAML validation.
+// surfaced at server start rather than on the first cross-origin request.
+// Installation of the runtime matcher is the server bootstrap's
+// responsibility (see cors.InitializeMatcher); this config layer only owns
+// YAML validation.
 func (c *CORSConfig) Validate() error {
-	return cors.InitializeMatcher(c.AllowedOrigins)
+	return cors.Validate(c.AllowedOrigins)
 }
 
 // DeclarativeResources holds the configuration details for the declarative resources.

--- a/backend/internal/system/cors/canonical.go
+++ b/backend/internal/system/cors/canonical.go
@@ -31,7 +31,7 @@ const (
 	schemeHTTPS = "https"
 )
 
-// Canonicalize returns the canonical form of an HTTP(S) origin for literal-rule
+// canonicalize returns the canonical form of an HTTP(S) origin for literal-rule
 // comparison. The canonical form lowercases the scheme and host, strips a
 // trailing dot from the host, Punycode-encodes IDN labels, and wraps IPv6
 // hosts in brackets so the resulting string compares equal across all common
@@ -46,7 +46,7 @@ const (
 //
 // "null" is not a valid input here; callers must route the null origin through
 // the IsNull flag on ParseResult instead.
-func Canonicalize(raw string) (string, error) {
+func canonicalize(raw string) (string, error) {
 	if raw == "" {
 		return "", fmt.Errorf("%w: empty origin", ErrInvalidOrigin)
 	}

--- a/backend/internal/system/cors/canonical_test.go
+++ b/backend/internal/system/cors/canonical_test.go
@@ -35,37 +35,37 @@ func TestCanonicalTestSuite(t *testing.T) {
 }
 
 func (suite *CanonicalTestSuite) TestHTTPSNoPortKeptPortless() {
-	got, err := Canonicalize("https://example.com")
+	got, err := canonicalize("https://example.com")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://example.com", got)
 }
 
 func (suite *CanonicalTestSuite) TestHTTPNoPortKeptPortless() {
-	got, err := Canonicalize("http://example.com")
+	got, err := canonicalize("http://example.com")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "http://example.com", got)
 }
 
 func (suite *CanonicalTestSuite) TestHTTPSDefaultPortPreserved() {
-	got, err := Canonicalize("https://example.com:443")
+	got, err := canonicalize("https://example.com:443")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://example.com:443", got)
 }
 
 func (suite *CanonicalTestSuite) TestHTTPDefaultPortPreserved() {
-	got, err := Canonicalize("http://example.com:80")
+	got, err := canonicalize("http://example.com:80")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "http://example.com:80", got)
 }
 
 func (suite *CanonicalTestSuite) TestExplicitPortPreserved() {
-	got, err := Canonicalize("https://example.com:8443")
+	got, err := canonicalize("https://example.com:8443")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://example.com:8443", got)
 }
 
 func (suite *CanonicalTestSuite) TestSchemeAndHostLowercased() {
-	got, err := Canonicalize("HTTPS://Example.COM:443")
+	got, err := canonicalize("HTTPS://Example.COM:443")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://example.com:443", got)
 }
@@ -74,9 +74,9 @@ func (suite *CanonicalTestSuite) TestExplicitDefaultPortDistinctFromImplicit() {
 	// The operator owns the port spelling: portless and default-port forms are
 	// canonicalized as distinct origins so the literal-rule list stays
 	// explicit about which variants are allowed.
-	a, errA := Canonicalize("https://example.com")
+	a, errA := canonicalize("https://example.com")
 	suite.Require().NoError(errA)
-	b, errB := Canonicalize("https://example.com:443")
+	b, errB := canonicalize("https://example.com:443")
 	suite.Require().NoError(errB)
 	assert.NotEqual(suite.T(), a, b)
 	assert.Equal(suite.T(), "https://example.com", a)
@@ -84,28 +84,28 @@ func (suite *CanonicalTestSuite) TestExplicitDefaultPortDistinctFromImplicit() {
 }
 
 func (suite *CanonicalTestSuite) TestEmptyRejected() {
-	_, err := Canonicalize("")
+	_, err := canonicalize("")
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrInvalidOrigin))
 }
 
 func (suite *CanonicalTestSuite) TestUnsupportedSchemeRejected() {
-	_, err := Canonicalize("ftp://example.com")
+	_, err := canonicalize("ftp://example.com")
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrInvalidOrigin))
 }
 
 func (suite *CanonicalTestSuite) TestMissingHostRejected() {
-	_, err := Canonicalize("https://")
+	_, err := canonicalize("https://")
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrInvalidOrigin))
 }
 
 func (suite *CanonicalTestSuite) TestTrailingDotStripped() {
 	// FQDN-with-trailing-dot must canonicalize the same as the bare host.
-	a, errA := Canonicalize("https://example.com.")
+	a, errA := canonicalize("https://example.com.")
 	suite.Require().NoError(errA)
-	b, errB := Canonicalize("https://example.com")
+	b, errB := canonicalize("https://example.com")
 	suite.Require().NoError(errB)
 	assert.Equal(suite.T(), b, a)
 }
@@ -114,27 +114,27 @@ func (suite *CanonicalTestSuite) TestIDNUnicodeAndPunycodeEqual() {
 	// Unicode form and Punycode form must produce the same canonical key
 	// so a literal-rule match is consistent regardless of how the operator
 	// or browser spelled the host.
-	uni, errA := Canonicalize("https://münchen.example")
+	uni, errA := canonicalize("https://münchen.example")
 	suite.Require().NoError(errA)
-	puny, errB := Canonicalize("https://xn--mnchen-3ya.example")
+	puny, errB := canonicalize("https://xn--mnchen-3ya.example")
 	suite.Require().NoError(errB)
 	assert.Equal(suite.T(), puny, uni)
 }
 
 func (suite *CanonicalTestSuite) TestIPv6HostBracketed() {
-	got, err := Canonicalize("https://[::1]:8443")
+	got, err := canonicalize("https://[::1]:8443")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://[::1]:8443", got)
 }
 
 func (suite *CanonicalTestSuite) TestIPv6HostNoPortBracketedNoPort() {
-	got, err := Canonicalize("https://[::1]")
+	got, err := canonicalize("https://[::1]")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "https://[::1]", got)
 }
 
 func (suite *CanonicalTestSuite) TestIPv4HostUnbracketed() {
-	got, err := Canonicalize("http://127.0.0.1:8080")
+	got, err := canonicalize("http://127.0.0.1:8080")
 	suite.Require().NoError(err)
 	assert.Equal(suite.T(), "http://127.0.0.1:8080", got)
 }
@@ -144,6 +144,6 @@ func (suite *CanonicalTestSuite) TestNonIDNStrictHostPassedThrough() {
 	// emit them; canonicalization must not reject the host. We do not assert
 	// the exact byte-for-byte output to avoid coupling to the idna package's
 	// behavior for non-IDN labels — only that the call succeeds.
-	_, err := Canonicalize("https://my_service.example")
+	_, err := canonicalize("https://my_service.example")
 	suite.Require().NoError(err)
 }

--- a/backend/internal/system/cors/compiler.go
+++ b/backend/internal/system/cors/compiler.go
@@ -26,36 +26,9 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// Entry is the discriminated-union type produced by YAML decoding. It carries
-// either a literal allowed-origin string or a regex pattern. Compile turns an
-// Entry into the corresponding compiled OriginRule.
-type Entry interface {
-	isOriginEntry()
-}
-
-// LiteralEntry is the bare-string YAML form, e.g. "https://example.com" or
-// the special-case "null".
-type LiteralEntry struct {
-	Value string
-}
-
-func (LiteralEntry) isOriginEntry() {}
-
-// RegexEntry is the object YAML form, e.g. { regex: "\\Ahttps://..." }.
-type RegexEntry struct {
-	Pattern string
-}
-
-func (RegexEntry) isOriginEntry() {}
-
-// OriginEntries is the slice wrapper that carries the heterogeneous YAML
-// schema for cors.allowed_origins. Custom YAML unmarshaling on this type
-// dispatches between the two entry forms.
-type OriginEntries []Entry
-
 // UnmarshalYAML decodes a YAML sequence whose elements are either scalar
-// strings (LiteralEntry) or mappings of the shape { regex: "..." }
-// (RegexEntry). Anything else is rejected at decode time.
+// strings (literal entries) or mappings of the shape { regex: "..." } (regex
+// entries). Anything else is rejected at decode time.
 func (e *OriginEntries) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.SequenceNode {
 		return fmt.Errorf("cors: allowed_origins must be a list, got %v", nodeKindString(node.Kind))
@@ -64,7 +37,7 @@ func (e *OriginEntries) UnmarshalYAML(node *yaml.Node) error {
 	for i, child := range node.Content {
 		switch child.Kind {
 		case yaml.ScalarNode:
-			out = append(out, LiteralEntry{Value: child.Value})
+			out = append(out, literalEntry{Value: child.Value})
 		case yaml.MappingNode:
 			var obj struct {
 				Regex string `yaml:"regex"`
@@ -75,7 +48,7 @@ func (e *OriginEntries) UnmarshalYAML(node *yaml.Node) error {
 			if obj.Regex == "" {
 				return fmt.Errorf("cors: allowed_origins[%d]: regex object missing 'regex' field", i)
 			}
-			out = append(out, RegexEntry{Pattern: obj.Regex})
+			out = append(out, regexEntry{Pattern: obj.Regex})
 		default:
 			return fmt.Errorf("cors: allowed_origins[%d]: entry must be a string or { regex: ... } object", i)
 		}
@@ -102,32 +75,40 @@ func nodeKindString(k yaml.Kind) string {
 	}
 }
 
-// Compile turns one Entry into a compiled OriginRule. Literal entries are
+// Validate checks every entry without installing the resulting matcher. It is
+// the pure-validation entry point used by the config layer; runtime
+// installation happens later via InitializeMatcher.
+func Validate(entries OriginEntries) error {
+	_, err := compileAll(entries)
+	return err
+}
+
+// compile turns one entry into a compiled originRule. Literal entries are
 // gated through ParseOrigin and (for non-null entries) canonicalized; regex
 // entries are compiled via Go's RE2 engine without any additional validation.
 // Operator-supplied regex patterns are taken as-is.
-func Compile(entry Entry) (OriginRule, error) {
-	switch e := entry.(type) {
-	case LiteralEntry:
-		return compileLiteral(e.Value)
-	case RegexEntry:
-		return compileRegex(e.Pattern)
+func compile(e entry) (originRule, error) {
+	switch v := e.(type) {
+	case literalEntry:
+		return compileLiteral(v.Value)
+	case regexEntry:
+		return compileRegex(v.Pattern)
 	default:
-		return nil, fmt.Errorf("cors: unknown entry type %T", entry)
+		return nil, fmt.Errorf("cors: unknown entry type %T", e)
 	}
 }
 
-// CompileAll compiles a slice of entries in declaration order. It fails fast
+// compileAll compiles a slice of entries in declaration order. It fails fast
 // on the first invalid entry, reporting the index and underlying cause so the
 // operator can locate the bad entry in deployment.yaml. Empty input yields a
 // nil slice with no error.
-func CompileAll(entries []Entry) ([]OriginRule, error) {
+func compileAll(entries []entry) ([]originRule, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
-	out := make([]OriginRule, 0, len(entries))
+	out := make([]originRule, 0, len(entries))
 	for i, e := range entries {
-		rule, err := Compile(e)
+		rule, err := compile(e)
 		if err != nil {
 			return nil, fmt.Errorf("cors: allowed_origins[%d]: %w", i, err)
 		}
@@ -136,8 +117,8 @@ func CompileAll(entries []Entry) ([]OriginRule, error) {
 	return out, nil
 }
 
-// compileLiteral builds a LiteralRule from a YAML bare-string value.
-func compileLiteral(value string) (OriginRule, error) {
+// compileLiteral builds a literalRule from a YAML bare-string value.
+func compileLiteral(value string) (originRule, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return nil, fmt.Errorf("%w: literal value is empty", ErrEmptyEntry)
@@ -146,22 +127,22 @@ func compileLiteral(value string) (OriginRule, error) {
 		return nil, fmt.Errorf("%w: list explicit origins or use a regex entry", ErrWildcardLiteral)
 	}
 	if trimmed == "null" {
-		return LiteralRule{isNull: true}, nil
+		return literalRule{isNull: true}, nil
 	}
 	if _, err := ParseOrigin(trimmed); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidLiteral, err)
 	}
-	canonical, err := Canonicalize(trimmed)
+	canonical, err := canonicalize(trimmed)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidLiteral, err)
 	}
-	return LiteralRule{canonical: canonical}, nil
+	return literalRule{canonical: canonical}, nil
 }
 
-// compileRegex builds a RegexRule from a YAML regex object's pattern. The
+// compileRegex builds a regexRule from a YAML regex object's pattern. The
 // pattern is compiled by Go's RE2 engine; no further "safety" checks are
 // applied — operator owns the pattern.
-func compileRegex(pattern string) (OriginRule, error) {
+func compileRegex(pattern string) (originRule, error) {
 	if pattern == "" {
 		return nil, fmt.Errorf("%w: regex pattern is empty", ErrEmptyEntry)
 	}
@@ -169,17 +150,17 @@ func compileRegex(pattern string) (OriginRule, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidRegex, err)
 	}
-	return RegexRule{re: re}, nil
+	return regexRule{re: re}, nil
 }
 
-// IsRegexAnchored reports whether the given pattern starts with a
+// isRegexAnchored reports whether the given pattern starts with a
 // start-of-input anchor (^ or \A) and ends with an end-of-input anchor ($ or
 // \z). A pattern lacking either anchor permits substring matches and almost
 // always allows far more origins than the operator intended; callers should
 // log a warning at boot for unanchored patterns. The check is intentionally
 // syntactic — alternation patterns like "(^a|^b)$" are flagged as a false
 // positive, which is acceptable given the diagnostic-only intent.
-func IsRegexAnchored(pattern string) bool {
+func isRegexAnchored(pattern string) bool {
 	starts := strings.HasPrefix(pattern, "^") || strings.HasPrefix(pattern, `\A`)
 	ends := strings.HasSuffix(pattern, "$") || strings.HasSuffix(pattern, `\z`)
 	return starts && ends

--- a/backend/internal/system/cors/compiler_test.go
+++ b/backend/internal/system/cors/compiler_test.go
@@ -36,21 +36,21 @@ func TestCompilerTestSuite(t *testing.T) {
 }
 
 func (suite *CompilerTestSuite) TestCompileLiteralEntry() {
-	rule, err := Compile(LiteralEntry{Value: "https://example.com"})
+	rule, err := compile(literalEntry{Value: "https://example.com"})
 	suite.Require().NoError(err)
-	assert.Equal(suite.T(), RuleLiteral, rule.Kind())
+	assert.Equal(suite.T(), kindLiteral, rule.kind())
 }
 
 func (suite *CompilerTestSuite) TestCompileRegexEntry() {
-	rule, err := Compile(RegexEntry{Pattern: `^https://.+$`})
+	rule, err := compile(regexEntry{Pattern: `^https://.+$`})
 	suite.Require().NoError(err)
-	assert.Equal(suite.T(), RuleRegex, rule.Kind())
+	assert.Equal(suite.T(), kindRegex, rule.kind())
 }
 
 func (suite *CompilerTestSuite) TestCompileLiteralWhitespaceTrimmed() {
-	rule, err := Compile(LiteralEntry{Value: "  https://example.com  "})
+	rule, err := compile(literalEntry{Value: "  https://example.com  "})
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 	parsed, err := ParseOrigin("https://example.com")
 	suite.Require().NoError(err)
 	allow, _ := m.Match(parsed)
@@ -58,9 +58,9 @@ func (suite *CompilerTestSuite) TestCompileLiteralWhitespaceTrimmed() {
 }
 
 func (suite *CompilerTestSuite) TestCompileNullLiteral() {
-	rule, err := Compile(LiteralEntry{Value: "null"})
+	rule, err := compile(literalEntry{Value: "null"})
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 	allowNull, _ := m.Match(ParseResult{Raw: "null", IsNull: true})
 	assert.True(suite.T(), allowNull)
 	parsed, err := ParseOrigin("https://example.com")
@@ -70,12 +70,12 @@ func (suite *CompilerTestSuite) TestCompileNullLiteral() {
 }
 
 func (suite *CompilerTestSuite) TestCompileWildcardLiteralRejected() {
-	_, err := Compile(LiteralEntry{Value: "*"})
+	_, err := compile(literalEntry{Value: "*"})
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrWildcardLiteral))
 }
 
-func (suite *CompilerTestSuite) TestIsRegexAnchored() {
+func (suite *CompilerTestSuite) TestisRegexAnchored() {
 	cases := []struct {
 		pattern  string
 		anchored bool
@@ -90,30 +90,30 @@ func (suite *CompilerTestSuite) TestIsRegexAnchored() {
 		{`.*\.example\.com`, false},
 	}
 	for _, c := range cases {
-		assert.Equal(suite.T(), c.anchored, IsRegexAnchored(c.pattern), c.pattern)
+		assert.Equal(suite.T(), c.anchored, isRegexAnchored(c.pattern), c.pattern)
 	}
 }
 
 func (suite *CompilerTestSuite) TestCompileEmptyLiteralRejected() {
-	_, err := Compile(LiteralEntry{Value: "   "})
+	_, err := compile(literalEntry{Value: "   "})
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrEmptyEntry))
 }
 
 func (suite *CompilerTestSuite) TestCompileInvalidLiteralRejected() {
-	_, err := Compile(LiteralEntry{Value: "not-a-url"})
+	_, err := compile(literalEntry{Value: "not-a-url"})
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrInvalidLiteral))
 }
 
 func (suite *CompilerTestSuite) TestCompileEmptyRegexRejected() {
-	_, err := Compile(RegexEntry{Pattern: ""})
+	_, err := compile(regexEntry{Pattern: ""})
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrEmptyEntry))
 }
 
 func (suite *CompilerTestSuite) TestCompileInvalidRegexRejected() {
-	_, err := Compile(RegexEntry{Pattern: "([unterminated"})
+	_, err := compile(regexEntry{Pattern: "([unterminated"})
 	suite.Require().Error(err)
 	assert.True(suite.T(), errors.Is(err, ErrInvalidRegex))
 }
@@ -123,33 +123,33 @@ type unknownEntry struct{}
 func (unknownEntry) isOriginEntry() {}
 
 func (suite *CompilerTestSuite) TestCompileUnknownEntryTypeRejected() {
-	_, err := Compile(unknownEntry{})
+	_, err := compile(unknownEntry{})
 	suite.Require().Error(err)
 }
 
 func (suite *CompilerTestSuite) TestCompileAllEmptyInput() {
-	rules, err := CompileAll(nil)
+	rules, err := compileAll(nil)
 	suite.Require().NoError(err)
 	assert.Nil(suite.T(), rules)
 }
 
 func (suite *CompilerTestSuite) TestCompileAllPreservesOrder() {
-	rules, err := CompileAll([]Entry{
-		LiteralEntry{Value: "https://a.com"},
-		RegexEntry{Pattern: `^https://b\.com$`},
-		LiteralEntry{Value: "https://c.com"},
+	rules, err := compileAll([]entry{
+		literalEntry{Value: "https://a.com"},
+		regexEntry{Pattern: `^https://b\.com$`},
+		literalEntry{Value: "https://c.com"},
 	})
 	suite.Require().NoError(err)
 	suite.Require().Len(rules, 3)
-	assert.Equal(suite.T(), RuleLiteral, rules[0].Kind())
-	assert.Equal(suite.T(), RuleRegex, rules[1].Kind())
-	assert.Equal(suite.T(), RuleLiteral, rules[2].Kind())
+	assert.Equal(suite.T(), kindLiteral, rules[0].kind())
+	assert.Equal(suite.T(), kindRegex, rules[1].kind())
+	assert.Equal(suite.T(), kindLiteral, rules[2].kind())
 }
 
 func (suite *CompilerTestSuite) TestCompileAllFailsFastWithIndex() {
-	_, err := CompileAll([]Entry{
-		LiteralEntry{Value: "https://ok.com"},
-		RegexEntry{Pattern: "([bad"},
+	_, err := compileAll([]entry{
+		literalEntry{Value: "https://ok.com"},
+		regexEntry{Pattern: "([bad"},
 	})
 	suite.Require().Error(err)
 	assert.Contains(suite.T(), err.Error(), "allowed_origins[1]")
@@ -163,8 +163,8 @@ func (suite *CompilerTestSuite) TestUnmarshalYAMLLiteralEntries() {
 	var entries OriginEntries
 	suite.Require().NoError(yaml.Unmarshal(doc, &entries))
 	suite.Require().Len(entries, 2)
-	assert.IsType(suite.T(), LiteralEntry{}, entries[0])
-	assert.IsType(suite.T(), LiteralEntry{}, entries[1])
+	assert.IsType(suite.T(), literalEntry{}, entries[0])
+	assert.IsType(suite.T(), literalEntry{}, entries[1])
 }
 
 func (suite *CompilerTestSuite) TestUnmarshalYAMLRegexEntries() {
@@ -174,7 +174,7 @@ func (suite *CompilerTestSuite) TestUnmarshalYAMLRegexEntries() {
 	var entries OriginEntries
 	suite.Require().NoError(yaml.Unmarshal(doc, &entries))
 	suite.Require().Len(entries, 1)
-	r, ok := entries[0].(RegexEntry)
+	r, ok := entries[0].(regexEntry)
 	suite.Require().True(ok)
 	assert.Equal(suite.T(), `^https://[a-z]+\.example\.com$`, r.Pattern)
 }
@@ -188,9 +188,9 @@ func (suite *CompilerTestSuite) TestUnmarshalYAMLMixedEntries() {
 	var entries OriginEntries
 	suite.Require().NoError(yaml.Unmarshal(doc, &entries))
 	suite.Require().Len(entries, 3)
-	assert.IsType(suite.T(), LiteralEntry{}, entries[0])
-	assert.IsType(suite.T(), RegexEntry{}, entries[1])
-	assert.IsType(suite.T(), LiteralEntry{}, entries[2])
+	assert.IsType(suite.T(), literalEntry{}, entries[0])
+	assert.IsType(suite.T(), regexEntry{}, entries[1])
+	assert.IsType(suite.T(), literalEntry{}, entries[2])
 }
 
 func (suite *CompilerTestSuite) TestUnmarshalYAMLNonSequenceRejected() {

--- a/backend/internal/system/cors/instance.go
+++ b/backend/internal/system/cors/instance.go
@@ -27,12 +27,12 @@ package cors
 import "github.com/asgardeo/thunder/internal/system/log"
 
 // instance holds the process-wide compiled CORS matcher. It is populated once
-// at server start by InitializeMatcher (called from the config package during
-// deployment.yaml validation) and read on every CORS request via GetMatcher.
+// at server start by InitializeMatcher (called from the server bootstrap
+// after configuration has been validated) and read on every CORS request via
+// GetMatcher.
 //
 // The field is a plain pointer rather than an atomic — Initialize runs on the
-// main goroutine before the HTTP server starts, and tests reset and reinstall
-// it synchronously before issuing requests, so there is no concurrent
+// main goroutine before the HTTP server starts, so there is no concurrent
 // reader/writer overlap to guard against.
 var instance *Matcher
 
@@ -47,18 +47,18 @@ var instance *Matcher
 // pattern into a partial-match filter and almost always allows far more
 // origins than intended.
 func InitializeMatcher(entries OriginEntries) error {
-	rules, err := CompileAll(entries)
+	rules, err := compileAll(entries)
 	if err != nil {
 		return err
 	}
-	m := NewMatcher(rules)
+	m := newMatcher(rules)
 
-	for i, entry := range entries {
-		rx, ok := entry.(RegexEntry)
+	for i, e := range entries {
+		rx, ok := e.(regexEntry)
 		if !ok {
 			continue
 		}
-		if !IsRegexAnchored(rx.Pattern) {
+		if !isRegexAnchored(rx.Pattern) {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CORS"))
 			logger.Warn("cors.allowed_origins regex is not fully anchored; partial matches are likely",
 				log.Int("index", i),
@@ -76,11 +76,4 @@ func InitializeMatcher(entries OriginEntries) error {
 // AllowedOrigins list.
 func GetMatcher() *Matcher {
 	return instance
-}
-
-// ResetMatcher clears the installed singleton. It is intended for tests that
-// exercise multiple configurations within a single process; production code
-// calls InitializeMatcher once at boot and never resets.
-func ResetMatcher() {
-	instance = nil
 }

--- a/backend/internal/system/cors/matcher.go
+++ b/backend/internal/system/cors/matcher.go
@@ -35,23 +35,23 @@ type Matcher struct {
 	size        int
 }
 
-// NewMatcher constructs a Matcher over the given compiled rules. Literal and
+// newMatcher constructs a Matcher over the given compiled rules. Literal and
 // regex rules are partitioned; null literals are tracked via nullAllowed. A
 // nil or empty slice yields a matcher that rejects every origin.
-func NewMatcher(rules []OriginRule) *Matcher {
+func newMatcher(rules []originRule) *Matcher {
 	m := &Matcher{
 		literals: make(map[string]struct{}),
 		size:     len(rules),
 	}
 	for _, rule := range rules {
 		switch r := rule.(type) {
-		case LiteralRule:
+		case literalRule:
 			if r.isNull {
 				m.nullAllowed = true
 				continue
 			}
 			m.literals[r.canonical] = struct{}{}
-		case RegexRule:
+		case regexRule:
 			m.regexes = append(m.regexes, r.re)
 		}
 	}
@@ -90,8 +90,7 @@ func (m *Matcher) Match(parsed ParseResult) (allow bool, echo string) {
 	return false, ""
 }
 
-// Size reports the total number of rules the matcher holds. Intended for
-// boot-time logging and tests.
+// Size reports the total number of rules the matcher holds.
 func (m *Matcher) Size() int {
 	if m == nil {
 		return 0

--- a/backend/internal/system/cors/matcher_test.go
+++ b/backend/internal/system/cors/matcher_test.go
@@ -33,14 +33,14 @@ func TestMatcherTestSuite(t *testing.T) {
 	suite.Run(t, new(MatcherTestSuite))
 }
 
-func (suite *MatcherTestSuite) buildMatcher(entries ...Entry) *Matcher {
-	rules, err := CompileAll(entries)
+func (suite *MatcherTestSuite) buildMatcher(entries ...entry) *Matcher {
+	rules, err := compileAll(entries)
 	suite.Require().NoError(err)
-	return NewMatcher(rules)
+	return newMatcher(rules)
 }
 
 func (suite *MatcherTestSuite) TestEmptyMatcherRejectsAll() {
-	m := NewMatcher(nil)
+	m := newMatcher(nil)
 	allow, echo := m.Match(ParseResult{Raw: "https://example.com"})
 	assert.False(suite.T(), allow)
 	assert.Empty(suite.T(), echo)
@@ -56,7 +56,7 @@ func (suite *MatcherTestSuite) TestNilMatcherRejectsAll() {
 }
 
 func (suite *MatcherTestSuite) TestMatchEchoesRawHeader() {
-	m := suite.buildMatcher(LiteralEntry{Value: "https://example.com"})
+	m := suite.buildMatcher(literalEntry{Value: "https://example.com"})
 	parsed, err := ParseOrigin("HTTPS://Example.COM")
 	suite.Require().NoError(err)
 	allow, echo := m.Match(parsed)
@@ -67,8 +67,8 @@ func (suite *MatcherTestSuite) TestMatchEchoesRawHeader() {
 
 func (suite *MatcherTestSuite) TestFirstMatchWins() {
 	m := suite.buildMatcher(
-		LiteralEntry{Value: "https://example.com"},
-		RegexEntry{Pattern: `^https://example\.com$`},
+		literalEntry{Value: "https://example.com"},
+		regexEntry{Pattern: `^https://example\.com$`},
 	)
 	parsed, err := ParseOrigin("https://example.com")
 	suite.Require().NoError(err)
@@ -80,8 +80,8 @@ func (suite *MatcherTestSuite) TestFirstMatchWins() {
 
 func (suite *MatcherTestSuite) TestRegexFallbackWhenLiteralMisses() {
 	m := suite.buildMatcher(
-		LiteralEntry{Value: "https://exact.com"},
-		RegexEntry{Pattern: `^https://[a-z]+\.staging\.example\.com$`},
+		literalEntry{Value: "https://exact.com"},
+		regexEntry{Pattern: `^https://[a-z]+\.staging\.example\.com$`},
 	)
 	allow, echo := m.Match(ParseResult{Raw: "https://tenant.staging.example.com"})
 	assert.True(suite.T(), allow)
@@ -90,8 +90,8 @@ func (suite *MatcherTestSuite) TestRegexFallbackWhenLiteralMisses() {
 
 func (suite *MatcherTestSuite) TestNoMatchRejected() {
 	m := suite.buildMatcher(
-		LiteralEntry{Value: "https://example.com"},
-		RegexEntry{Pattern: `^https://[a-z]+\.example\.com$`},
+		literalEntry{Value: "https://example.com"},
+		regexEntry{Pattern: `^https://[a-z]+\.example\.com$`},
 	)
 	allow, echo := m.Match(ParseResult{Raw: "https://malicious.com"})
 	assert.False(suite.T(), allow)
@@ -99,23 +99,23 @@ func (suite *MatcherTestSuite) TestNoMatchRejected() {
 }
 
 func (suite *MatcherTestSuite) TestNullOriginMatchesOnlyNullRule() {
-	m := suite.buildMatcher(LiteralEntry{Value: "null"})
+	m := suite.buildMatcher(literalEntry{Value: "null"})
 	allow, echo := m.Match(ParseResult{Raw: "null", IsNull: true})
 	assert.True(suite.T(), allow)
 	assert.Equal(suite.T(), "null", echo)
 }
 
 func (suite *MatcherTestSuite) TestNullOriginRejectedByLiteralOrigins() {
-	m := suite.buildMatcher(LiteralEntry{Value: "https://example.com"})
+	m := suite.buildMatcher(literalEntry{Value: "https://example.com"})
 	allow, _ := m.Match(ParseResult{Raw: "null", IsNull: true})
 	assert.False(suite.T(), allow)
 }
 
 func (suite *MatcherTestSuite) TestNewMatcherCopiesRuleSlice() {
-	rules, err := CompileAll([]Entry{LiteralEntry{Value: "https://example.com"}})
+	rules, err := compileAll([]entry{literalEntry{Value: "https://example.com"}})
 	suite.Require().NoError(err)
 
-	m := NewMatcher(rules)
+	m := newMatcher(rules)
 
 	// Mutate the caller's slice; the matcher must be unaffected.
 	rules[0] = nil
@@ -128,10 +128,10 @@ func (suite *MatcherTestSuite) TestNewMatcherCopiesRuleSlice() {
 
 func (suite *MatcherTestSuite) TestLiteralAndRegexCounts() {
 	m := suite.buildMatcher(
-		LiteralEntry{Value: "https://a.com"},
-		LiteralEntry{Value: "https://b.com"},
-		LiteralEntry{Value: "null"},
-		RegexEntry{Pattern: `^https://[a-z]+\.example\.com$`},
+		literalEntry{Value: "https://a.com"},
+		literalEntry{Value: "https://b.com"},
+		literalEntry{Value: "null"},
+		regexEntry{Pattern: `^https://[a-z]+\.example\.com$`},
 	)
 	assert.Equal(suite.T(), 4, m.Size())
 	assert.Equal(suite.T(), 3, m.LiteralCount())
@@ -139,18 +139,21 @@ func (suite *MatcherTestSuite) TestLiteralAndRegexCounts() {
 }
 
 func (suite *MatcherTestSuite) TestMatchUsesPreCanonicalizedFastPath() {
-	// When ParseOrigin has populated Canonical, the matcher must not
-	// require the matcher to recompute it. This is the production hot path.
-	m := suite.buildMatcher(LiteralEntry{Value: "https://example.com"})
-	parsed, err := ParseOrigin("HTTPS://Example.COM")
-	suite.Require().NoError(err)
+	// Construct ParseResult directly so the test would fail if Match ever
+	// recomputed the canonical form internally instead of trusting the
+	// pre-populated value. This is the production hot path.
+	m := suite.buildMatcher(literalEntry{Value: "https://example.com"})
+	parsed := ParseResult{
+		Raw:       "HTTPS://Example.COM",
+		Canonical: "https://example.com",
+	}
 	allow, echo := m.Match(parsed)
 	assert.True(suite.T(), allow)
 	assert.Equal(suite.T(), "HTTPS://Example.COM", echo)
 }
 
 func (suite *MatcherTestSuite) TestIPv6OriginMatchesLiteral() {
-	m := suite.buildMatcher(LiteralEntry{Value: "https://[::1]:8443"})
+	m := suite.buildMatcher(literalEntry{Value: "https://[::1]:8443"})
 	parsed, err := ParseOrigin("https://[::1]:8443")
 	suite.Require().NoError(err)
 	allow, _ := m.Match(parsed)
@@ -158,7 +161,7 @@ func (suite *MatcherTestSuite) TestIPv6OriginMatchesLiteral() {
 }
 
 func (suite *MatcherTestSuite) TestIDNUnicodeMatchesPunycodeLiteral() {
-	m := suite.buildMatcher(LiteralEntry{Value: "https://xn--mnchen-3ya.example"})
+	m := suite.buildMatcher(literalEntry{Value: "https://xn--mnchen-3ya.example"})
 	parsed, err := ParseOrigin("https://münchen.example")
 	suite.Require().NoError(err)
 	allow, echo := m.Match(parsed)
@@ -168,7 +171,7 @@ func (suite *MatcherTestSuite) TestIDNUnicodeMatchesPunycodeLiteral() {
 }
 
 func (suite *MatcherTestSuite) TestTrailingDotMatchesBareHost() {
-	m := suite.buildMatcher(LiteralEntry{Value: "https://example.com"})
+	m := suite.buildMatcher(literalEntry{Value: "https://example.com"})
 	parsed, err := ParseOrigin("https://example.com.")
 	suite.Require().NoError(err)
 	allow, _ := m.Match(parsed)
@@ -179,18 +182,18 @@ func (suite *MatcherTestSuite) TestTrailingDotMatchesBareHost() {
 // O(1) map path so we can compare it against the legacy O(n) scan if needed
 // while sizing rule-set growth budgets.
 func BenchmarkMatchLiteralHitMap(b *testing.B) {
-	entries := []Entry{
-		LiteralEntry{Value: "https://a.example.com"},
-		LiteralEntry{Value: "https://b.example.com"},
-		LiteralEntry{Value: "https://c.example.com"},
-		LiteralEntry{Value: "https://d.example.com"},
-		LiteralEntry{Value: "https://e.example.com"},
+	entries := []entry{
+		literalEntry{Value: "https://a.example.com"},
+		literalEntry{Value: "https://b.example.com"},
+		literalEntry{Value: "https://c.example.com"},
+		literalEntry{Value: "https://d.example.com"},
+		literalEntry{Value: "https://e.example.com"},
 	}
-	rules, err := CompileAll(entries)
+	rules, err := compileAll(entries)
 	if err != nil {
 		b.Fatal(err)
 	}
-	m := NewMatcher(rules)
+	m := newMatcher(rules)
 	parsed, err := ParseOrigin("https://e.example.com")
 	if err != nil {
 		b.Fatal(err)
@@ -207,18 +210,18 @@ func BenchmarkMatchLiteralHitMap(b *testing.B) {
 // BenchmarkMatchRegexMiss measures the cost of a regex-only matcher when the
 // request origin does not match — this is the worst case for CORS overhead.
 func BenchmarkMatchRegexMiss(b *testing.B) {
-	entries := []Entry{
-		RegexEntry{Pattern: `^https://[a-z]+\.a\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z]+\.b\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z]+\.c\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z]+\.d\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z]+\.e\.example\.com$`},
+	entries := []entry{
+		regexEntry{Pattern: `^https://[a-z]+\.a\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z]+\.b\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z]+\.c\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z]+\.d\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z]+\.e\.example\.com$`},
 	}
-	rules, err := CompileAll(entries)
+	rules, err := compileAll(entries)
 	if err != nil {
 		b.Fatal(err)
 	}
-	m := NewMatcher(rules)
+	m := newMatcher(rules)
 	parsed, err := ParseOrigin("https://attacker.example")
 	if err != nil {
 		b.Fatal(err)
@@ -235,14 +238,14 @@ func BenchmarkMatchRegexMiss(b *testing.B) {
 // BenchmarkCompileAllRegex sizes the boot-time cost of compiling a small
 // regex set so we can confirm the cached-matcher decision (D1) is justified.
 func BenchmarkCompileAllRegex(b *testing.B) {
-	entries := []Entry{
-		RegexEntry{Pattern: `^https://[a-z0-9-]+\.tenant\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z0-9-]+\.staging\.example\.com$`},
-		RegexEntry{Pattern: `^https://[a-z0-9-]+\.dev\.example\.com$`},
+	entries := []entry{
+		regexEntry{Pattern: `^https://[a-z0-9-]+\.tenant\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z0-9-]+\.staging\.example\.com$`},
+		regexEntry{Pattern: `^https://[a-z0-9-]+\.dev\.example\.com$`},
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := CompileAll(entries)
+		_, err := compileAll(entries)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/backend/internal/system/cors/model.go
+++ b/backend/internal/system/cors/model.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cors
+
+// entry is the discriminated-union type produced by YAML decoding. It carries
+// either a literal allowed-origin string or a regex pattern. compile turns an
+// entry into the corresponding compiled originRule. The interface and its
+// implementations are unexported; callers outside the cors package construct
+// OriginEntries values exclusively via YAML decoding through UnmarshalYAML.
+type entry interface {
+	isOriginEntry()
+}
+
+// literalEntry is the bare-string YAML form, e.g. "https://example.com" or
+// the special-case "null".
+type literalEntry struct {
+	Value string
+}
+
+// isOriginEntry marks literalEntry as a member of the entry sealed-interface
+// union. The method has no behavior and is never called directly; its sole
+// purpose is to restrict entry implementations to types declared in this
+// package.
+func (literalEntry) isOriginEntry() {}
+
+// regexEntry is the object YAML form, e.g. { regex: "\\Ahttps://..." }.
+type regexEntry struct {
+	Pattern string
+}
+
+// isOriginEntry marks regexEntry as a member of the entry sealed-interface
+// union. The method has no behavior and is never called directly; its sole
+// purpose is to restrict entry implementations to types declared in this
+// package.
+func (regexEntry) isOriginEntry() {}
+
+// OriginEntries is the slice wrapper that carries the heterogeneous YAML
+// schema for cors.allowed_origins. The element type is unexported, so callers
+// outside the cors package construct values exclusively through YAML
+// decoding. Custom YAML unmarshaling on this type dispatches between the two
+// entry forms.
+type OriginEntries []entry

--- a/backend/internal/system/cors/rule.go
+++ b/backend/internal/system/cors/rule.go
@@ -20,28 +20,28 @@ package cors
 
 import "regexp"
 
-// RuleKind identifies whether a compiled rule was sourced from a literal or
+// ruleKind identifies whether a compiled rule was sourced from a literal or
 // a regex configuration entry. It is intended for diagnostics and logging.
-type RuleKind int
+type ruleKind int
 
 const (
-	// RuleLiteral indicates a rule compiled from a bare-string YAML entry.
-	RuleLiteral RuleKind = iota
-	// RuleRegex indicates a rule compiled from a regex YAML entry.
-	RuleRegex
+	// kindLiteral indicates a rule compiled from a bare-string YAML entry.
+	kindLiteral ruleKind = iota
+	// kindRegex indicates a rule compiled from a regex YAML entry.
+	kindRegex
 )
 
-// OriginRule is the discriminated-union type produced by Compile. The matcher
+// originRule is the discriminated-union type produced by compile. The matcher
 // disassembles compiled rules into kind-specific data structures
 // (canonical-key map for literals, regex slice for regex rules) so request-time
 // matching avoids interface dispatch and per-request canonicalization. Only
-// Kind() is needed at runtime; matching itself is performed by the Matcher.
-type OriginRule interface {
-	// Kind reports the rule's source kind.
-	Kind() RuleKind
+// kind() is needed at runtime; matching itself is performed by the Matcher.
+type originRule interface {
+	// kind reports the rule's source kind.
+	kind() ruleKind
 }
 
-// LiteralRule matches a single canonicalized origin. The canonical form uses
+// literalRule matches a single canonicalized origin. The canonical form uses
 // the lowercased scheme + lowercased host (with IDN labels Punycode-encoded
 // and any trailing dot stripped); IPv6 hosts are bracketed. The port is
 // preserved verbatim, so a portless origin and the same origin with an
@@ -49,22 +49,22 @@ type OriginRule interface {
 // "https://example.com:443") remain distinct rules — operators that want both
 // allowed must list each entry. The "null" origin is represented by isNull;
 // such a rule matches only inputs whose IsNull flag is set.
-type LiteralRule struct {
+type literalRule struct {
 	canonical string
 	isNull    bool
 }
 
-// Kind reports RuleLiteral.
-func (r LiteralRule) Kind() RuleKind { return RuleLiteral }
+// kind reports kindLiteral.
+func (r literalRule) kind() ruleKind { return kindLiteral }
 
-// RegexRule matches the raw request Origin header against an operator-supplied
+// regexRule matches the raw request Origin header against an operator-supplied
 // RE2 pattern. The regex sees the raw header byte for byte after only the
 // parse gate; no canonicalization or transformation is applied on the regex
 // path. Operators own pattern correctness, including any anchoring required
 // for full-input match (\A...\z).
-type RegexRule struct {
+type regexRule struct {
 	re *regexp.Regexp
 }
 
-// Kind reports RuleRegex.
-func (r RegexRule) Kind() RuleKind { return RuleRegex }
+// kind reports kindRegex.
+func (r regexRule) kind() ruleKind { return kindRegex }

--- a/backend/internal/system/cors/rule_test.go
+++ b/backend/internal/system/cors/rule_test.go
@@ -40,7 +40,7 @@ func TestRuleTestSuite(t *testing.T) {
 func (suite *RuleTestSuite) matchLiteralAgainst(literal, input string) bool {
 	rule, err := compileLiteral(literal)
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 	parsed, parseErr := ParseOrigin(input)
 	if parseErr != nil {
 		// Parse-gate failure → matcher should reject; we propagate by
@@ -88,7 +88,7 @@ func (suite *RuleTestSuite) TestLiteralRejectsUncanonicalizableInput() {
 func (suite *RuleTestSuite) TestLiteralNullMatchesOnlyNull() {
 	rule, err := compileLiteral("null")
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 
 	allowNull, _ := m.Match(ParseResult{Raw: "null", IsNull: true})
 	assert.True(suite.T(), allowNull)
@@ -102,7 +102,7 @@ func (suite *RuleTestSuite) TestLiteralNullMatchesOnlyNull() {
 func (suite *RuleTestSuite) TestLiteralNonNullDoesNotMatchNullInput() {
 	rule, err := compileLiteral("https://example.com")
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 	allow, _ := m.Match(ParseResult{Raw: "null", IsNull: true})
 	assert.False(suite.T(), allow)
 }
@@ -110,13 +110,13 @@ func (suite *RuleTestSuite) TestLiteralNonNullDoesNotMatchNullInput() {
 func (suite *RuleTestSuite) TestLiteralKindIsLiteral() {
 	rule, err := compileLiteral("https://example.com")
 	suite.Require().NoError(err)
-	assert.Equal(suite.T(), RuleLiteral, rule.Kind())
+	assert.Equal(suite.T(), kindLiteral, rule.kind())
 }
 
 func (suite *RuleTestSuite) TestRegexMatchesAgainstRawHeader() {
 	rule, err := compileRegex(`^https://[a-z]+\.example\.com$`)
 	suite.Require().NoError(err)
-	m := NewMatcher([]OriginRule{rule})
+	m := newMatcher([]originRule{rule})
 
 	lower, err := ParseOrigin("https://tenant.example.com")
 	suite.Require().NoError(err)
@@ -138,5 +138,5 @@ func (suite *RuleTestSuite) TestRegexMatchesAgainstRawHeader() {
 func (suite *RuleTestSuite) TestRegexKindIsRegex() {
 	rule, err := compileRegex(`.+`)
 	suite.Require().NoError(err)
-	assert.Equal(suite.T(), RuleRegex, rule.Kind())
+	assert.Equal(suite.T(), kindRegex, rule.kind())
 }

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -47,7 +47,9 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // HandlerTestSuite contains comprehensive tests for the export handler functions.
@@ -64,15 +66,14 @@ type HandlerTestSuite struct {
 func (suite *HandlerTestSuite) SetupTest() {
 	// Initialize config for tests
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	suite.Require().NoError(yaml.Unmarshal([]byte(`
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	suite.Require().NoError(testConfig.CORS.Validate())
+	suite.Require().NoError(cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	suite.Require().NoError(err)
 
@@ -94,7 +95,6 @@ func (suite *HandlerTestSuite) SetupTest() {
 
 func (suite *HandlerTestSuite) TearDownTest() {
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
 }
 
 func TestHandlerTestSuite(t *testing.T) {
@@ -377,21 +377,17 @@ func TestGenerateAndSendZipResponse_Standalone(t *testing.T) {
 	logger := log.GetLogger()
 	// Setup config
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	assert.NoError(t, yaml.Unmarshal([]byte(`
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	require.NoError(t, cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	assert.NoError(t, err)
-	defer func() {
-		config.ResetThunderRuntime()
-		cors.ResetMatcher()
-	}()
+	defer config.ResetThunderRuntime()
 
 	// Setup handler
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)

--- a/backend/internal/system/export/init_test.go
+++ b/backend/internal/system/export/init_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // InitTestSuite contains comprehensive tests for the init.go file.
@@ -61,17 +62,16 @@ func (suite *InitTestSuite) SetupTest() {
 	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	// Initialize config for CORS middleware
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	suite.Require().NoError(yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	if err := testConfig.CORS.Validate(); err != nil {
-		suite.T().Fatalf("Failed to validate CORS config: %v", err)
+	if err := cors.InitializeMatcher(testConfig.CORS.AllowedOrigins); err != nil {
+		suite.T().Fatalf("Failed to initialize CORS matcher: %v", err)
 	}
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	if err != nil {
@@ -82,7 +82,6 @@ func (suite *InitTestSuite) SetupTest() {
 func (suite *InitTestSuite) TearDownTest() {
 	// Reset config to clear singleton state for next test
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
 }
 
 func TestInitTestSuite(t *testing.T) {
@@ -358,22 +357,18 @@ func BenchmarkRegisterRoutes(b *testing.B) {
 func TestInitialize_Standalone(t *testing.T) {
 	// Setup config for CORS middleware
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	assert.NoError(t, yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	assert.NoError(t, cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	assert.NoError(t, err)
-	defer func() {
-		config.ResetThunderRuntime()
-		cors.ResetMatcher()
-	}()
+	defer config.ResetThunderRuntime()
 
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 	mockIDPService := idpmock.NewIDPServiceInterfaceMock(t)
@@ -394,22 +389,18 @@ func TestInitialize_Standalone(t *testing.T) {
 func TestRegisterRoutes_Standalone(t *testing.T) {
 	// Setup config for CORS middleware
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	assert.NoError(t, yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	assert.NoError(t, cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	assert.NoError(t, err)
-	defer func() {
-		config.ResetThunderRuntime()
-		cors.ResetMatcher()
-	}()
+	defer config.ResetThunderRuntime()
 
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 	mockIDPService := idpmock.NewIDPServiceInterfaceMock(t)
@@ -430,22 +421,18 @@ func TestRegisterRoutes_Standalone(t *testing.T) {
 func TestRouteHandling_Standalone(t *testing.T) {
 	// Setup config for CORS middleware
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	assert.NoError(t, yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	assert.NoError(t, cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	assert.NoError(t, err)
-	defer func() {
-		config.ResetThunderRuntime()
-		cors.ResetMatcher()
-	}()
+	defer config.ResetThunderRuntime()
 
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 	mockIDPService := idpmock.NewIDPServiceInterfaceMock(t)
@@ -494,22 +481,18 @@ func TestRouteHandling_Standalone(t *testing.T) {
 func TestCORSConfiguration_Standalone(t *testing.T) {
 	// Setup config for CORS middleware
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
+	var allowedOrigins cors.OriginEntries
+	assert.NoError(t, yaml.Unmarshal([]byte(`
+- https://example.com
+- https://localhost:3000
+`), &allowedOrigins))
 	testConfig := &config.Config{
-		CORS: config.CORSConfig{
-			AllowedOrigins: cors.OriginEntries{
-				cors.LiteralEntry{Value: "https://example.com"},
-				cors.LiteralEntry{Value: "https://localhost:3000"},
-			},
-		},
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
 	}
-	_ = testConfig.CORS.Validate()
+	assert.NoError(t, cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	assert.NoError(t, err)
-	defer func() {
-		config.ResetThunderRuntime()
-		cors.ResetMatcher()
-	}()
+	defer config.ResetThunderRuntime()
 
 	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
 	mockIDPService := idpmock.NewIDPServiceInterfaceMock(t)

--- a/backend/internal/system/middleware/cors_test.go
+++ b/backend/internal/system/middleware/cors_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/cors"
@@ -38,29 +39,33 @@ func TestCORSMiddlewareTestSuite(t *testing.T) {
 	suite.Run(t, new(CORSMiddlewareTestSuite))
 }
 
-// initRuntime installs a fresh CORS matcher built from the given entries and
-// seeds the runtime config singleton. SetupTest calls this with the default
-// configuration; tests that need a different one call ResetThunderRuntime +
-// initRuntime directly. Validate is invoked explicitly here because the
-// matcher now lives in the cors package — production goes through LoadConfig,
-// and tests that bypass it own that step.
-func initRuntime(entries cors.OriginEntries) {
+// initRuntime parses the given YAML allowed-origins document, installs a
+// fresh CORS matcher from it, and seeds the runtime config singleton. Pass
+// the empty string to install an empty matcher. SetupTest calls this with
+// the default doc; tests that need different origins call ResetThunderRuntime
+// + initRuntime directly. cors.InitializeMatcher is invoked explicitly here
+// because production wires it from the server bootstrap; tests that bypass
+// LoadConfig + main own that step themselves.
+func (suite *CORSMiddlewareTestSuite) initRuntime(allowedOriginsYAML string) {
+	var entries cors.OriginEntries
+	if allowedOriginsYAML != "" {
+		suite.Require().NoError(yaml.Unmarshal([]byte(allowedOriginsYAML), &entries))
+	}
 	cfg := &config.Config{CORS: config.CORSConfig{AllowedOrigins: entries}}
-	_ = cfg.CORS.Validate()
-	_ = config.InitializeThunderRuntime("/tmp", cfg)
+	suite.Require().NoError(cors.InitializeMatcher(cfg.CORS.AllowedOrigins))
+	suite.Require().NoError(config.InitializeThunderRuntime("/tmp", cfg))
 }
 
 func (suite *CORSMiddlewareTestSuite) SetupTest() {
-	initRuntime(cors.OriginEntries{
-		cors.LiteralEntry{Value: "https://example.com"},
-		cors.LiteralEntry{Value: "https://test.com"},
-		cors.RegexEntry{Pattern: `^https://[a-z0-9-]+\.staging\.example\.com$`},
-	})
+	suite.initRuntime(`
+- https://example.com
+- https://test.com
+- regex: ^https://[a-z0-9-]+\.staging\.example\.com$
+`)
 }
 
 func (suite *CORSMiddlewareTestSuite) TearDownTest() {
 	config.ResetThunderRuntime()
-	cors.ResetMatcher()
 }
 
 // newGetRequest returns a (GET request, recorder) pair primed with the given
@@ -263,7 +268,7 @@ func (suite *CORSMiddlewareTestSuite) TestWithCORS_MultipleAllowedOrigins() {
 
 func (suite *CORSMiddlewareTestSuite) TestWithCORS_NoOriginsConfigured() {
 	config.ResetThunderRuntime()
-	initRuntime(nil)
+	suite.initRuntime("")
 
 	_, wrapped := WithCORS("GET /test", noopHandler, fullOpts)
 
@@ -388,9 +393,9 @@ func (suite *CORSMiddlewareTestSuite) TestWithCORS_OriginAllWhitespaceIgnored() 
 
 func (suite *CORSMiddlewareTestSuite) TestWithCORS_IPv6Origin() {
 	config.ResetThunderRuntime()
-	initRuntime(cors.OriginEntries{
-		cors.LiteralEntry{Value: "http://[::1]:8080"},
-	})
+	suite.initRuntime(`
+- http://[::1]:8080
+`)
 
 	_, wrapped := WithCORS("GET /test", noopHandler, fullOpts)
 
@@ -405,9 +410,9 @@ func (suite *CORSMiddlewareTestSuite) TestWithCORS_IDNOriginPunycodeEquivalence(
 	// Configure with the Punycode form; a request that uses the Unicode form
 	// must canonicalize to the same value and match.
 	config.ResetThunderRuntime()
-	initRuntime(cors.OriginEntries{
-		cors.LiteralEntry{Value: "https://xn--mnchen-3ya.example"},
-	})
+	suite.initRuntime(`
+- https://xn--mnchen-3ya.example
+`)
 
 	_, wrapped := WithCORS("GET /test", noopHandler, fullOpts)
 
@@ -420,9 +425,9 @@ func (suite *CORSMiddlewareTestSuite) TestWithCORS_IDNOriginPunycodeEquivalence(
 
 func (suite *CORSMiddlewareTestSuite) TestWithCORS_NullOriginAllowed() {
 	config.ResetThunderRuntime()
-	initRuntime(cors.OriginEntries{
-		cors.LiteralEntry{Value: "null"},
-	})
+	suite.initRuntime(`
+- "null"
+`)
 
 	_, wrapped := WithCORS("GET /test", noopHandler, fullOpts)
 
@@ -480,9 +485,9 @@ func (suite *CORSMiddlewareTestSuite) TestWithCORS_HotReloadMatcherTakesEffect()
 	assert.Equal(suite.T(), "https://example.com", w1.Header().Get("Access-Control-Allow-Origin"))
 
 	config.ResetThunderRuntime()
-	initRuntime(cors.OriginEntries{
-		cors.LiteralEntry{Value: "https://other.com"},
-	})
+	suite.initRuntime(`
+- https://other.com
+`)
 
 	req2, w2 := newGetRequest("https://example.com")
 	wrapped(w2, req2)


### PR DESCRIPTION
### Purpose

Follow-up to #2494 — addresses the unresolved review comments on the merged CORS hardening PR.

Changes are incremental polish on top of the merged work. No behavioral change to the CORS matching algorithm itself; this PR is about API surface, package separation, and a couple of test/doc fixes that came out of review.

### Approach

**Split `CORSConfig.Validate()` into pure validation; install matcher from server bootstrap (#3163140532)**
The config layer now owns _validation only_. A new `cors.Validate(entries)` is the pure-validation entry point used by `(*CORSConfig).Validate`. The runtime matcher is installed from `cmd/server/main.go` via `cors.InitializeMatcher(cfg.CORS.AllowedOrigins)`, immediately after configuration is loaded. Tests that previously relied on `Validate()` to also install the singleton now call `cors.InitializeMatcher` directly (`oauth/oauth2/authz`, `flow/mgt`, `system/export`, `system/middleware`).

**Audit `cors` package exports; unexport everything internal (#3163215656)**
Outside the package, callers only need:

- `OriginEntries` — YAML config slice type (used in `CORSConfig.AllowedOrigins`)
- `Validate`, `InitializeMatcher`, `GetMatcher` — lifecycle entry points
- `*Matcher`, `Match`, `Size`, `LiteralCount`, `RegexCount` — middleware-facing API
- `ParseOrigin`, `ParseResult` — origin parsing used by middleware
- `Err*` sentinels — error matching

Everything else is now unexported: `entry` interface, `literalEntry`/`regexEntry` structs, `originRule`/`literalRule`/`regexRule`, `ruleKind`/`kindLiteral`/`kindRegex`, `compile`, `compileAll`, `compileLiteral`, `compileRegex`, `canonicalize`, `isRegexAnchored`, `newMatcher`. `ResetMatcher` deleted entirely (no callers after external test cleanup). External tests construct `OriginEntries` exclusively through `yaml.Unmarshal` on the existing `UnmarshalYAML` path — same pattern already established by `cors/compiler_test.go`, `flow/mgt/declarative_resource_test.go`, and others.

**Move type definitions to `model.go` (#3163246931)**
Introduced `cors/model.go` holding the YAML-config type defs (`entry`, `literalEntry`, `regexEntry`, `OriginEntries`, and the marker methods), to match the convention used by other packages (`idp/model.go`, `role/model.go`, `entity/model.go`, etc.). Behavior (`UnmarshalYAML`, `Validate`, `compile*`, `isRegexAnchored`, `nodeKindString`) stays in `compiler.go`.

**Lock the pre-canonicalized fast-path test (CodeRabbit)**
`TestMatchUsesPreCanonicalizedFastPath` now constructs `ParseResult` literally so the test would fail if `Match` ever recomputed the canonical form internally. Previously it called `ParseOrigin`, which could mask a regression where `Match` re-canonicalizes on the hot path.

**Doc-comment polish**

- Added doc comments to the two `isOriginEntry()` marker methods explaining the sealed-interface pattern (#3163088005, #3163224530, #3163225503).
- Dropped test-usage mentions from source comments (#3163328747).
- Trimmed `var instance` and (the now-deleted) `ResetMatcher` comments to focus on intent rather than implementation history (#3163203513, #3163174649).

**Test-setup fail-fast fixes**

- `system/export/handler_test.go`: switched the standalone test from `assert.NoError` to `require.NoError` for `cors.InitializeMatcher` so initialization failures are fatal and don't cascade.
- `system/middleware/cors_test.go`: replaced `_ = config.InitializeThunderRuntime(...)` with `suite.Require().NoError(...)` to surface runtime-init failures the same way matcher-init does.

### Testing

#### Unit tests + lint
- `go test ./...` — **103 packages pass, 0 fail**.
- `make lint_backend` — **0 issues**.

#### Wire-level (curl harness)
A local harness (`target/cors-e2e/run.sh`, not committed) swaps the `cors:` block in `deployment.yaml` across six fixtures, bounces Thunder, and captures every CORS-relevant response header. Every probe matched the unit-test predictions. Spot checks:

| # | Config | Highlights |
|---|---|---|
| 01 | `literal-single` | Allowed origin echoed; uppercase-scheme variant accepted via canonicalization; trailing-slash rejected; preflight allowed and denied paths both correct. |
| 02 | `literal-multi` | All three literals match individually; attacker rejected. |
| 03 | `regex-only` | Anchored `^http://localhost:[0-9]+$` accepts `:9000`/`:1234`/`:8000`; rejects substring/prefix pretenders (`localhost.evil.com`, `evilocalhost:9000`); scheme mismatch (`https://`) denied. |
| 04 | `mixed` | Literal + 2 regex entries all matched; `staging.example.com` (no subdomain) correctly rejected. |
| 05 | `empty` | Every Origin denied; no-Origin still served (no `Vary` because nothing to vary on); preflight denied. |
| 06 | `null-origin` | `Origin: null` echoed; regular literal still works alongside; attacker still rejected. |

#### Browser-level (real Chrome via test harness)
Page origin `http://localhost:9000` (python `http.server` over `harness/index.html`); Thunder on `http://localhost:8090`. Each config swapped the `cors:` block in `deployment.yaml` and bounced Thunder. Each page run executes four cross-origin fetches in real Chrome — matrix below.

| #  | Config           | T1 GET no-creds | T2 GET creds:include[¹] | T3 POST preflight+creds | T4 null-origin iframe |
|----|------------------|:---:|:---:|:---:|:---:|
| 01 | literal-single   | ✓ success    | ✓ blocked | ✓ success | ✓ blocked |
| 02 | literal-multi    | ✓ success    | ✓ blocked | ✓ success | ✓ blocked |
| 03 | regex-only       | ✓ success    | ✓ blocked | ✓ success | ✓ blocked |
| 04 | mixed            | ✓ success    | ✓ blocked | ✓ success | ✓ blocked |
| 05 | empty            | ✓ blocked    | ✓ blocked | ✓ blocked | ✓ blocked |
| 06 | null-origin      | ✓ success    | ✓ blocked | ✓ success | ✓ **success** |

[¹] T2 is by-design blocked across every config: the `/.well-known` endpoint sets `AllowCredentials: false` (public metadata), and Fetch refuses to expose a credentialed-mode response without `Access-Control-Allow-Credentials: true`.

Notable confirmations:
- **Config 03** — page origin matches the regex `^http://localhost:[0-9]+$` end-to-end including the preflight path.
- **Config 05** — every fetch blocked by the browser even though the server returns 2xx (no `Access-Control-Allow-Origin` → browser hides the body). Fail-closed verified.
- **Config 06** — sandboxed iframe produced an opaque `Origin: null`; matcher accepted it because `"null"` was in the allowed list, and the iframe's JS read the response. The single asymmetric cell.

All 24 cells match the predictions. No regressions vs the prior PR #2494 browser run.

### Related Issues
- N/A

### Related PRs
- #2494 (merged — this PR addresses the unresolved review comments)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (See **Testing** above — wire-level curl harness across 6 configs + browser-level Chrome E2E across the same 6 configs, all 24 cells match the unit-test predictions.)
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CORS matcher installation moved to server startup.
  * Internal CORS processing APIs and types made non-public to tighten internal boundaries.

* **Chores**
  * Test suites updated to use the new CORS initialization flow and removed prior matcher reset calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
