### PR TITLE
Add dynamic input control properties to ProvisioningExecutor

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -197,6 +197,18 @@ const (
 	RuntimeKeySkipDelivery = "skipDelivery"
 	// RuntimeKeyCandidateUsers holds serialized candidate users during disambiguation in resolve mode.
 	RuntimeKeyCandidateUsers = "candidateUsers"
+	// RuntimeKeyPresentedOptionalAttrs holds a space-separated list of optional schema attribute
+	// identifiers that have already been prompted to the user. ProvisioningExecutor uses this to
+	// skip optional attrs the user has already been shown, even if they left the value empty.
+	// TODO: Revisit optional input tracking — if the flow engine gains a mechanism to detect whether
+	// an optional field was intentionally skipped, remove this key and its associated helper methods.
+	RuntimeKeyPresentedOptionalAttrs = "provisioningPresentedOptionalAttrs"
+	// RuntimeKeySMSOTPMobileNumber holds the resolved mobile number for SMS OTP verification.
+	// TODO: Revisit when the generic OTP executor is implemented.
+	RuntimeKeySMSOTPMobileNumber = "smsOTPMobileNumber"
+	// RuntimeKeySMSOTPPhoneAttr holds the schema attribute name used to look up the mobile number.
+	// TODO: Revisit when the generic OTP executor is implemented.
+	RuntimeKeySMSOTPPhoneAttr = "smsOTPPhoneAttr"
 )
 
 // TODO: Define a go type for InputType when formalizing input types

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -77,9 +77,6 @@ const (
 	ouIDKey        = "ouId"
 	defaultOUIDKey = "defaultOUID"
 	userTypeKey    = "userType"
-	// TODO: Revisit when the generic OTP executor is implemented.
-	runtimeKeySMSOTPMobileNumber = "smsOTPMobileNumber"
-	runtimeKeySMSOTPPhoneAttr    = "smsOTPPhoneAttr"
 
 	dataValueTrue  = "true"
 	dataValueFalse = "false"
@@ -87,13 +84,15 @@ const (
 
 // Executor property keys
 const (
-	propertyKeyAssignGroup          = "assignGroup"
-	propertyKeyAssignRole           = "assignRole"
-	propertyKeyRequiredScopes       = "requiredScopes"
-	propertyKeyEmailTemplate        = "emailTemplate"
-	propertyKeySMSTemplate          = "smsTemplate"
-	propertyKeyAllowedUserTypes     = "allowedUserTypes"
-	propertyKeyNotificationSenderID = "senderId"
+	propertyKeyAssignGroup                  = "assignGroup"
+	propertyKeyAssignRole                   = "assignRole"
+	propertyKeyRequiredScopes               = "requiredScopes"
+	propertyKeyEmailTemplate                = "emailTemplate"
+	propertyKeySMSTemplate                  = "smsTemplate"
+	propertyKeyAllowedUserTypes             = "allowedUserTypes"
+	propertyKeyNotificationSenderID         = "senderId"
+	propertyKeyDynamicInputsIncludeOptional = "includeOptional"
+	propertyKeyMaxDynamicInputsPerPrompt    = "maxPerPrompt"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/entityprovider"
@@ -285,30 +287,54 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		return nodeInputsSatisfied
 	}
 
-	schemaMissingAttrs := make([]common.Input, 0, len(schemaAttrs))
+	// Load the set of optional attrs already prompted in previous iterations so they are not
+	// re-prompted even when the user left them empty.
+	alreadyPromptedOptionalAttrs := p.getPresentedOptionalAttrs(ctx)
+
+	// Build required and optional missing lists separately so required ones are always shown first.
+	requiredMissing := make([]common.Input, 0, len(schemaAttrs))
+	optionalMissing := make([]common.Input, 0, len(schemaAttrs))
 	for _, attr := range schemaAttrs {
 		if p.isAttrSatisfied(ctx, attr.Attribute) {
 			continue
 		}
-
-		schemaMissingAttrs = append(schemaMissingAttrs, common.Input{
+		if !attr.Required && alreadyPromptedOptionalAttrs[attr.Attribute] {
+			continue
+		}
+		input := common.Input{
 			Identifier:  attr.Attribute,
 			Type:        common.InputTypeText,
-			Required:    true,
+			Required:    attr.Required,
 			DisplayName: attr.DisplayName,
-		})
+		}
+		if attr.Required {
+			requiredMissing = append(requiredMissing, input)
+		} else {
+			optionalMissing = append(optionalMissing, input)
+		}
 	}
 
+	schemaMissingAttrs := make([]common.Input, 0, len(requiredMissing)+len(optionalMissing))
+	schemaMissingAttrs = append(schemaMissingAttrs, requiredMissing...)
+	schemaMissingAttrs = append(schemaMissingAttrs, optionalMissing...)
 	if len(schemaMissingAttrs) == 0 {
 		return nodeInputsSatisfied
 	}
+
+	if maxInputs := p.getMaxDynamicInputs(ctx); maxInputs > 0 && len(schemaMissingAttrs) > maxInputs {
+		schemaMissingAttrs = schemaMissingAttrs[:maxInputs]
+	}
+
+	// Record which optional attrs are being presented in this iteration so future iterations
+	// know not to re-prompt them even if the user left the value empty.
+	p.storePresentedOptionalAttrs(execResp, schemaMissingAttrs, alreadyPromptedOptionalAttrs)
 
 	execResp.Inputs = upsertInputs(execResp.Inputs, schemaMissingAttrs)
 	if execResp.ForwardedData == nil {
 		execResp.ForwardedData = make(map[string]interface{})
 	}
 	execResp.ForwardedData[common.ForwardedDataKeyInputs] = schemaMissingAttrs
-	logger.Debug("Schema-required attributes are missing, requesting via prompt",
+	logger.Debug("Schema attributes are missing, requesting via prompt",
 		log.Int("missingCount", len(schemaMissingAttrs)))
 	return false
 }
@@ -340,7 +366,8 @@ func (p *provisioningExecutor) checkNodeInputs(ctx *core.NodeContext,
 	return len(remaining) == 0
 }
 
-// fetchSchemaAttributes retrieves required non-credential attributes from the user schema service.
+// fetchSchemaAttributes retrieves non-credential attributes from the user schema service.
+// When promptOptionalAttributes is true it fetches all attributes; otherwise only required ones.
 func (p *provisioningExecutor) fetchSchemaAttributes(
 	ctx *core.NodeContext, logger *log.Logger,
 ) ([]userschema.AttributeInfo, error) {
@@ -351,13 +378,78 @@ func (p *provisioningExecutor) fetchSchemaAttributes(
 	if userType == "" {
 		return nil, fmt.Errorf("user type not found")
 	}
-	attrs, svcErr := p.userSchemaService.GetNonCredentialAttributes(ctx.Context, userType, true)
+	requiredOnly := !p.isPromptOptionalAttributesEnabled(ctx)
+	attrs, svcErr := p.userSchemaService.GetNonCredentialAttributes(ctx.Context, userType, requiredOnly)
 	if svcErr != nil {
 		logger.Warn("Failed to fetch schema attributes for provisioning, skipping schema check",
 			log.Any("error", svcErr))
 		return nil, nil
 	}
 	return attrs, nil
+}
+
+// isPromptOptionalAttributesEnabled reads the includeOptional node property.
+// Returns false when the property is absent, preserving the default behavior of prompting only required attributes.
+func (p *provisioningExecutor) isPromptOptionalAttributesEnabled(ctx *core.NodeContext) bool {
+	if val, ok := ctx.NodeProperties[propertyKeyDynamicInputsIncludeOptional]; ok {
+		if boolVal, ok := val.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// getMaxDynamicInputs reads the maxPerPrompt node property.
+// Returns 0 when absent, meaning all missing inputs are prompted at once (current default behavior).
+func (p *provisioningExecutor) getMaxDynamicInputs(ctx *core.NodeContext) int {
+	if val, ok := ctx.NodeProperties[propertyKeyMaxDynamicInputsPerPrompt]; ok {
+		switch v := val.(type) {
+		case int:
+			return v
+		case float64:
+			return int(v)
+		}
+	}
+	return 0
+}
+
+// getPresentedOptionalAttrs returns the set of optional attr identifiers that have already been
+// prompted to the user in previous iterations, loaded from RuntimeData.
+func (p *provisioningExecutor) getPresentedOptionalAttrs(ctx *core.NodeContext) map[string]bool {
+	result := make(map[string]bool)
+	raw, ok := ctx.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs]
+	if !ok || raw == "" {
+		return result
+	}
+	for _, id := range strings.Split(raw, " ") {
+		if id != "" {
+			result[id] = true
+		}
+	}
+	return result
+}
+
+// storePresentedOptionalAttrs accumulates the optional attrs being shown in this iteration into
+// RuntimeData so the next iteration can skip them.
+func (p *provisioningExecutor) storePresentedOptionalAttrs(
+	execResp *common.ExecutorResponse,
+	toPrompt []common.Input,
+	alreadyPresented map[string]bool,
+) {
+	for _, inp := range toPrompt {
+		if !inp.Required {
+			alreadyPresented[inp.Identifier] = true
+		}
+	}
+	if len(alreadyPresented) == 0 {
+		return
+	}
+	ids := make([]string, 0, len(alreadyPresented))
+	for id := range alreadyPresented {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	execResp.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs] = strings.Join(ids, " ")
 }
 
 // isAttrSatisfied returns true if the attribute has a non-empty usable value in any context source.
@@ -377,7 +469,8 @@ func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr strin
 }
 
 // getAttributesForProvisioning returns the user profile attributes to store.
-// Schema is the whitelist: required attrs always collected, optional attrs only if in node inputs.
+// Schema is the whitelist: required attrs always collected, optional attrs only if in node inputs
+// or if promptOptionalAttributes is enabled.
 func (p *provisioningExecutor) getAttributesForProvisioning(ctx *core.NodeContext) (map[string]interface{}, error) {
 	nodeInputAttrs := p.GetRequiredInputs(ctx)
 	schemaAttrs, err := p.fetchAllNonCredentialAttributes(ctx)
@@ -391,11 +484,12 @@ func (p *provisioningExecutor) getAttributesForProvisioning(ctx *core.NodeContex
 	for _, inp := range nodeInputAttrs {
 		nodeInputSet[inp.Identifier] = struct{}{}
 	}
+	promptOptional := p.isPromptOptionalAttributesEnabled(ctx)
 
 	attributesMap := make(map[string]interface{})
 	for _, a := range schemaAttrs {
 		_, inNodeInputs := nodeInputSet[a.Attribute]
-		if len(nodeInputSet) > 0 && !a.Required && !inNodeInputs {
+		if len(nodeInputSet) > 0 && !a.Required && !inNodeInputs && !promptOptional {
 			continue
 		}
 

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -1928,8 +1928,8 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSati
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMissing_AppendedToInputsAndForwardedData() {
 	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
 		Return([]model.AttributeInfo{
-			{Attribute: "email", DisplayName: "Email Address"},
-			{Attribute: "firstName", DisplayName: ""},
+			{Attribute: "email", DisplayName: "Email Address", Required: true},
+			{Attribute: "firstName", DisplayName: "", Required: true},
 		}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -1951,7 +1951,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMiss
 
 	emailInput, ok := inputMap["email"]
 	assert.True(suite.T(), ok)
-	assert.True(suite.T(), emailInput.Required)
+	assert.True(suite.T(), emailInput.Required, "required schema attr must have Required=true in the built input")
 	assert.Equal(suite.T(), "Email Address", emailInput.DisplayName)
 
 	firstNameInput, ok := inputMap["firstName"]
@@ -1962,6 +1962,131 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMiss
 	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
 	assert.True(suite.T(), ok)
 	assert.Len(suite.T(), fwdInputs, 2)
+}
+
+// TestHasRequiredInputs_IncludeOptionalTrue_OptionalRenderedAsNotRequired verifies that when
+// includeOptional=true, optional schema attrs are forwarded with Required=false.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_OptionalRenderedAsNotRequired() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	inputMap := make(map[string]common.Input, len(execResp.Inputs))
+	for _, inp := range execResp.Inputs {
+		inputMap[inp.Identifier] = inp
+	}
+	assert.True(suite.T(), inputMap["email"].Required, "required attr must be marked required")
+	assert.False(suite.T(), inputMap["nickname"].Required,
+		"optional attr must be marked not-required so the UI does not force the user to fill it")
+}
+
+// TestHasRequiredInputs_IncludeOptionalTrue_SkipsOptionalAlreadyPresented verifies that when
+// includeOptional=true an optional attr recorded as already presented in RuntimeData
+// is not re-prompted, even if the user left it empty.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_SkipsOptionalAlreadyPresented() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{
+			userTypeKey: testUserType,
+			// nickname was presented in the previous iteration and the user left it blank.
+			common.RuntimeKeyPresentedOptionalAttrs: "nickname",
+		},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result,
+		"must not block when all required attrs are satisfied and optional was already presented")
+	assert.Empty(suite.T(), execResp.Inputs,
+		"nickname must not be re-prompted once it appears in the presented list")
+}
+
+// TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals verifies that optional attrs
+// included in the prompt batch are written to RuntimeData for tracking across iterations.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	stored := execResp.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs]
+	assert.Contains(suite.T(), stored, "nickname",
+		"presented optional attrs must be written to RuntimeData for subsequent iterations")
+	assert.NotContains(suite.T(), stored, "email",
+		"required attrs must not be written to the presented-optionals tracking key")
+}
+
+// TestHasRequiredInputs_IncludeOptionalTrue_RequiredBeforeOptional verifies that required missing
+// attrs always appear before optional ones in the prompted list.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_RequiredBeforeOptional() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "phone", DisplayName: "Phone", Required: false},
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	require := true
+	for _, inp := range execResp.Inputs {
+		if inp.Required {
+			assert.True(suite.T(), require,
+				"required attr %q must come before optional attrs", inp.Identifier)
+		} else {
+			require = false
+		}
+	}
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrCoveredByNodeInput_NotDuplicated() {
@@ -2345,4 +2470,235 @@ func (suite *ProvisioningExecutorTestSuite) TestCreateUserInStore_MissingUserTyp
 	assert.Nil(suite.T(), result)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "user type not found")
+}
+
+// TestHasRequiredInputs_IncludeOptionalTrue_PromptsOptionals verifies that when
+// includeOptional=true, missing optional schema attributes are also requested via prompt.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_PromptsOptionals() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	identifiers := make([]string, 0, len(execResp.Inputs))
+	for _, inp := range execResp.Inputs {
+		identifiers = append(identifiers, inp.Identifier)
+	}
+	assert.Contains(suite.T(), identifiers, "nickname",
+		"optional attr must be prompted when includeOptional=true")
+	assert.NotContains(suite.T(), identifiers, "email", "already-satisfied attr must not be re-prompted")
+}
+
+// TestHasRequiredInputs_IncludeOptionalFalse_SkipsOptionals verifies the default
+// behavior: optional schema attrs are not prompted when includeOptional is absent or false.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalFalse_SkipsOptionals() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID:    "flow-123",
+		FlowType:       common.FlowTypeRegistration,
+		UserInputs:     map[string]string{"email": "user@example.com"},
+		RuntimeData:    map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result)
+	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+// TestHasRequiredInputs_MaxPerPrompt_LimitsPromptedAttrs verifies that when maxPerPrompt=1,
+// only one missing schema attribute is prompted per iteration.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_LimitsPromptedAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
+			{Attribute: "phone", DisplayName: "Phone", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyMaxDynamicInputsPerPrompt: 1,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 1, "only one input should be prompted per iteration")
+	assert.Equal(suite.T(), "firstName", execResp.Inputs[0].Identifier)
+}
+
+// TestHasRequiredInputs_MaxPerPrompt_Zero_PromptsAllMissingAttrs verifies that maxPerPrompt=0
+// (the default) prompts all missing attributes at once.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_Zero_PromptsAllMissingAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID:    "flow-123",
+		FlowType:       common.FlowTypeRegistration,
+		UserInputs:     map[string]string{},
+		RuntimeData:    map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 2, "all missing inputs should be prompted when maxPerPrompt is not set")
+}
+
+// TestGetAttributesForProvisioning_IncludeOptionalTrue_CollectsOptionals verifies that when
+// includeOptional=true, optional schema attrs are collected even when node inputs are set.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalTrue_CollectsOptionals() {
+	nodeInputs := []common.Input{
+		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			"email":    "user@example.com",
+			"nickname": "nick",
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  nodeInputs,
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+	}
+
+	result, err := exec.getAttributesForProvisioning(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.Equal(suite.T(), "nick", result["nickname"],
+		"optional attr must be collected when includeOptional=true")
+}
+
+// TestGetAttributesForProvisioning_IncludeOptionalFalse_ExcludesOptionals verifies the default
+// behavior: optional attrs not in node inputs are excluded when includeOptional=false.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalFalse_ExcludesOptionals() {
+	nodeInputs := []common.Input{
+		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
+	}
+	exec := suite.newExecutorWithNodeInputs(nodeInputs)
+
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", Required: true},
+			{Attribute: "nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			"email":    "user@example.com",
+			"nickname": "nick",
+		},
+		RuntimeData:    map[string]string{userTypeKey: testUserType},
+		NodeInputs:     nodeInputs,
+		NodeProperties: map[string]interface{}{},
+	}
+
+	result, err := exec.getAttributesForProvisioning(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "user@example.com", result["email"])
+	assert.NotContains(suite.T(), result, "nickname",
+		"optional attr not in node inputs must be excluded when includeOptional=false")
+}
+
+// TestHasRequiredInputs_MaxPerPrompt_Float64_LimitsPromptedAttrs verifies that maxPerPrompt
+// supplied as float64 (the type JSON unmarshalling produces) is handled correctly.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_Float64_LimitsPromptedAttrs() {
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyMaxDynamicInputsPerPrompt: float64(1),
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 1,
+		"float64 maxPerPrompt value (from JSON) must be handled correctly")
+}
+
+// TestHasRequiredInputs_NoProperties_DefaultBehavior verifies that when no properties are set the
+// executor falls back to prompting only required schema attributes, all at once.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NoProperties_DefaultBehavior() {
+	// requiredOnly=true: service returns only required attrs (optional ones are filtered by the service).
+	suite.mockUserSchemaService.On("GetNonCredentialAttributes", mock.Anything, testUserType, true).
+		Return([]model.AttributeInfo{
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	ids := make([]string, 0, len(execResp.Inputs))
+	for _, inp := range execResp.Inputs {
+		ids = append(ids, inp.Identifier)
+	}
+	assert.Contains(suite.T(), ids, "firstName")
+	assert.Contains(suite.T(), ids, "lastName")
+	assert.Len(suite.T(), execResp.Inputs, 2,
+		"all required missing inputs must be prompted at once when maxPerPrompt is absent")
 }

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -221,8 +221,8 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	}
 
 	logger.Debug("SMS OTP sent successfully")
