### PR TITLE
Add comment explaining scope configuration for other repositories

### DIFF
--- a/scripts/validate-go-dependencies.sh
+++ b/scripts/validate-go-dependencies.sh
@@ -5,6 +5,7 @@ set -e
 BASE_SHA=$1
 HEAD_SHA=$2
 APPROVED_LIST=$3
+# Update scope value when using in other repositories.
 REQUIRED_SCOPE="${REQUIRED_SCOPE:-thunder-id}"
 
 if [ ! -s "$APPROVED_LIST" ]; then


### PR DESCRIPTION
Added a comment to the dependency validation script explaining that the scope value needs to be updated when using the script in other repositories

## Context
  The `REQUIRED_SCOPE` variable is currently set to `thunder-id` for the Thunder
  repository. When this script is used in other repositories, the scope value needs to be
   changed to match the target repository's scope. This comment helps clarify this
  configuration requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added clarifying documentation note to internal validation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->