### PR TITLE
Add state parameter to federated OAuth authorize URL

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -209,6 +209,8 @@ const (
 	// RuntimeKeySMSOTPPhoneAttr holds the schema attribute name used to look up the mobile number.
 	// TODO: Revisit when the generic OTP executor is implemented.
 	RuntimeKeySMSOTPPhoneAttr = "smsOTPPhoneAttr"
+	// RuntimeKeyOAuthState holds the generated OAuth state parameter for CSRF validation.
+	RuntimeKeyOAuthState = "oauthState"
 )
 
 // TODO: Define a go type for InputType when formalizing input types

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -65,8 +65,10 @@ const (
 	userAttributeGroups   = "groups"
 	userAttributeSub      = "sub"
 
-	userInputCode             = "code"
-	userInputNonce            = "nonce"
+	userInputCode  = "code"
+	userInputNonce = "nonce"
+	userInputState = "state"
+
 	userInputOuName           = "ouName"
 	userInputOuHandle         = "ouHandle"
 	userInputOuDesc           = "ouDescription"

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -184,12 +184,20 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 		return fmt.Errorf("failed to get idp name: %w", err)
 	}
 
+	// Generate a random state parameter for CSRF protection and append it to the authorize URL.
+	state := systemutils.GenerateUUID()
+	authorizeURL = authorizeURL + "&" + "state=" + state
+
 	// Set the response to redirect the user to the authorization URL.
 	execResp.Status = common.ExecExternalRedirection
 	execResp.RedirectURL = authorizeURL
 	execResp.AdditionalData = map[string]string{
 		common.DataIDPName: idpName,
 	}
+	if execResp.RuntimeData == nil {
+		execResp.RuntimeData = make(map[string]string)
+	}
+	execResp.RuntimeData[common.RuntimeKeyOAuthState] = state
 
 	return nil
 }
@@ -206,6 +214,20 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 			IsAuthenticated: false,
 		}
 		return nil
+	}
+
+	// Validate the OAuth state parameter to prevent CSRF attacks.
+	// State is validated only when the client sends it back. Clients that handle CSRF
+	// protection client-side (e.g., via sessionStorage) may omit it.
+	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
+		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
+		if returnedState != expectedState {
+			logger.Debug("OAuth state mismatch")
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "Invalid OAuth state parameter"
+			return nil
+		}
+		delete(ctx.RuntimeData, common.RuntimeKeyOAuthState)
 	}
 
 	idpID, err := o.GetIdpID(ctx)

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -99,8 +99,10 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecExternalRedirection, resp.Status)
-	assert.Equal(suite.T(), "https://oauth.provider.com/authorize?client_id=abc", resp.RedirectURL)
+	assert.Contains(suite.T(), resp.RedirectURL, "https://oauth.provider.com/authorize?client_id=abc")
+	assert.Contains(suite.T(), resp.RedirectURL, "state=")
 	assert.Equal(suite.T(), "TestIDP", resp.AdditionalData[common.DataIDPName])
+	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyOAuthState])
 	suite.mockOAuthService.AssertExpectations(suite.T())
 	suite.mockIDPService.AssertExpectations(suite.T())
 }
@@ -164,8 +166,10 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecExternalRedirection, execResp.Status)
-	assert.Equal(suite.T(), "https://oauth.provider.com/authorize", execResp.RedirectURL)
+	assert.Contains(suite.T(), execResp.RedirectURL, "https://oauth.provider.com/authorize")
+	assert.Contains(suite.T(), execResp.RedirectURL, "state=")
 	assert.Equal(suite.T(), "GoogleIDP", execResp.AdditionalData[common.DataIDPName])
+	assert.NotEmpty(suite.T(), execResp.RuntimeData[common.RuntimeKeyOAuthState])
 	suite.mockOAuthService.AssertExpectations(suite.T())
 	suite.mockIDPService.AssertExpectations(suite.T())
 }

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -137,6 +137,20 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 
+	// Validate the OAuth state parameter to prevent CSRF attacks.
+	// State is validated only when the client sends it back. Clients that handle CSRF
+	// protection client-side (e.g., via sessionStorage) may omit it.
+	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
+		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
+		if returnedState != expectedState {
+			logger.Debug("OAuth state mismatch")
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "Invalid OAuth state parameter"
+			return nil
+		}
+		delete(ctx.RuntimeData, common.RuntimeKeyOAuthState)
+	}
+
 	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
 		return err