-	execResp.RuntimeData[runtimeKeySMSOTPMobileNumber] = mobileNumber
-	execResp.RuntimeData[runtimeKeySMSOTPPhoneAttr] = phoneAttr
+	execResp.RuntimeData[common.RuntimeKeySMSOTPMobileNumber] = mobileNumber
+	execResp.RuntimeData[common.RuntimeKeySMSOTPPhoneAttr] = phoneAttr
 	execResp.Status = common.ExecComplete
 
 	return nil
@@ -578,11 +578,11 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*authncm.AuthenticatedUser, error) {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
-	phoneAttr := ctx.RuntimeData[runtimeKeySMSOTPPhoneAttr]
+	phoneAttr := ctx.RuntimeData[common.RuntimeKeySMSOTPPhoneAttr]
 	if phoneAttr == "" {
 		phoneAttr = s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
 	}
-	mobileNumber := ctx.RuntimeData[runtimeKeySMSOTPMobileNumber]
+	mobileNumber := ctx.RuntimeData[common.RuntimeKeySMSOTPMobileNumber]
 	if mobileNumber == "" {
 		return nil, errors.New("mobile number not found in context")
 	}

--- a/backend/internal/flow/executor/sms_auth_executor_test.go
+++ b/backend/internal/flow/executor/sms_auth_executor_test.go
@@ -212,8 +212,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_MFA_AddsMobileNu
 			userInputOTP: "123456",
 		},
 		RuntimeData: map[string]string{
-			runtimeKeySMSOTPMobileNumber: "+1234567890",
-			"otpSessionToken":            "test-session-token",
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
@@ -263,8 +263,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_P
 			userInputOTP: "123456",
 		},
 		RuntimeData: map[string]string{
-			runtimeKeySMSOTPMobileNumber: "+1234567890",
-			"otpSessionToken":            "test-session-token",
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
@@ -430,8 +430,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_MFA_NilAttribute
 			userInputOTP: "123456",
 		},
 		RuntimeData: map[string]string{
-			runtimeKeySMSOTPMobileNumber: "+1234567890",
-			"otpSessionToken":            "test-session-token",
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
@@ -540,8 +540,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_EmptyOTP_Returns
 			userInputOTP: "", // empty OTP
 		},
 		RuntimeData: map[string]string{
-			runtimeKeySMSOTPMobileNumber: "+1234567890",
-			"otpSessionToken":            "test-session-token",
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: false},
 	}
