### PR TITLE
Add layout positions and missing variants to user onboarding flow

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -6,18 +6,40 @@
         {
             "id": "start",
             "type": "START",
-            "onSuccess": "permission_validator"
+            "onSuccess": "permission_validator",
+            "layout": {
+                "size": {
+                    "width": 101,
+                    "height": 34
+                },
+                "position": {
+                    "x": 47,
+                    "y": 571
+                }
+            }
         },
         {
             "id": "permission_validator",
             "type": "TASK_EXECUTION",
             "properties": {
-                "requiredScopes": ["system"]
+                "requiredScopes": [
+                    "system"
+                ]
             },
             "executor": {
                 "name": "PermissionValidator"
             },
-            "onSuccess": "user_type_resolver"
+            "onSuccess": "user_type_resolver",
+            "layout": {
+                "size": {
+                    "width": 206,
+                    "height": 113
+                },
+                "position": {
+                    "x": 248,
+                    "y": 531
+                }
+            }
         },
         {
             "id": "user_type_resolver",
@@ -26,7 +48,17 @@
                 "name": "UserTypeResolver"
             },
             "onSuccess": "ou_selection",
-            "onIncomplete": "prompt_usertype"
+            "onIncomplete": "prompt_usertype",
+            "layout": {
+                "size": {
+                    "width": 205,
+                    "height": 113
+                },
+                "position": {
+                    "x": 554,
+                    "y": 545
+                }
+            }
         },
         {
             "id": "prompt_usertype",
@@ -43,7 +75,8 @@
                     {
                         "type": "TEXT",
                         "id": "subtitle_usertype",
-                        "label": "{{ t(onboarding:forms.user_type.subtitle) }}"
+                        "label": "{{ t(onboarding:forms.user_type.subtitle) }}",
+                        "variant": "HEADING_6"
                     },
                     {
                         "type": "BLOCK",
@@ -84,7 +117,17 @@
                         "nextNode": "user_type_resolver"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 529
+                },
+                "position": {
+                    "x": 830,
+                    "y": -84
+                }
+            }
         },
         {
             "id": "ou_selection",
@@ -96,7 +139,17 @@
                 "name": "OUResolverExecutor"
             },
             "onSuccess": "prompt_email",
-            "onIncomplete": "prompt_ou_selection"
+            "onIncomplete": "prompt_ou_selection",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 939,
+                    "y": 610
+                }
+            }
         },
         {
             "id": "prompt_ou_selection",
@@ -113,7 +166,8 @@
                     {
                         "type": "TEXT",
                         "id": "subtitle_ou_selection",
-                        "label": "{{ t(onboarding:forms.ou_selection.subtitle) }}"
+                        "label": "{{ t(onboarding:forms.ou_selection.subtitle) }}",
+                        "variant": "HEADING_6"
                     },
                     {
                         "type": "BLOCK",
@@ -152,7 +206,17 @@
                         "nextNode": "ou_selection"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 525
+                },
+                "position": {
+                    "x": 829,
+                    "y": 823
+                }
+            }
         },
         {
             "id": "prompt_email",
@@ -204,7 +268,17 @@
                         "nextNode": "check_email_uniqueness"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 431
+                },
+                "position": {
+                    "x": 1384,
+                    "y": 452
+                }
+            }
         },
         {
             "id": "check_email_uniqueness",
@@ -213,7 +287,17 @@
                 "name": "AttributeUniquenessValidator"
             },
             "onSuccess": "prompt_invite_method",
-            "onIncomplete": "prompt_email"
+            "onIncomplete": "prompt_email",
+            "layout": {
+                "size": {
+                    "width": 272,
+                    "height": 113
+                },
+                "position": {
+                    "x": 1890,
+                    "y": 675
+                }
+            }
         },
         {
             "id": "prompt_invite_method",
@@ -230,7 +314,8 @@
                     {
                         "type": "TEXT",
                         "id": "text_subtitle_invite_method",
-                        "label": "{{ t(onboarding:forms.invite_mode.subtitle) }}"
+                        "label": "{{ t(onboarding:forms.invite_mode.subtitle) }}",
+                        "variant": "HEADING_6"
                     },
                     {
                         "type": "BLOCK",
@@ -275,7 +360,17 @@
                         "nextNode": "invite_generate_manual"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 566
+                },
+                "position": {
+                    "x": 2323,
+                    "y": 447
+                }
+            }
         },
         {
             "id": "invite_generate_manual",
@@ -284,7 +379,17 @@
                 "name": "InviteExecutor",
                 "mode": "generate"
             },
-            "onSuccess": "invite_link_status"
+            "onSuccess": "invite_link_status",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 2794,
+                    "y": 594
+                }
+            }
         },
         {
             "id": "invite_generate_email",
@@ -293,7 +398,17 @@
                 "name": "InviteExecutor",
                 "mode": "generate"
             },
-            "onSuccess": "send_invite_email"
+            "onSuccess": "send_invite_email",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 2791,
+                    "y": 809
+                }
+            }
         },
         {
             "id": "send_invite_email",
@@ -306,7 +421,17 @@
                 "mode": "send"
             },
             "onSuccess": "email_invite_status",
-            "onFailure": "invite_email_service_unavailable"
+            "onFailure": "invite_email_service_unavailable",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 3114,
+                    "y": 808
+                }
+            }
         },
         {
             "id": "email_invite_status",
@@ -317,7 +442,7 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "email_status_icon",
-                        "label": "✅",
+                        "label": "\u2705",
                         "variant": "HEADING_1"
                     },
                     {
@@ -331,12 +456,23 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "email_status_message",
-                        "label": "{{ t(onboarding:forms.invite_email_sent.message) }}"
+                        "label": "{{ t(onboarding:forms.invite_email_sent.message) }}",
+                        "variant": "HEADING_6"
                     }
                 ]
             },
             "message": "{{ t(onboarding:forms.invite_email_sent.title) }}",