--- a/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
-import {SignUp, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowEventType, SignUp, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {FlowComponentRenderer, AuthCardLayout, useDesign} from '@thunderid/design';
 import {Box, Button, Alert, Typography, AlertTitle, CircularProgress} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
@@ -70,7 +70,8 @@ export default function SignUpBox(): JSX.Element {
               onInputChange={handleInputChange}
               onSubmit={(action, inputs) => {
                 setFlowError(null);
-                void handleSubmit(action, inputs);
+                const isTrigger = action.eventType === EmbeddedFlowEventType.Trigger || action.eventType === 'TRIGGER';
+                void handleSubmit(action, inputs, isTrigger);
               }}
             />
           ))}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.23.1
-      version: 0.23.1
+      specifier: 0.23.4
+      version: 0.23.4
     '@asgardeo/react-router':
       specifier: 2.0.0
       version: 2.0.0
@@ -264,10 +264,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.23.1(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.23.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.4.0
         version: 0.4.0
@@ -502,10 +502,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.23.1(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.23.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -617,7 +617,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -702,7 +702,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@hookform/resolvers':
         specifier: 'catalog:'
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.3))(zod@4.3.6)
@@ -808,7 +808,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@monaco-editor/react':
         specifier: 'catalog:'
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -899,7 +899,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@hookform/resolvers':
         specifier: 'catalog:'
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.3))(zod@4.3.6)
@@ -1115,7 +1115,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1364,7 +1364,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.23.1(@types/react@19.2.7)(react@19.2.3)
+        version: 0.23.4(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1744,14 +1744,14 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.7.0':
-    resolution: {integrity: sha512-TaUkzBHxMMDiLeO1JRZmMeL9JCOceCt9TBomph4cv8JUfIlvT8O7szxMVjMhHhMBCOjf57/C5yfX+JFht7Z9dg==}
+  '@asgardeo/browser@0.7.2':
+    resolution: {integrity: sha512-n9J153vQ0WehoSHZeMI/rBYgA/EAKnZiKSlik3+UPgmE+ZW/4TIPqcp/hLHGaF1nP1yz/d80nJpwDPYwcylKqA==}
 
   '@asgardeo/i18n@0.4.5':
     resolution: {integrity: sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==}
 
-  '@asgardeo/javascript@0.19.0':
-    resolution: {integrity: sha512-zlveJbY/oQrfokn2PHpOJlHlih5MOq6F4WHcd60oLw0II6nmjw1WTI3drJQsj6W+2emB5gYv257vYjdLcYbYAA==}
+  '@asgardeo/javascript@0.19.1':
+    resolution: {integrity: sha512-HWthqx9aIPqwA0fAUbqmN9+oy9UCunYkSnRFRYr+I8m5iTkvRl7A+nY5J37ohhUIYWZ2Phhj/SLPR13z57x7hw==}
 
   '@asgardeo/react-router@2.0.0':
     resolution: {integrity: sha512-RvHol3VgjV466y7RhpmPosER89Yz1prREvjWjhu95X9e4l761+3n8bRSQR5lpP1tasAVKtVH6RzWvWoPST7+Zg==}
@@ -1760,8 +1760,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.23.1':
-    resolution: {integrity: sha512-rmfNT/TUknevNLrLZdjq/XSUIMLkuybyB6kAyTyArqqfHqgoZdetl/ug3p8PeKyMgrnE9Av21aCRPH1rcK1amQ==}
+  '@asgardeo/react@0.23.4':
+    resolution: {integrity: sha512-JPpPfsyAPIp00U5f7JA0czhz9oSEqmGBdK8p16tNmgfrxSsJnh/4zokfeNbOnKLhB8blKRaRlKjq2wbkcEQGBA==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -11838,9 +11838,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.7.0':
+  '@asgardeo/browser@0.7.2':
     dependencies:
-      '@asgardeo/javascript': 0.19.0
+      '@asgardeo/javascript': 0.19.1
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -11856,22 +11856,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@asgardeo/javascript@0.19.0':
+  '@asgardeo/javascript@0.19.1':
     dependencies:
       '@asgardeo/i18n': 0.4.5
       jose: 5.10.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.23.1(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.23.4(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@asgardeo/react': 0.23.1(@types/react@19.2.7)(react@19.2.3)
+      '@asgardeo/react': 0.23.4(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.23.1(@types/react@19.2.7)(react@19.2.3)':
+  '@asgardeo/react@0.23.4(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
-      '@asgardeo/browser': 0.7.0
+      '@asgardeo/browser': 0.7.2
       '@asgardeo/i18n': 0.4.5
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - ../docs
 
 catalog:
-  '@asgardeo/react': 0.23.1
+  '@asgardeo/react': 0.23.4
   '@asgardeo/react-router': 2.0.0
   '@hookform/resolvers': 5.2.2
   '@monaco-editor/react': 4.7.0

--- a/tests/integration/flow/authentication/conditional_exec_auth_test.go
+++ b/tests/integration/flow/authentication/conditional_exec_auth_test.go
@@ -384,12 +384,13 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestSkipConditionalNodes() {
 	redirectURLStr := flowStep.Data.RedirectURL
 
 	// Step 2: Simulate user authorization at Google
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	ts.Require().NoError(err, "Failed to simulate Google authorization")
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication flow")
@@ -430,13 +431,14 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate user authorization at Google
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	ts.Require().NoError(err, "Failed to simulate Google authorization")
 	ts.Require().NotEmpty(authCode, "Authorization code should not be empty")
 
 	// Step 3: Continue the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete authentication flow")

--- a/tests/integration/flow/authentication/github_auth_test.go
+++ b/tests/integration/flow/authentication/github_auth_test.go
@@ -375,7 +375,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate user authorization at GitHub (get authorization code)
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate GitHub authorization: %v", err)
 	}
@@ -383,7 +383,8 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -416,10 +417,12 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteWithInvalidCode() {
 	}
 
 	ExecutionID := flowStep.ExecutionID
+	state := testutils.ExtractStateFromRedirectURL(flowStep.Data.RedirectURL)
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
-		"code": "invalid-auth-code-12345",
+		"code":  "invalid-auth-code-12345",
+		"state": state,
 	}
 
 	_, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)

--- a/tests/integration/flow/authentication/google_auth_test.go
+++ b/tests/integration/flow/authentication/google_auth_test.go
@@ -390,7 +390,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate user authorization at Google (get authorization code)
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate Google authorization: %v", err)
 	}
@@ -398,7 +398,8 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -431,10 +432,12 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteWithInvalidCode() {
 	}
 
 	ExecutionID := flowStep.ExecutionID
+	state := testutils.ExtractStateFromRedirectURL(flowStep.Data.RedirectURL)
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
-		"code": "invalid-auth-code-12345",
+		"code":  "invalid-auth-code-12345",
+		"state": state,
 	}
 
 	_, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -487,14 +490,15 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowMultipleUsersSuccess() {
 	redirectURLStr := flowStep.Data.RedirectURL
 
 	// Step 2: Simulate user authorization at Google
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate Google authorization: %v", err)
 	}
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -418,12 +418,12 @@ func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
 	ts.Require().NotEmpty(redirectURL)
 
 	// Simulate Google OAuth flow
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURL)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURL)
 	ts.Require().NoError(err, "Failed to simulate Google authorization")
 	ts.Require().NotEmpty(authCode)
 
 	// Complete flow with authorization code