@@ -581,8 +581,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_N
 			userInputOTP: "123456",
 		},
 		RuntimeData: map[string]string{
-			runtimeKeySMSOTPMobileNumber: "+1234567890",
-			"otpSessionToken":            "test-session-token",
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
 		},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,


### PR DESCRIPTION
### Purpose
Introduces two optional node properties on the **ProvisioningExecutor** that give flow authors fine-grained control over how schema-driven dynamic inputs are collected during user provisioning. Without these properties the executor behaves exactly as before — only required schema attributes are prompted, all at once.

### Approach
## Dynamic Node Properties

Two new node properties are read from `NodeProperties` at runtime. Both are fully optional; omitting either one preserves the existing behaviour.

### `dynamicInputsIncludeOptional`

**Type:** `bool`  
**Default:** `false`

Controls whether optional schema attributes are included in the dynamic input prompt alongside required ones.

| Value | Behaviour |
|---|---|
| `false` (default) | Only required schema attributes are fetched and prompted, identical to the previous behaviour |
| `true` | Both required and optional schema attributes are fetched; optional ones are presented to the user but rendered as non-required in the UI, so the user can submit without filling them |

### `maxDynamicInputs`

**Type:** `int`  
**Default:** `0`

Caps how many dynamic inputs are shown in a single prompt iteration, enabling paged collection for schemas with many attributes.