-            "next": "invite_verify"
+            "next": "invite_verify",
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 381
+                },
+                "position": {
+                    "x": 3714,
+                    "y": 673
+                }
+            }
         },
         {
             "id": "invite_email_service_unavailable",
@@ -347,7 +483,7 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "email_unavailable_icon",
-                        "label": "⚠️",
+                        "label": "\u26a0\ufe0f",
                         "variant": "HEADING_1"
                     },
                     {
@@ -361,7 +497,8 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "email_unavailable_message",
-                        "label": "{{ t(onboarding:forms.invite_email_unavailable.message) }}"
+                        "label": "{{ t(onboarding:forms.invite_email_unavailable.message) }}",
+                        "variant": "HEADING_6"
                     },
                     {
                         "type": "COPYABLE_TEXT",
@@ -372,7 +509,17 @@
                 ]
             },
             "message": "{{ t(onboarding:forms.invite_email_unavailable.title) }}",
-            "next": "invite_link_status"
+            "next": "invite_link_status",
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 433
+                },
+                "position": {
+                    "x": 3240,
+                    "y": 1021
+                }
+            }
         },
         {
             "id": "invite_link_status",
@@ -383,7 +530,7 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "link_status_icon",
-                        "label": "✅",
+                        "label": "\u2705",
                         "variant": "HEADING_1"
                     },
                     {
@@ -397,7 +544,8 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "link_status_message",
-                        "label": "{{ t(onboarding:forms.invite_link_status.message) }}"
+                        "label": "{{ t(onboarding:forms.invite_link_status.message) }}",
+                        "variant": "HEADING_6"
                     },
                     {
                         "type": "COPYABLE_TEXT",
@@ -408,7 +556,17 @@
                 ]
             },
             "message": "The invite link is ready to share",
-            "next": "invite_verify"
+            "next": "invite_verify",
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 410
+                },
+                "position": {
+                    "x": 4256,
+                    "y": 931
+                }
+            }
         },
         {
             "id": "invite_verify",
@@ -425,7 +583,17 @@
                 "name": "InviteExecutor",
                 "mode": "verify"
             },
-            "onSuccess": "prompt_user_details"
+            "onSuccess": "prompt_user_details",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 4775,
+                    "y": 927
+                }
+            }
         },
         {
             "id": "prompt_user_details",
@@ -505,7 +673,17 @@
                         "nextNode": "check_user_details_uniqueness"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 590
+                },
+                "position": {
+                    "x": 5110,
+                    "y": 687
+                }
+            }
         },
         {
             "id": "check_user_details_uniqueness",
@@ -514,7 +692,17 @@
                 "name": "AttributeUniquenessValidator"
             },
             "onSuccess": "prompt_credential",
-            "onIncomplete": "prompt_user_details"
+            "onIncomplete": "prompt_user_details",
+            "layout": {
+                "size": {
+                    "width": 272,
+                    "height": 113
+                },
+                "position": {
+                    "x": 5640,
+                    "y": 915
+                }
+            }
         },
         {
             "id": "prompt_credential",
@@ -566,7 +754,17 @@
                         "nextNode": "provisioning"
                     }
                 }
-            ]
+            ],
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 431
+                },
+                "position": {
+                    "x": 6020,
+                    "y": 757
+                }
+            }
         },
         {
             "id": "provisioning",
@@ -607,7 +805,17 @@
                 "name": "ProvisioningExecutor"
             },
             "onSuccess": "registration_complete",
-            "onIncomplete": "prompt_credential"
+            "onIncomplete": "prompt_credential",
+            "layout": {
+                "size": {
+                    "width": 200,
+                    "height": 113
+                },
+                "position": {
+                    "x": 6484,
+                    "y": 979
+                }
+            }
         },
         {
             "id": "registration_complete",
@@ -618,7 +826,7 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "registration_complete_icon",
-                        "label": "✅",
+                        "label": "\u2705",
                         "variant": "HEADING_1"
                     },
                     {
@@ -632,16 +840,37 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "registration_complete_message",
-                        "label": "{{ t(invite:complete.description) }}"
+                        "label": "{{ t(invite:complete.description) }}",
+                        "variant": "HEADING_6"
                     }
                 ]
             },
             "message": "Registration complete",
-            "next": "end"
+            "next": "end",
+            "layout": {
+                "size": {
+                    "width": 350,
+                    "height": 358
+                },
+                "position": {
+                    "x": 6796,
+                    "y": 857
+                }
+            }
         },
         {
             "id": "end",
-            "type": "END"
+            "type": "END",
+            "layout": {
+                "size": {
+                    "width": 85,
+                    "height": 34
+                },
+                "position": {
+                    "x": 7275,
+                    "y": 1019
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Add layout positions to all 22 nodes in the default user onboarding bootstrap flow so nodes render at proper positions in the flow builder
- Add missing `variant` fields to TEXT components in view nodes (HEADING_1 for titles, HEADING_6 for subtitles/messages)

## Test plan

- [ ] Start a fresh Thunder instance and verify the user onboarding flow renders with proper node positions in the flow builder
- [ ] Verify all view nodes display correct text styling (headings vs body text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual layout and styling of the user onboarding flow, including enhanced node positioning and adjusted text styling for better clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->