-	inputs := map[string]string{"code": authCode}
+	inputs := map[string]string{"code": authCode, "state": state}
 	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow with auth code")
 

--- a/tests/integration/flow/registration/github_registration_test.go
+++ b/tests/integration/flow/registration/github_registration_test.go
@@ -522,7 +522,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteSuc
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate user authorization at GitHub (get authorization code)
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate GitHub authorization: %v", err)
 	}
@@ -530,7 +530,8 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteSuc
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
@@ -585,8 +586,10 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteWit
 	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
+	state := testutils.ExtractStateFromRedirectURL(flowStep.Data.RedirectURL)
 	inputs := map[string]string{
-		"code": "invalid-reg-auth-code-12345",
+		"code":  "invalid-reg-auth-code-12345",
+		"state": state,
 	}
 
 	_, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
@@ -633,13 +636,14 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 	}
 
 	redirectURLStr := flowStep.Data.RedirectURL
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate first GitHub authorization: %v", err)
 	}
 
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -662,13 +666,14 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 	}
 
 	redirectURLStr2 := flowStep2.Data.RedirectURL
-	authCode2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
+	authCode2, state2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate second GitHub authorization: %v", err)
 	}
 
 	inputs2 := map[string]string{
-		"code": authCode2,
+		"code":  authCode2,
+		"state": state2,
 	}
 
 	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)