| Value | Behaviour |
|---|---|
| `0` (default) | All missing inputs are prompted at once, identical to the previous behaviour |
| `N > 0` | At most `N` inputs are shown per iteration; the executor re-prompts until all have been presented |

## Key Implementation Decisions

- **Required-before-optional ordering**  
  Within each batch, required missing attributes are always placed before optional ones so the user sees mandatory fields first.

- **Presented-optional tracking**  
  When `dynamicInputsIncludeOptional` is enabled, the identifiers of optional attributes that have been shown to the user are accumulated in a `RuntimeData` key named `provisioningPresentedOptionalAttrs`.

  On each subsequent call to `HasRequiredInputs`, this list is used to skip already-presented optional attributes regardless of whether the user submitted an empty value or omitted the field entirely, preventing infinite re-prompt loops.

- **Backward compatibility**  
  Both properties are absent from all existing flow definitions by default. The executor reads them defensively and falls back to the original code path when they are not present, so no existing flow requires any changes.

## Example Node Configuration

```json
{
  "id": "provisioning",
  "type": "TASK_EXECUTION",
  "properties": {
    "includeOptional": true,
    "maxPerPrompt": 3
  },
  "executor": {
    "name": "ProvisioningExecutor"
  },
  "onSuccess": "auth_assert",
  "onIncomplete": "prompt_schema_attrs"
}
```

### Related Issues
- https://github.com/asgardeo/thunder/issues/2516

### Related PRs
- https://github.com/asgardeo/thunder/pull/2450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-node settings to include optional attributes and to limit how many inputs are requested per iteration; optional prompts are skipped if already presented and required inputs are prioritized.

* **Refactor**
  * SMS OTP runtime state consolidated to use standardized runtime keys for phone attribute and mobile number.

* **Tests**
  * Expanded coverage for dynamic prompting, optional-attribute handling, ordering, limits, and default required-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->