### PR TITLE
Remove verified boolean attributes from default Person schema

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -129,11 +129,6 @@ $userSchemaData = ([ordered]@{
             unique = $true
             regex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         }
-        email_verified = @{
-            type = "boolean"
-            displayName = "Email Verified"
-            required = $false
-        }
         given_name = @{
             type = "string"
             displayName = "First Name"
@@ -152,11 +147,6 @@ $userSchemaData = ([ordered]@{
         phone_number = @{
             type = "string"
             displayName = "Phone Number"
-            required = $false
-        }
-        phone_number_verified = @{
-            type = "boolean"
-            displayName = "Phone Number Verified"
             required = $false
         }
         sub = @{
@@ -215,13 +205,11 @@ $adminUserData = ([ordered]@{
         password = "admin"
         sub = "admin"
         email = "admin@example.com"
-        email_verified = $true
         name = "Administrator"
         given_name = "Admin"
         family_name = "User"
         picture = "https://example.com/avatar.jpg"
         phone_number = "+12345678920"
-        phone_number_verified = $true
     }
 } | ConvertTo-Json -Depth 5)
 

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -118,11 +118,6 @@ RESPONSE=$(api_call POST "/user-schemas" '{
       "unique": true,
       "regex": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
     },
-    "email_verified": {
-      "type": "boolean",
-      "displayName": "Email Verified",
-      "required": false
-    },
     "given_name": {
       "type": "string",
       "displayName": "First Name",
@@ -141,11 +136,6 @@ RESPONSE=$(api_call POST "/user-schemas" '{
     "phone_number": {
       "type": "string",
       "displayName": "Phone Number",
-      "required": false
-    },
-    "phone_number_verified": {
-      "type": "boolean",
-      "displayName": "Phone Number Verified",
       "required": false
     },
     "sub": {
@@ -202,13 +192,11 @@ RESPONSE=$(api_call POST "/users" '{
     "password": "admin",
     "sub": "admin",
     "email": "admin@example.com",
-    "email_verified": true,
     "name": "Administrator",
     "given_name": "Admin",
     "family_name": "User",
     "picture": "https://example.com/avatar.jpg",
-    "phone_number": "+12345678920",
-    "phone_number_verified": true
+    "phone_number": "+12345678920"
   }
 }')
 


### PR DESCRIPTION
### Purpose
This change updates the default system-created Person user schema to remove the boolean attributes **email_verified** and **phone_number_verified**.

The reason for this change is that social authentication provisioning is currently failing for system-created user types. In the flow execution path, provisioned attributes are handled as strings. When social login returns verified-status attributes and provisioning passes them through as string values, schema validation fails because the default Person schema expects those attributes to be boolean.

By removing these boolean attributes from the default bootstrap schema, social authentication with provisioning can proceed successfully for system-created user types.

### Approach
Updated the default bootstrap resources in both shell and PowerShell variants to keep the default system-created Person schema aligned with the provisioning behavior used in social authentication flows.

Changes made:

- Removed email_verified and phone_number_verified from the default Person schema definition.
- Removed the same attributes from the seeded admin user payload so bootstrap-created users remain valid against the updated schema.
- Kept the change limited to the default system-created user type bootstrap path, without changing the existing Customer schema which don't have any boolean attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default user schema initialization to remove email and phone number verification flags from the bootstrap process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->