--- a/tests/integration/flow/registration/google_registration_test.go
+++ b/tests/integration/flow/registration/google_registration_test.go
@@ -508,7 +508,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteSuc
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate user authorization at Google (get authorization code)
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate Google authorization: %v", err)
 	}
@@ -516,7 +516,8 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteSuc
 
 	// Step 3: Complete the flow with the authorization code
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
@@ -571,8 +572,10 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteWit
 	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
+	state := testutils.ExtractStateFromRedirectURL(flowStep.Data.RedirectURL)
 	inputs := map[string]string{
-		"code": "invalid-reg-auth-code-12345",
+		"code":  "invalid-reg-auth-code-12345",
+		"state": state,
 	}
 
 	_, err = common.CompleteFlow(flowID, inputs, "", flowStep.ChallengeToken)
@@ -619,13 +622,14 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 	}
 
 	redirectURLStr := flowStep.Data.RedirectURL
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate first Google authorization: %v", err)
 	}
 
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -648,13 +652,14 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 	}
 
 	redirectURLStr2 := flowStep2.Data.RedirectURL
-	authCode2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
+	authCode2, state2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate second Google authorization: %v", err)
 	}
 
 	inputs2 := map[string]string{
-		"code": authCode2,
+		"code":  authCode2,
+		"state": state2,
 	}
 
 	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)
@@ -676,13 +681,14 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 	}
 
 	redirectURLStr := flowStep.Data.RedirectURL
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate first Google authorization: %v", err)
 	}
 
 	inputs := map[string]string{
-		"code": authCode,
+		"code":  authCode,
+		"state": state,
 	}
 
 	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
@@ -717,13 +723,14 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 	}
 
 	redirectURLStr2 := flowStep2.Data.RedirectURL
-	authCode2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
+	authCode2, state2, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr2)
 	if err != nil {
 		ts.T().Fatalf("Failed to simulate second Google authorization: %v", err)
 	}
 
 	inputs2 := map[string]string{
-		"code": authCode2,
+		"code":  authCode2,
+		"state": state2,
 	}
 
 	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "", flowStep2.ChallengeToken)

--- a/tests/integration/flow/registration/google_registration_with_role_group_test.go
+++ b/tests/integration/flow/registration/google_registration_with_role_group_test.go
@@ -443,12 +443,12 @@ func (ts *GoogleRegistrationGroupRoleTestSuite) TestGoogleRegistrationWithGroupA
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
 	// Step 2: Simulate OAuth flow
-	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
 	ts.Require().NoError(err, "Failed to simulate OAuth flow")
 	ts.Require().NotEmpty(authCode, "Authorization code should not be empty")
 
 	// Step 3: Complete the flow
-	inputs := map[string]string{"code": authCode}
+	inputs := map[string]string{"code": authCode, "state": state}
 	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete flow")
 

--- a/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
+++ b/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
@@ -522,12 +522,12 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 	ts.Require().Equal("REDIRECTION", flowStep.Type)
 	ts.Require().NotEmpty(flowStep.Data.RedirectURL)
 
-	authCode, err := testutils.SimulateFederatedOAuthFlow(flowStep.Data.RedirectURL)
+	authCode, state, err := testutils.SimulateFederatedOAuthFlow(flowStep.Data.RedirectURL)
 	ts.Require().NoError(err, "Failed to simulate Google authorization for runtime data flow")
 	ts.Require().NotEmpty(authCode, "Authorization code should not be empty")
 
 	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
-		"code": authCode,
+		"code": authCode, "state": state,
 	}, "", flowStep.ChallengeToken)
 	ts.Require().NoError(err, "Failed to complete runtime data flow with authorization code")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -901,8 +901,8 @@ func removeRoleAssignments(roleID string, assignments []Assignment, client *http
 }
 
 // SimulateFederatedOAuthFlow simulates a federated OAuth flow (Google, GitHub, etc.) by
-// following the redirect URL and extracting the authorization code.
-func SimulateFederatedOAuthFlow(redirectURL string) (string, error) {
+// following the redirect URL and extracting the authorization code and state parameter.
+func SimulateFederatedOAuthFlow(redirectURL string) (string, string, error) {
 	// Create HTTP client that doesn't follow redirects automatically
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -916,7 +916,7 @@ func SimulateFederatedOAuthFlow(redirectURL string) (string, error) {
 	// Make request to the authorization endpoint
 	resp, err := client.Get(redirectURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to make authorization request: %w", err)
+		return "", "", fmt.Errorf("failed to make authorization request: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -924,29 +924,42 @@ func SimulateFederatedOAuthFlow(redirectURL string) (string, error) {
 	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusSeeOther &&
 		resp.StatusCode != http.StatusTemporaryRedirect {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("expected redirect response, got status %d: %s",
+		return "", "", fmt.Errorf("expected redirect response, got status %d: %s",
 			resp.StatusCode, string(bodyBytes))
 	}
 
 	// Extract the Location header which contains the callback URL with the code
 	location := resp.Header.Get("Location")
 	if location == "" {
-		return "", fmt.Errorf("no Location header in redirect response")
+		return "", "", fmt.Errorf("no Location header in redirect response")
 	}
 
 	// Parse the location URL to extract the authorization code
 	locationURL, err := url.Parse(location)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse location URL: %w", err)
+		return "", "", fmt.Errorf("failed to parse location URL: %w", err)
 	}
 
 	// Extract the code parameter
 	code := locationURL.Query().Get("code")
 	if code == "" {
-		return "", fmt.Errorf("no authorization code found in callback URL")
+		return "", "", fmt.Errorf("no authorization code found in callback URL")
 	}
 
-	return code, nil
+	// Extract the state parameter
+	state := locationURL.Query().Get("state")
+
+	return code, state, nil
+}
+
+// ExtractStateFromRedirectURL extracts the OAuth state parameter from a redirect URL.
+func ExtractStateFromRedirectURL(redirectURL string) string {
+	parsedURL, err := url.Parse(redirectURL)
+	if err != nil {
+		return ""
+	}
+
+	return parsedURL.Query().Get("state")
 }
 
 // CreateResourceServerWithActions creates a resource server and multiple actions, returning the resource server ID


### PR DESCRIPTION
## Summary

- Include a random `state` parameter in the authorization request URL generated by `BuildAuthorizeURL` for federated IDPs (Google, GitHub)
- This is required per OAuth 2.0 spec (RFC 6749 Section 10.12) for CSRF protection
- The Asgardeo SDK's `Callback` component uses the `state` parameter to validate the callback and route OAuth parameters back to the parent window in popup-based social signup flows

## Context

Without the `state` parameter, the SDK's popup-based social signup flow fails because:
1. The `Callback` component throws "Missing OAuth state parameter"
2. The popup URL monitor requires both `code` and `state` to process the callback

The companion SDK fix is in asgardeo/javascript#488.

## Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2346
- Fixes https://github.com/asgardeo/thunder/issues/2368

## Test plan

- [ ] Test Google social signup flow (popup-based)
- [ ] Test GitHub social signup flow (popup-based)
- [ ] Verify existing OAuth flows (sign-in redirect) still work
- [ ] Run `make test` - unit tests pass

Refs #2368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth state parameter generation and validation to strengthen authentication flows.

* **New Features**
  * Improved embedded flow submission handling with refined control-flow logic.

* **Chores**
  * Updated authentication library dependency to version 0.23.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->