### PR TITLE
Add external IDP token exchange via JWKS-based verification

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -200,7 +200,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	exporters = append(exporters, roleExporter)
 	authZService := authz.Initialize(roleService)
 
-	idpService, idpExporter, err := idp.Initialize(mux)
+	idpService, idpExporter, err := idp.Initialize(cacheManager, mux)
 	if err != nil {
 		logger.Fatal("Failed to initialize IDPService", log.Error(err))
 	}
@@ -348,7 +348,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Initialize OAuth services.
 	err = oauth.Initialize(mux, applicationService, inboundClientService, authnProvider, jwtService, jweService,
 		flowExecService, observabilitySvc, pkiService, ouService, attributeCacheService, authZService, entityProvider,
-		resourceService, i18nService)
+		resourceService, i18nService, idpService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/dbscripts/configdb/postgres.sql
+++ b/backend/dbscripts/configdb/postgres.sql
@@ -139,6 +139,9 @@ CREATE TABLE "IDP" (
 -- Composite index for name-based IDP lookups
 CREATE INDEX idx_idp_name_deployment ON "IDP" (DEPLOYMENT_ID, NAME);
 
+-- GIN index for JSONB containment queries on IDP properties (e.g. issuer lookup via @>)
+CREATE INDEX idx_idp_properties ON "IDP" USING GIN ("PROPERTIES" jsonb_path_ops);
+
 -- Table to store notification senders.
 CREATE TABLE "NOTIFICATION_SENDER" (
     DEPLOYMENT_ID VARCHAR(255) NOT NULL,

--- a/backend/internal/idp/IDPServiceInterface_mock_test.go
+++ b/backend/internal/idp/IDPServiceInterface_mock_test.go
@@ -237,6 +237,76 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetIdentityProviderByIssuer provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, issuer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderByIssuer")
+	}
+
+	var r0 *IDPDTO
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*IDPDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, issuer)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *IDPDTO); ok {
+		r0 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
+type IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderByIssuer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - issuer string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	return &IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(iDPDTO, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProviderByName provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, idpName)

--- a/backend/internal/idp/cache_backed_store.go
+++ b/backend/internal/idp/cache_backed_store.go
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/asgardeo/thunder/internal/system/cache"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+const cacheBackedIDPStoreLoggerComponentName = "CacheBackedIDPStore"
+
+// cacheBackedIDPStore wraps any idpStoreInterface with two in-memory caches.
+type cacheBackedIDPStore struct {
+	idpByIDCache     cache.CacheInterface[*IDPDTO]
+	idpByIssuerCache cache.CacheInterface[*IDPDTO]
+	inner            idpStoreInterface
+}
+
+// newCacheBackedIDPStore creates a new cache-backed IDP store wrapping the provided inner store.
+func newCacheBackedIDPStore(
+	idpByIDCache cache.CacheInterface[*IDPDTO],
+	idpByIssuerCache cache.CacheInterface[*IDPDTO],
+	inner idpStoreInterface,
+) idpStoreInterface {
+	return &cacheBackedIDPStore{
+		idpByIDCache:     idpByIDCache,
+		idpByIssuerCache: idpByIssuerCache,
+		inner:            inner,
+	}
+}
+
+// CreateIdentityProvider delegates to the inner store and caches the created IDP.
+func (s *cacheBackedIDPStore) CreateIdentityProvider(ctx context.Context, idp IDPDTO) error {
+	if err := s.inner.CreateIdentityProvider(ctx, idp); err != nil {
+		return err
+	}
+	s.cacheIDP(ctx, &idp)
+	return nil
+}
+
+// GetIdentityProviderList delegates to the inner store without caching.
+func (s *cacheBackedIDPStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, error) {
+	return s.inner.GetIdentityProviderList(ctx)
+}
+
+// GetIdentityProviderListCount delegates to the inner store without caching.
+func (s *cacheBackedIDPStore) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	return s.inner.GetIdentityProviderListCount(ctx)
+}
+
+// GetIdentityProvider retrieves an IDP by ID, using the ID cache on a hit.
+func (s *cacheBackedIDPStore) GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, error) {
+	cacheKey := cache.CacheKey{Key: idpID}
+	if cached, ok := s.idpByIDCache.Get(ctx, cacheKey); ok {
+		return cached, nil
+	}
+
+	idp, err := s.inner.GetIdentityProvider(ctx, idpID)
+	if err != nil || idp == nil {
+		return idp, err
+	}
+	s.cacheIDP(ctx, idp)
+	return idp, nil
+}
+
+// GetIdentityProviderByName delegates to inner store and populates the ID and issuer caches with the result.
+func (s *cacheBackedIDPStore) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error) {
+	idp, err := s.inner.GetIdentityProviderByName(ctx, idpName)
+	if err != nil || idp == nil {
+		return idp, err
+	}
+	s.cacheIDP(ctx, idp)
+	return idp, nil
+}
+
+// GetIdentityProviderByIssuer retrieves an IDP by its issuer property, using the issuer cache on a hit.
+// A nil cached value means the absence of an IDP for that issuer was previously recorded.
+func (s *cacheBackedIDPStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+	cacheKey := cache.CacheKey{Key: issuer}
+	if cached, ok := s.idpByIssuerCache.Get(ctx, cacheKey); ok {
+		if cached == nil {
+			return nil, ErrIDPNotFound
+		}
+		return cached, nil
+	}
+
+	idp, err := s.inner.GetIdentityProviderByIssuer(ctx, issuer)
+	if err != nil {
+		if errors.Is(err, ErrIDPNotFound) {
+			_ = s.idpByIssuerCache.Set(ctx, cacheKey, nil)
+		}
+		return nil, err
+	}
+	if idp == nil {
+		_ = s.idpByIssuerCache.Set(ctx, cacheKey, nil)
+		return nil, ErrIDPNotFound
+	}
+	s.cacheIDP(ctx, idp)
+	return idp, nil
+}
+
+// UpdateIdentityProvider fetches the old IDP to capture its issuer, delegates the update, then
+// invalidates old cache entries and caches the new state.
+func (s *cacheBackedIDPStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {
+	oldIDP, err := s.inner.GetIdentityProvider(ctx, idp.ID)
+	if err != nil {
+		return err
+	}
+
+	var oldIssuer string
+	if oldIDP != nil {
+		oldIssuer = GetPropertyValue(oldIDP.Properties, PropIssuer)
+	}
+
+	if err := s.inner.UpdateIdentityProvider(ctx, idp); err != nil {
+		return err
+	}
+
+	s.invalidateIDP(ctx, idp.ID, oldIssuer)
+	s.cacheIDP(ctx, idp)
+	return nil
+}
+
+// DeleteIdentityProvider fetches the IDP to get its issuer before delegating deletion,
+// then invalidates the relevant cache entries.
+func (s *cacheBackedIDPStore) DeleteIdentityProvider(ctx context.Context, id string) error {
+	existing, err := s.inner.GetIdentityProvider(ctx, id)
+	if err != nil && !errors.Is(err, ErrIDPNotFound) {
+		return err
+	}
+
+	var issuer string
+	if existing != nil {
+		issuer = GetPropertyValue(existing.Properties, PropIssuer)
+	}
+
+	if err := s.inner.DeleteIdentityProvider(ctx, id); err != nil {
+		return err
+	}
+
+	s.invalidateIDP(ctx, id, issuer)
+	return nil
+}
+
+// cacheIDP stores the IDP in both the ID cache and (when an issuer is present) the issuer cache.
+func (s *cacheBackedIDPStore) cacheIDP(ctx context.Context, idp *IDPDTO) {
+	if idp == nil {
+		return
+	}
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cacheBackedIDPStoreLoggerComponentName))
+
+	if idp.ID != "" {
+		idKey := cache.CacheKey{Key: idp.ID}
+		if err := s.idpByIDCache.Set(ctx, idKey, idp); err != nil {
+			logger.Error("Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
+		}
+	}
+
+	issuer := GetPropertyValue(idp.Properties, PropIssuer)
+	if issuer != "" {
+		issuerKey := cache.CacheKey{Key: issuer}
+		if err := s.idpByIssuerCache.Set(ctx, issuerKey, idp); err != nil {
+			logger.Error("Failed to cache IDP by issuer", log.Error(err), log.String("issuer", issuer))
+		}
+	}
+}
+
+// invalidateIDP removes the IDP from both the ID cache and the issuer cache.
+func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, id, issuer string) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cacheBackedIDPStoreLoggerComponentName))
+
+	if id != "" {
+		idKey := cache.CacheKey{Key: id}
+		if err := s.idpByIDCache.Delete(ctx, idKey); err != nil {
+			logger.Error("Failed to invalidate IDP cache by ID", log.Error(err), log.String("idpID", id))
+		}
+	}
+
+	if issuer != "" {
+		issuerKey := cache.CacheKey{Key: issuer}
+		if err := s.idpByIssuerCache.Delete(ctx, issuerKey); err != nil {
+			logger.Error("Failed to invalidate IDP cache by issuer", log.Error(err), log.String("issuer", issuer))
+		}
+	}
+}

--- a/backend/internal/idp/cache_backed_store_test.go
+++ b/backend/internal/idp/cache_backed_store_test.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/cache"
+	"github.com/asgardeo/thunder/internal/system/cmodels"
+)
+
+// mockIDPCache is a test mock for cache.CacheInterface[*IDPDTO].
+type mockIDPCache struct {
+	mock.Mock
+}
+
+func (m *mockIDPCache) GetName() string               { return "test" }
+func (m *mockIDPCache) IsEnabled() bool               { return true }
+func (m *mockIDPCache) GetStats() cache.CacheStat     { return cache.CacheStat{} }
+func (m *mockIDPCache) CleanupExpired()               {}
+func (m *mockIDPCache) Clear(_ context.Context) error { return nil }
+
+func (m *mockIDPCache) Set(ctx context.Context, key cache.CacheKey, value *IDPDTO) error {
+	args := m.Called(ctx, key, value)
+	return args.Error(0)
+}
+
+func (m *mockIDPCache) Get(ctx context.Context, key cache.CacheKey) (*IDPDTO, bool) {
+	args := m.Called(ctx, key)
+	v, _ := args.Get(0).(*IDPDTO)
+	return v, args.Bool(1)
+}
+
+func (m *mockIDPCache) Delete(ctx context.Context, key cache.CacheKey) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+type CacheBackedIDPStoreTestSuite struct {
+	suite.Suite
+	mockInner   *idpStoreInterfaceMock
+	idCache     *mockIDPCache
+	issuerCache *mockIDPCache
+	cachedStore *cacheBackedIDPStore
+}
+
+func TestCacheBackedIDPStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(CacheBackedIDPStoreTestSuite))
+}
+
+func (s *CacheBackedIDPStoreTestSuite) SetupTest() {
+	s.mockInner = newIdpStoreInterfaceMock(s.T())
+	s.idCache = &mockIDPCache{}
+	s.issuerCache = &mockIDPCache{}
+	s.cachedStore = &cacheBackedIDPStore{
+		idpByIDCache:     s.idCache,
+		idpByIssuerCache: s.issuerCache,
+		inner:            s.mockInner,
+	}
+}
+
+func makeIDPWithIssuer(id, name, issuer string) *IDPDTO {
+	prop, _ := cmodels.NewProperty(PropIssuer, issuer, false)
+	return &IDPDTO{
+		ID:         id,
+		Name:       name,
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop},
+	}
+}
+
+// TestGetIdentityProvider_CacheHit tests that an ID cache hit is returned without hitting inner store.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvider_CacheHit() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.idCache.On("Get", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(idp, true)
+
+	result, err := s.cachedStore.GetIdentityProvider(context.Background(), "idp-1")
+
+	s.NoError(err)
+	s.Equal(idp, result)
+	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProvider")
+}
+
+// TestGetIdentityProvider_CacheMiss tests a cache miss delegates to inner and populates both caches.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvider_CacheMiss() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.idCache.On("Get", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return((*IDPDTO)(nil), false)
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(idp, nil)
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, idp).Return(nil)
+	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}, idp).Return(nil)
+
+	result, err := s.cachedStore.GetIdentityProvider(context.Background(), "idp-1")
+
+	s.NoError(err)
+	s.Equal(idp, result)
+	s.mockInner.AssertExpectations(s.T())
+	s.idCache.AssertExpectations(s.T())
+	s.issuerCache.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_CacheHit tests that an issuer cache hit returns without hitting inner store.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CacheHit() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).Return(idp, true)
+
+	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.NoError(err)
+	s.Equal(idp, result)
+	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProviderByIssuer")
+}
+
+// TestGetIdentityProviderByIssuer_AbsenceCacheHit tests a nil-value cache hit returns ErrIDPNotFound.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_AbsenceCacheHit() {
+	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
+		Return((*IDPDTO)(nil), true)
+
+	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Nil(result)
+	s.ErrorIs(err, ErrIDPNotFound)
+	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProviderByIssuer")
+}
+
+// TestGetIdentityProviderByIssuer_CacheMiss tests a cache miss delegates to inner and populates caches.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CacheMiss() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
+		Return((*IDPDTO)(nil), false)
+	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").Return(idp, nil)
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, idp).Return(nil)
+	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}, idp).Return(nil)
+
+	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.NoError(err)
+	s.Equal(idp, result)
+	s.mockInner.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_CachesAbsenceOnNotFound tests that ErrIDPNotFound is cached as nil.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CachesAbsenceOnNotFound() {
+	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://unknown.example.com"}).
+		Return((*IDPDTO)(nil), false)
+	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://unknown.example.com").
+		Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://unknown.example.com"}, (*IDPDTO)(nil)).
+		Return(nil)
+
+	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+
+	s.Nil(result)
+	s.ErrorIs(err, ErrIDPNotFound)
+	s.issuerCache.AssertExpectations(s.T())
+}
+
+// TestCreateIdentityProvider_CachesResult tests create delegates to inner and caches the result.
+func (s *CacheBackedIDPStoreTestSuite) TestCreateIdentityProvider_CachesResult() {
+	idp := IDPDTO{ID: "idp-1", Name: "IDP 1", Type: IDPTypeOIDC}
+	s.mockInner.On("CreateIdentityProvider", mock.Anything, idp).Return(nil)
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, &idp).Return(nil)
+
+	err := s.cachedStore.CreateIdentityProvider(context.Background(), idp)
+
+	s.NoError(err)
+	s.mockInner.AssertExpectations(s.T())
+	s.idCache.AssertExpectations(s.T())
+}
+
+// TestUpdateIdentityProvider_InvalidatesOldCacheAndCachesNew tests update invalidates old issuer and caches new.
+func (s *CacheBackedIDPStoreTestSuite) TestUpdateIdentityProvider_InvalidatesOldCacheAndCachesNew() {
+	oldIssuer := "https://old.example.com"
+	newIssuer := "https://new.example.com"
+
+	oldProp, _ := cmodels.NewProperty(PropIssuer, oldIssuer, false)
+	oldIDP := &IDPDTO{ID: "idp-1", Name: "Old IDP", Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{*oldProp}}
+
+	newProp, _ := cmodels.NewProperty(PropIssuer, newIssuer, false)
+	newIDP := &IDPDTO{ID: "idp-1", Name: "Updated IDP", Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{*newProp}}
+
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(oldIDP, nil)
+	s.mockInner.On("UpdateIdentityProvider", mock.Anything, newIDP).Return(nil)
+	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
+	s.issuerCache.On("Delete", mock.Anything, cache.CacheKey{Key: oldIssuer}).Return(nil)
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, newIDP).Return(nil)
+	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: newIssuer}, newIDP).Return(nil)
+
+	err := s.cachedStore.UpdateIdentityProvider(context.Background(), newIDP)
+
+	s.NoError(err)
+	s.mockInner.AssertExpectations(s.T())
+	s.idCache.AssertExpectations(s.T())
+	s.issuerCache.AssertExpectations(s.T())
+}
+
+// TestDeleteIdentityProvider_InvalidatesCacheEntries tests delete fetches old IDP and invalidates cache.
+func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_InvalidatesCacheEntries() {
+	issuer := "https://idp.example.com"
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", issuer)
+
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(idp, nil)
+	s.mockInner.On("DeleteIdentityProvider", mock.Anything, "idp-1").Return(nil)
+	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
+	s.issuerCache.On("Delete", mock.Anything, cache.CacheKey{Key: issuer}).Return(nil)
+
+	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
+
+	s.NoError(err)
+	s.mockInner.AssertExpectations(s.T())
+	s.idCache.AssertExpectations(s.T())
+	s.issuerCache.AssertExpectations(s.T())
+}
+
+// TestDeleteIdentityProvider_StillDeletesWhenNotFound tests delete succeeds when inner store has no record.
+func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_StillDeletesWhenNotFound() {
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.mockInner.On("DeleteIdentityProvider", mock.Anything, "idp-1").Return(nil)
+	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
+
+	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
+
+	s.NoError(err)
+	s.mockInner.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByName_PopulatesCaches tests GetByName populates ID and issuer caches.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByName_PopulatesCaches() {
+	idp := makeIDPWithIssuer("idp-2", "IDP 2", "https://other.example.com")
+	s.mockInner.On("GetIdentityProviderByName", mock.Anything, "IDP 2").Return(idp, nil)
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-2"}, idp).Return(nil)
+	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://other.example.com"}, idp).Return(nil)
+
+	result, err := s.cachedStore.GetIdentityProviderByName(context.Background(), "IDP 2")
+
+	s.NoError(err)
+	s.Equal(idp, result)
+	s.mockInner.AssertExpectations(s.T())
+	s.idCache.AssertExpectations(s.T())
+	s.issuerCache.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderList_NoCaching tests GetIdentityProviderList is a pure delegate.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderList_NoCaching() {
+	list := []BasicIDPDTO{{ID: "idp-1", Name: "IDP 1"}}
+	s.mockInner.On("GetIdentityProviderList", mock.Anything).Return(list, nil)
+
+	result, err := s.cachedStore.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Equal(list, result)
+	s.idCache.AssertNotCalled(s.T(), "Set")
+	s.issuerCache.AssertNotCalled(s.T(), "Set")
+}
+
+// TestGetIdentityProviderListCount_NoCaching tests GetIdentityProviderListCount is a pure delegate.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderListCount_NoCaching() {
+	s.mockInner.On("GetIdentityProviderListCount", mock.Anything).Return(5, nil)
+
+	count, err := s.cachedStore.GetIdentityProviderListCount(context.Background())
+
+	s.NoError(err)
+	s.Equal(5, count)
+	s.idCache.AssertNotCalled(s.T(), "Set")
+}
+
+// TestGetIdentityProviderByIssuer_InnerStoreError tests that a non-NotFound error is propagated.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_InnerStoreError() {
+	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
+		Return((*IDPDTO)(nil), false)
+	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").
+		Return((*IDPDTO)(nil), errors.New("db error"))
+
+	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Nil(result)
+	s.Error(err)
+	s.NotErrorIs(err, ErrIDPNotFound)
+	s.issuerCache.AssertNotCalled(s.T(), "Set")
+}

--- a/backend/internal/idp/composite_store.go
+++ b/backend/internal/idp/composite_store.go
@@ -122,6 +122,16 @@ func (c *compositeIDPStore) GetIdentityProviderByName(ctx context.Context, idpNa
 	)
 }
 
+// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property from either store.
+// Checks database store first, then falls back to file store.
+func (c *compositeIDPStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+	return declarativeresource.CompositeGetHelper(
+		func() (*IDPDTO, error) { return c.dbStore.GetIdentityProviderByIssuer(ctx, issuer) },
+		func() (*IDPDTO, error) { return c.fileStore.GetIdentityProviderByIssuer(ctx, issuer) },
+		ErrIDPNotFound,
+	)
+}
+
 // UpdateIdentityProvider updates an identity provider in the database store only.
 // Returns an error if the IDP is declarative (exists in file store).
 func (c *compositeIDPStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {

--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -53,6 +53,8 @@ const (
 	PropLogoutEndpoint        = "logout_endpoint"
 	PropJwksEndpoint          = "jwks_endpoint"
 	PropPrompt                = "prompt"
+	PropIssuer                = "issuer"
+	PropTokenExchangeEnabled  = "token_exchange_enabled"
 )
 
 // Known endpoints for Google OAuth2/OIDC.
@@ -111,6 +113,8 @@ var idpPropertyConfigs = map[IDPType]idpPropertyConfig{
 			PropLogoutEndpoint,
 			PropJwksEndpoint,
 			PropPrompt,
+			PropIssuer,
+			PropTokenExchangeEnabled,
 		},
 		Defaults: map[string]string{},
 	},
@@ -128,6 +132,8 @@ var idpPropertyConfigs = map[IDPType]idpPropertyConfig{
 			PropLogoutEndpoint,
 			PropJwksEndpoint,
 			PropPrompt,
+			PropIssuer,
+			PropTokenExchangeEnabled,
 		},
 		Defaults: map[string]string{
 			PropAuthorizationEndpoint: googleAuthorizationEndpoint,
@@ -157,5 +163,17 @@ var idpPropertyConfigs = map[IDPType]idpPropertyConfig{
 			PropUserInfoEndpoint:      gitHubUserInfoEndpoint,
 			PropUserEmailEndpoint:     gitHubUserEmailEndpoint,
 		},
+	},
+}
+
+// tokenExchangeRequiredProps defines the required properties per IDP type when token exchange is enabled.
+var tokenExchangeRequiredProps = map[IDPType][]string{
+	IDPTypeOIDC: {
+		PropIssuer,
+		PropJwksEndpoint,
+	},
+	IDPTypeGoogle: {
+		PropIssuer,
+		PropJwksEndpoint,
 	},
 }

--- a/backend/internal/idp/file_based_store.go
+++ b/backend/internal/idp/file_based_store.go
@@ -94,6 +94,17 @@ func (f *idpFileBasedStore) GetIdentityProviderList(ctx context.Context) ([]Basi
 	return idpList, nil
 }
 
+// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property from the file-based store.
+func (f *idpFileBasedStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+	data, err := f.GenericFileBasedStore.GetByField(issuer, func(d interface{}) string {
+		return GetPropertyValue(d.(*IDPDTO).Properties, PropIssuer)
+	})
+	if err != nil {
+		return nil, ErrIDPNotFound
+	}
+	return data.(*IDPDTO), nil
+}
+
 // GetIdentityProviderListCount retrieves the total count of identity providers.
 func (f *idpFileBasedStore) GetIdentityProviderListCount(ctx context.Context) (int, error) {
 	return f.GenericFileBasedStore.Count()

--- a/backend/internal/idp/idpStoreInterface_mock_test.go
+++ b/backend/internal/idp/idpStoreInterface_mock_test.go
@@ -219,6 +219,74 @@ func (_c *idpStoreInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetIdentityProviderByIssuer provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+	ret := _mock.Called(ctx, issuer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderByIssuer")
+	}
+
+	var r0 *IDPDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*IDPDTO, error)); ok {
+		return returnFunc(ctx, issuer)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *IDPDTO); ok {
+		r0 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, issuer)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
+type idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderByIssuer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - issuer string
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	return &idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(iDPDTO, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProviderByName provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error) {
 	ret := _mock.Called(ctx, idpName)

--- a/backend/internal/idp/init.go
+++ b/backend/internal/idp/init.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -31,9 +32,11 @@ import (
 )
 
 // Initialize initializes the IDP service and registers its routes.
-func Initialize(mux *http.ServeMux) (IDPServiceInterface, declarativeresource.ResourceExporter, error) {
+func Initialize(
+	cacheManager cache.CacheManagerInterface, mux *http.ServeMux,
+) (IDPServiceInterface, declarativeresource.ResourceExporter, error) {
 	// Create store and transactioner based on store mode
-	idpStore, transactioner, err := initializeStore()
+	idpStore, transactioner, err := initializeStore(cacheManager)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,8 +78,11 @@ func Initialize(mux *http.ServeMux) (IDPServiceInterface, declarativeresource.Re
 // - If identity_provider.store is not specified, falls back to global declarative_resources.enabled:
 //   - If declarative_resources.enabled = true: behaves as IMMUTABLE mode
 //   - If declarative_resources.enabled = false: behaves as MUTABLE mode
-func initializeStore() (idpStoreInterface, transaction.Transactioner, error) {
+func initializeStore(cacheManager cache.CacheManagerInterface) (idpStoreInterface, transaction.Transactioner, error) {
 	storeMode := getIdentityProviderStoreMode()
+
+	idpByIDCache := cache.GetCache[*IDPDTO](cacheManager, "IDPByIDCache")
+	idpByIssuerCache := cache.GetCache[*IDPDTO](cacheManager, "IDPByIssuerCache")
 
 	switch storeMode {
 	case serverconst.StoreModeComposite:
@@ -89,17 +95,21 @@ func initializeStore() (idpStoreInterface, transaction.Transactioner, error) {
 		if err := loadDeclarativeResources(fileStore); err != nil {
 			return nil, nil, err
 		}
-		return idpStore, transactioner, nil
+		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, idpStore), transactioner, nil
 
 	case serverconst.StoreModeDeclarative:
 		fileStore, transactioner := newIDPFileBasedStore()
 		if err := loadDeclarativeResources(fileStore); err != nil {
 			return nil, nil, err
 		}
-		return fileStore, transactioner, nil
+		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, fileStore), transactioner, nil
 
 	default:
-		return newIDPStore()
+		store, transactioner, err := newIDPStore()
+		if err != nil {
+			return nil, nil, err
+		}
+		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, store), transactioner, nil
 	}
 }
 

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
@@ -85,7 +86,7 @@ func (s *IDPInitTestSuite) TestInitialize() {
 	_ = config.InitializeServerRuntime("", testConfig)
 	mux := http.NewServeMux()
 
-	service, _, err := Initialize(mux)
+	service, _, err := Initialize(cache.Initialize(), mux)
 	s.NoError(err)
 	s.NotNil(service)
 	s.Implements((*IDPServiceInterface)(nil), service)
@@ -316,7 +317,7 @@ func (suite *IDPInitTestSuite) TestInitialize_WithDeclarativeResourcesDisabled()
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(mux)
+	service, _, err := Initialize(cache.Initialize(), mux)
 
 	// Assert
 	suite.NoError(err)
@@ -367,7 +368,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_EmptyDirectory(t *testing.T)
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(mux)
+	service, _, err := Initialize(cache.Initialize(), mux)
 
 	// Assert
 	assert.NoError(t, err)
@@ -466,7 +467,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(mux)
+	service, _, err := Initialize(cache.Initialize(), mux)
 
 	// Assert
 	assert.NoError(t, err)
@@ -556,7 +557,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(mux)
+	_, _, err = Initialize(cache.Initialize(), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -617,7 +618,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(mux)
+	_, _, err = Initialize(cache.Initialize(), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -678,7 +679,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to invalid IDP type
-	_, _, err = Initialize(mux)
+	_, _, err = Initialize(cache.Initialize(), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -817,7 +818,7 @@ func (s *IDPInitTestSuite) TestInitialize_DBClientError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(mux)
+	_, _, err := Initialize(cache.Initialize(), mux)
 
 	s.Error(err)
 	s.Equal("mock db client error", err.Error())
@@ -841,7 +842,7 @@ func (s *IDPInitTestSuite) TestInitialize_TransactionerError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(mux)
+	_, _, err := Initialize(cache.Initialize(), mux)
 
 	s.Error(err)
 	s.Equal("mock transactioner error", err.Error())

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -37,6 +37,7 @@ type IDPServiceInterface interface {
 	GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, *serviceerror.ServiceError)
 	GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, *serviceerror.ServiceError)
 	GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, *serviceerror.ServiceError)
+	GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError)
 	UpdateIdentityProvider(ctx context.Context, idpID string, idp *IDPDTO) (*IDPDTO, *serviceerror.ServiceError)
 	DeleteIdentityProvider(ctx context.Context, idpID string) *serviceerror.ServiceError
 }
@@ -155,6 +156,26 @@ func (is *idpService) GetIdentityProviderByName(ctx context.Context,
 			return nil, &ErrorIDPNotFound
 		}
 		logger.Error("Failed to get identity provider by name", log.String("idpName", idpName), log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	return idp, nil
+}
+
+// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property.
+func (is *idpService) GetIdentityProviderByIssuer(ctx context.Context,
+	issuer string) (*IDPDTO, *serviceerror.ServiceError) {
+	logger := is.logger
+	if strings.TrimSpace(issuer) == "" {
+		return nil, &ErrorInvalidIDPID
+	}
+
+	idp, err := is.idpStore.GetIdentityProviderByIssuer(ctx, issuer)
+	if err != nil {
+		if errors.Is(err, ErrIDPNotFound) {
+			return nil, &ErrorIDPNotFound
+		}
+		logger.Error("Failed to get identity provider by issuer", log.String("issuer", issuer), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -19,13 +19,12 @@
 package idp
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-
-	"context"
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -43,7 +42,7 @@ func (m *mockTransactioner) Transact(ctx context.Context, operation func(txCtx c
 type IDPServiceTestSuite struct {
 	suite.Suite
 	mockStore  *idpStoreInterfaceMock
-	idpService IDPServiceInterface
+	idpService *idpService
 }
 
 const (
@@ -56,7 +55,6 @@ func TestIDPServiceTestSuite(t *testing.T) {
 }
 
 func (s *IDPServiceTestSuite) SetupTest() {
-	// Initialize server runtime with declarative mode disabled by default
 	config.ResetServerRuntime()
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
@@ -66,7 +64,11 @@ func (s *IDPServiceTestSuite) SetupTest() {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	s.mockStore = newIdpStoreInterfaceMock(s.T())
-	s.idpService = newIDPService(s.mockStore, &mockTransactioner{})
+	s.idpService = &idpService{
+		idpStore:      s.mockStore,
+		transactioner: &mockTransactioner{},
+		logger:        log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
+	}
 }
 
 func (s *IDPServiceTestSuite) TearDownTest() {
@@ -371,6 +373,61 @@ func (s *IDPServiceTestSuite) TestGetIdentityProviderByName_StoreError() {
 	s.mockStore.AssertExpectations(s.T())
 }
 
+// TestGetIdentityProviderByIssuer_Success tests successful IDP retrieval by issuer
+func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_Success() {
+	prop, _ := cmodels.NewProperty(PropIssuer, "https://idp.example.com", false)
+	idp := &IDPDTO{
+		ID:         "idp-123",
+		Name:       "Test IDP",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop},
+	}
+
+	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").Return(idp, nil)
+
+	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.Equal("idp-123", result.ID)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_EmptyIssuer tests empty issuer validation
+func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_EmptyIssuer() {
+	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPID.Code, err.Code)
+}
+
+// TestGetIdentityProviderByIssuer_NotFound tests IDP not found by issuer
+func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_NotFound() {
+	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://unknown.example.com").
+		Return((*IDPDTO)(nil), ErrIDPNotFound)
+
+	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorIDPNotFound.Code, err.Code)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_StoreError tests store error handling
+func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_StoreError() {
+	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").
+		Return((*IDPDTO)(nil), errors.New("database error"))
+
+	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(serviceerror.InternalServerError.Code, err.Code)
+	s.mockStore.AssertExpectations(s.T())
+}
+
 // TestUpdateIdentityProvider_Success tests successful IDP update
 func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_Success() {
 	idp := &IDPDTO{
@@ -606,7 +663,6 @@ func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_StoreError() {
 
 // TestCreateIdentityProvider_DeclarativeModeEnabled tests creation is blocked when declarative mode is enabled
 func (s *IDPServiceTestSuite) TestCreateIdentityProvider_DeclarativeModeEnabled() {
-	// Setup declarative mode
 	config.ResetServerRuntime()
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
@@ -630,7 +686,6 @@ func (s *IDPServiceTestSuite) TestCreateIdentityProvider_DeclarativeModeEnabled(
 
 // TestUpdateIdentityProvider_DeclarativeModeEnabled tests update is blocked when declarative mode is enabled
 func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_DeclarativeModeEnabled() {
-	// Setup declarative mode
 	config.ResetServerRuntime()
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
@@ -654,7 +709,6 @@ func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_DeclarativeModeEnabled(
 
 // TestDeleteIdentityProvider_DeclarativeModeEnabled tests deletion is blocked when declarative mode is enabled
 func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_DeclarativeModeEnabled() {
-	// Setup declarative mode
 	config.ResetServerRuntime()
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
@@ -759,11 +813,9 @@ func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_FailsForDeclarativeIDP(
 	dbStore := newIdpStoreInterfaceMock(s.T())
 	compositeStore := newCompositeIDPStore(fileStore, dbStore)
 
-	// Simulate IDP exists in file store (declarative) - dbStore should return not found, fileStore returns the IDP
 	dbStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
 	fileStore.On("GetIdentityProvider", context.Background(), idpID).Return(existingIDP, nil)
 
-	// Mock GetIdentityProviderByName check (name is changing)
 	dbStore.On("GetIdentityProviderByName", context.Background(), "Updated Name").Return((*IDPDTO)(nil), ErrIDPNotFound)
 	fileStore.On("GetIdentityProviderByName", context.Background(), "Updated Name").
 		Return((*IDPDTO)(nil), ErrIDPNotFound)
@@ -810,7 +862,6 @@ func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_SucceedsForMutableIDP()
 	dbStore := newIdpStoreInterfaceMock(s.T())
 	compositeStore := newCompositeIDPStore(fileStore, dbStore)
 
-	// Simulate IDP only exists in database (not in file store)
 	fileStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
 	fileStore.On("GetIdentityProviderByName", context.Background(), "Updated Name").
 		Return((*IDPDTO)(nil), ErrIDPNotFound)
@@ -859,7 +910,6 @@ func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_FailsForDeclarativeIDP(
 	dbStore := newIdpStoreInterfaceMock(s.T())
 	compositeStore := newCompositeIDPStore(fileStore, dbStore)
 
-	// Simulate IDP exists in file store (declarative) - dbStore should return not found, fileStore returns the IDP
 	dbStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
 	fileStore.On("GetIdentityProvider", context.Background(), idpID).Return(existingIDP, nil)
 
@@ -896,7 +946,6 @@ func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_SucceedsForMutableIDP()
 	dbStore := newIdpStoreInterfaceMock(s.T())
 	compositeStore := newCompositeIDPStore(fileStore, dbStore)
 
-	// Simulate IDP only exists in database (not in file store)
 	fileStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
 	dbStore.On("GetIdentityProvider", context.Background(), idpID).Return(existingIDP, nil)
 	dbStore.On("DeleteIdentityProvider", context.Background(), idpID).Return(nil)

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -20,6 +20,7 @@ package idp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
@@ -39,6 +40,7 @@ type idpStoreInterface interface {
 	GetIdentityProviderListCount(ctx context.Context) (int, error)
 	GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, error)
 	GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error)
+	GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error)
 	UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error
 	DeleteIdentityProvider(ctx context.Context, idpID string) error
 }
@@ -156,6 +158,74 @@ func (s *idpStore) GetIdentityProvider(ctx context.Context, id string) (*IDPDTO,
 // GetIdentityProviderByName retrieves a specific idp by its name from the database.
 func (s *idpStore) GetIdentityProviderByName(ctx context.Context, name string) (*IDPDTO, error) {
 	return s.getIDP(ctx, queryGetIdentityProviderByName, name)
+}
+
+// GetIdentityProviderByIssuer retrieves a specific idp by its issuer property from the database.
+func (s *idpStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+	dbClient, err := s.dbProvider.GetConfigDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	// For Postgres the $1 placeholder expects a JSON fragment; for SQLite it expects the raw string value.
+	// Build the JSON fragment safely via json.Marshal to avoid injection.
+	type issuerEntry struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+	pgParam, err := json.Marshal([]issuerEntry{{Name: "issuer", Value: issuer}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build issuer query parameter: %w", err)
+	}
+
+	// Select the right argument for the dialect. The DBClient picks the correct query string
+	// internally, but we must supply the matching arg for that query's $1 placeholder.
+	var param string
+	if config.GetServerRuntime().Config.Database.Config.Type == "postgres" {
+		param = string(pgParam)
+	} else {
+		param = issuer
+	}
+
+	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderByIssuer, param, s.deploymentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, ErrIDPNotFound
+	}
+
+	row := results[0]
+
+	basicIDP, err := buildIDPFromResultRow(row)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build idp from result row: %w", err)
+	}
+
+	var properties []cmodels.Property
+	var propertiesJSON string
+
+	switch v := row["properties"].(type) {
+	case string:
+		propertiesJSON = v
+	case []byte:
+		propertiesJSON = string(v)
+	}
+
+	if propertiesJSON != "" {
+		properties, err = cmodels.DeserializePropertiesFromJSON(propertiesJSON)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize properties from JSON: %w", err)
+		}
+	}
+
+	return &IDPDTO{
+		ID:          basicIDP.ID,
+		Name:        basicIDP.Name,
+		Description: basicIDP.Description,
+		Type:        basicIDP.Type,
+		Properties:  properties,
+	}, nil
 }
 
 // getIDP retrieves an IDP based on the provided query and identifier.

--- a/backend/internal/idp/store_constants.go
+++ b/backend/internal/idp/store_constants.go
@@ -58,4 +58,15 @@ var (
 		ID:    "IPQ-IDP_MGT-07",
 		Query: `SELECT COUNT(*) AS count FROM "IDP" WHERE DEPLOYMENT_ID = $1`,
 	}
+	// queryGetIdentityProviderByIssuer is the query to get an IDP by its issuer property value.
+	queryGetIdentityProviderByIssuer = model.DBQuery{
+		ID: "IPQ-IDP_MGT-08",
+		PostgresQuery: "SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM IDP " +
+			"WHERE PROPERTIES @> $1::jsonb AND DEPLOYMENT_ID = $2 LIMIT 1",
+		SQLiteQuery: "SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM IDP " +
+			"WHERE EXISTS (SELECT 1 FROM json_each(PROPERTIES) " +
+			"WHERE json_extract(value, '$.name') = 'issuer' " +
+			"AND json_extract(value, '$.value') = $1) " +
+			"AND DEPLOYMENT_ID = $2 LIMIT 1",
+	}
 )

--- a/backend/internal/idp/store_test.go
+++ b/backend/internal/idp/store_test.go
@@ -698,3 +698,73 @@ func (s *IDPStoreTestSuite) TestGetIdentityProvider_BuildRowError() {
 	s.mockDBProvider.AssertExpectations(s.T())
 	s.mockDBClient.AssertExpectations(s.T())
 }
+
+// TestGetIdentityProviderByIssuer_Success tests successful IDP retrieval by issuer.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_Success() {
+	results := []map[string]interface{}{
+		{
+			"id":          "idp-1",
+			"name":        "IDP 1",
+			"description": "Desc 1",
+			"type":        "OIDC",
+			"properties":  `[{"name":"issuer","value":"https://idp.example.com","isSecret":false}]`,
+		},
+	}
+
+	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
+		"https://idp.example.com", testDeploymentID).Return(results, nil)
+
+	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.NoError(err)
+	s.NotNil(idp)
+	s.Equal("idp-1", idp.ID)
+	s.Equal("IDP 1", idp.Name)
+	s.Len(idp.Properties, 1)
+	s.Equal("issuer", idp.Properties[0].GetName())
+	s.mockDBProvider.AssertExpectations(s.T())
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_NotFound tests IDP not found by issuer.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_NotFound() {
+	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
+		"https://unknown.example.com", testDeploymentID).Return([]map[string]interface{}{}, nil)
+
+	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+
+	s.Error(err)
+	s.Nil(idp)
+	s.ErrorIs(err, ErrIDPNotFound)
+	s.mockDBProvider.AssertExpectations(s.T())
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_DBClientError tests DB client error.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_DBClientError() {
+	s.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("db error"))
+
+	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Error(err)
+	s.Nil(idp)
+	s.Contains(err.Error(), "failed to get database client")
+	s.mockDBProvider.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderByIssuer_QueryError tests query execution error.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_QueryError() {
+	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
+		"https://idp.example.com", testDeploymentID).Return(nil, errors.New("query error"))
+
+	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+
+	s.Error(err)
+	s.Nil(idp)
+	s.Contains(err.Error(), "failed to execute query")
+	s.mockDBProvider.AssertExpectations(s.T())
+	s.mockDBClient.AssertExpectations(s.T())
+}

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -30,6 +30,21 @@ import (
 	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
+// GetPropertyValue returns the plain-text value for the named property from the slice,
+// or an empty string if the property is absent or its value cannot be retrieved.
+func GetPropertyValue(properties []cmodels.Property, name string) string {
+	for i := range properties {
+		if properties[i].GetName() == name {
+			val, err := properties[i].GetValue()
+			if err != nil {
+				return ""
+			}
+			return val
+		}
+	}
+	return ""
+}
+
 // validateIDP validates the identity provider details.
 func validateIDP(idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
 	if idp == nil {
@@ -107,8 +122,16 @@ func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logge
 		filteredPropKeys = append(filteredPropKeys, propName)
 	}
 
-	// Check for required properties
-	for _, requiredProp := range config.Required {
+	// Check for required properties, using the token-exchange override when applicable.
+	requiredProps := config.Required
+	if teProps, ok := tokenExchangeRequiredProps[idpType]; ok {
+		if prop, exists := filteredPropsMap[PropTokenExchangeEnabled]; exists {
+			if val, err := prop.GetValue(); err == nil && val == "true" {
+				requiredProps = teProps
+			}
+		}
+	}
+	for _, requiredProp := range requiredProps {
 		if !slices.Contains(filteredPropKeys, requiredProp) {
 			return nil, serviceerror.CustomServiceError(ErrorInvalidIDPProperty, core.I18nMessage{
 				Key:          "error.idpservice.required_property_missing_description",

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -602,3 +602,87 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithEmptyStringInScopes() {
 	// Should not have consecutive commas
 	s.NotContains(value, ",,")
 }
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeOnly_OIDC_Succeeds() {
+	// OIDC IDP with only the token-exchange required props and token_exchange_enabled=true should succeed.
+	// client_id is no longer required for token exchange; issuer and jwks_endpoint are sufficient.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "true", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_MissingIssuer_Fails() {
+	// OIDC IDP with token_exchange_enabled=true but missing issuer should fail.
+	prop1, _ := cmodels.NewProperty(PropClientID, "your_client_id", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "true", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.DefaultValue, PropIssuer)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_MissingJWKS_Fails() {
+	// OIDC IDP with token_exchange_enabled=true but missing jwks_endpoint should fail.
+	prop1, _ := cmodels.NewProperty(PropClientID, "your_client_id", false)
+	prop2, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop3, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "true", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.DefaultValue, PropJwksEndpoint)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDCWithoutTokenExchange_StillRequiresRedirectProps() {
+	// OIDC IDP without token_exchange_enabled must still require all 5 redirect-flow props.
+	prop1, _ := cmodels.NewProperty(PropClientID, "your_client_id", false)
+	prop2, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop3, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDCWithoutTokenExchange_MissingClientSecret_Fails() {
+	// OIDC IDP without token_exchange_enabled must fail when client_secret is missing.
+	prop1, _ := cmodels.NewProperty(PropClientID, "your_client_id", false)
+	prop2, _ := cmodels.NewProperty(PropRedirectURI, "https://thunder.example.com/callback", false)
+	prop3, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/authorize",
+		false)
+	prop4, _ := cmodels.NewProperty(PropTokenEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.DefaultValue, PropClientSecret)
+}

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -28,6 +28,7 @@ import (
 	"github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/entityprovider"
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
+	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/inboundclient"
 	"github.com/asgardeo/thunder/internal/oauth/jwks"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/dcr"
@@ -68,6 +69,7 @@ func Initialize(
 	entityProvider entityprovider.EntityProviderInterface,
 	resourceService resource.ResourceServiceInterface,
 	i18nService i18nmgt.I18nServiceInterface,
+	idpService idp.IDPServiceInterface,
 ) error {
 	// Fetch runtime transactioner for OAuth services.
 	transactioner, err := provider.GetDBProvider().GetRuntimeDBTransactioner()
@@ -80,7 +82,7 @@ func Initialize(
 		return syshttp.IsSSRFSafeURL(req.URL.String())
 	})
 	resolver := jwksresolver.Initialize(httpClient)
-	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService, jweService, resolver)
+	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService, jweService, resolver, idpService)
 	scopeValidator := scope.Initialize()
 	discoveryService := discovery.Initialize(mux, pkiService)
 	parService := par.Initialize(mux, inboundClient, authnProvider, jwtService, discoveryService,

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -136,7 +136,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenExchangeGrantHandler"))
 
 	// Validate and extract subject token claims
-	subjectClaims, err := h.tokenValidator.ValidateSubjectToken(tokenRequest.SubjectToken, oauthApp)
+	subjectClaims, err := h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.SubjectToken, oauthApp)
 	if err != nil {
 		logger.Debug("Failed to validate subject token", log.Error(err))
 		return nil, &model.ErrorResponse{
@@ -148,7 +148,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	// Validate and extract actor token claims if present
 	var actorClaims *tokenservice.SubjectTokenClaims
 	if tokenRequest.ActorToken != "" {
-		actorClaims, err = h.tokenValidator.ValidateSubjectToken(tokenRequest.ActorToken, oauthApp)
+		actorClaims, err = h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.ActorToken, oauthApp)
 		if err != nil {
 			logger.Debug("Failed to validate actor token", log.Error(err))
 			return nil, &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -160,7 +160,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMock(
 	expectedAudience string,
 	now int64,
 ) {
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -195,7 +195,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 	expectedScope string,
 	now int64,
 ) {
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -421,7 +421,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Basic()
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -505,14 +505,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 		ActorTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenValidator.On("ValidateSubjectToken", actorToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "service456",
 			Iss:            testCustomIssuer,
@@ -569,7 +569,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 		ActorTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "user123",
 			Iss:            testCustomIssuer,
@@ -579,7 +579,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 				"iss": "https://existing-actor.com",
 			},
 		}, nil)
-	suite.mockTokenValidator.On("ValidateSubjectToken", actorToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "service456",
 			Iss:            testCustomIssuer,
@@ -688,7 +688,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Preserv
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -748,7 +748,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 	}
 
 	// Token will pass issuer validation but fail signature verification
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, errors.New("invalid subject token signature: invalid signature"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -774,7 +774,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, errors.New("missing or invalid 'sub' claim"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -794,7 +794,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 	}
 
 	// Mock token validator to return decode error
-	suite.mockTokenValidator.On("ValidateSubjectToken", "invalid.jwt.format", suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, "invalid.jwt.format", suite.oauthApp).
 		Return(nil, errors.New("invalid token format"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -815,7 +815,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, errors.New("token has expired"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -836,7 +836,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, errors.New("token not yet valid"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -873,14 +873,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidActorTok
 		ActorTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenValidator.On("ValidateSubjectToken", actorToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
 		Return(nil, errors.New("invalid subject token signature: invalid signature"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -909,7 +909,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidScope() 
 		Scope:            "read write delete", // "delete" is not in subject token
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -957,7 +957,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ScopeEscalation
 		Scope:            "read write",
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -990,7 +990,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_JWTGenerationEr
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1031,7 +1031,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_UsesDefaultConf
 		GrantTypes: []constants.GrantType{constants.GrantTypeTokenExchange},
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, oauthAppNoConfig).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, oauthAppNoConfig).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1072,7 +1072,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithJWT
 		RequestedTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1155,7 +1155,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 		Scope:              "read",
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -1223,7 +1223,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWit
 		Resources:        []string{"https://resource.example.com"},
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1290,7 +1290,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ActorDelegationChai
 		ActorTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "user123",
 			Iss:            testCustomIssuer,
@@ -1300,7 +1300,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ActorDelegationChai
 				"iss": "https://previous-issuer.com",
 			},
 		}, nil)
-	suite.mockTokenValidator.On("ValidateSubjectToken", actorToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "current-actor",
 			Iss:            testCustomIssuer,
@@ -1372,14 +1372,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 		ActorTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenValidator.On("ValidateSubjectToken", actorToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            "current-actor",
 			Iss:            testCustomIssuer,
@@ -1446,7 +1446,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ScopeDownscopingEnf
 		Scope:            "read",
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1504,7 +1504,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_NoTokenLinkage() {
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1556,7 +1556,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ClaimPreservation()
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -1664,7 +1664,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 		SubjectTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1717,7 +1717,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 		SubjectTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, fmt.Errorf("auth assertion audience mismatch"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -1748,7 +1748,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 		SubjectTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(nil, fmt.Errorf("server auth assertion is missing 'aud' claim"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -1781,7 +1781,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 		SubjectTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1829,7 +1829,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 		SubjectTokenType: string(constants.TokenTypeIdentifierJWT),
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Iss:            testCustomIssuer,
@@ -1880,7 +1880,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudience_Au
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 	tokenRequest.Audiences = []string{"logical://x"}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -1909,7 +1909,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyResource_Au
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 	tokenRequest.Resources = []string{testRS01URI}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -1939,7 +1939,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceAndReso
 	tokenRequest.Audiences = []string{"logical://x"}
 	tokenRequest.Resources = []string{testRS01URI}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -1971,7 +1971,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwo
 	tokenRequest.Audiences = []string{"https://a1.example.com", "https://a2.example.com"}
 	tokenRequest.Resources = []string{testRS01URI, "https://rs02.example.com"}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -2005,7 +2005,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClien
 	tokenRequest.Audiences = []string{testClientID}
 	tokenRequest.Resources = []string{testRS01URI}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -2036,7 +2036,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_Cl
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 	tokenRequest.Audiences = []string{"https://other-service.example.com"}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -2064,7 +2064,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_NeitherAudience
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{},
@@ -2115,7 +2115,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resourc
 		resourceService: rsvc,
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{"read", "write", "admin"},
@@ -2171,7 +2171,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopeNo
 		resourceService: rsvc,
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{"read", "write", "admin"},
@@ -2208,7 +2208,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resourc
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{"read", "write"},
@@ -2270,7 +2270,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Multipl
 		resourceService: rsvc,
 	}
 
-	suite.mockTokenValidator.On("ValidateSubjectToken", subjectToken, suite.oauthApp).
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{"read", "write", "admin"},

--- a/backend/internal/oauth/oauth2/tokenservice/init.go
+++ b/backend/internal/oauth/oauth2/tokenservice/init.go
@@ -19,6 +19,7 @@
 package tokenservice
 
 import (
+	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/jwksresolver"
 	"github.com/asgardeo/thunder/internal/system/jose/jwe"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -30,8 +31,9 @@ func Initialize(
 	jwtService jwt.JWTServiceInterface,
 	jweService jwe.JWEServiceInterface,
 	resolver *jwksresolver.Resolver,
+	idpService idp.IDPServiceInterface,
 ) (TokenBuilderInterface, TokenValidatorInterface) {
 	tokenBuilder := newTokenBuilder(jwtService, jweService, resolver)
-	tokenValidator := newTokenValidator(jwtService)
+	tokenValidator := newTokenValidator(jwtService, idpService)
 	return tokenBuilder, tokenValidator
 }

--- a/backend/internal/oauth/oauth2/tokenservice/init_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/init_test.go
@@ -41,7 +41,7 @@ func (suite *InitTestSuite) SetupTest() {
 }
 
 func (suite *InitTestSuite) TestInitialize() {
-	tokenBuilder, tokenValidator := Initialize(suite.mockJWTService, nil, nil)
+	tokenBuilder, tokenValidator := Initialize(suite.mockJWTService, nil, nil, nil)
 
 	assert.NotNil(suite.T(), tokenBuilder)
 	assert.Implements(suite.T(), (*TokenBuilderInterface)(nil), tokenBuilder)

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -243,24 +243,9 @@ func ExtractUserAttributes(claims map[string]interface{}) map[string]interface{}
 	return userAttributes
 }
 
-// getValidIssuers collects all valid/trusted issuers for the given OAuth application.
-func getValidIssuers(oauthApp *inboundmodel.OAuthClient) map[string]bool {
-	validIssuers := make(map[string]bool)
-
-	tokenConfig := ResolveTokenConfig(oauthApp, TokenTypeAccess)
-	validIssuers[tokenConfig.Issuer] = true
-
-	// TODO: Add support for external issuers
-	return validIssuers
-}
-
-// validateIssuer validates that a token issuer is trusted by checking against configured issuers.
-func validateIssuer(issuer string, oauthApp *inboundmodel.OAuthClient) error {
-	validIssuers := getValidIssuers(oauthApp)
-	if !validIssuers[issuer] {
-		return fmt.Errorf("token issuer '%s' is not supported", issuer)
-	}
-	return nil
+// isSelfIssuer reports whether the given issuer is the server's own configured issuer.
+func isSelfIssuer(issuer string) bool {
+	return issuer == config.GetServerRuntime().Config.JWT.Issuer
 }
 
 // FetchUserAttributes fetches user attributes and merges default claims and groups into the return map.

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -57,209 +57,26 @@ func (suite *UtilsTestSuite) SetupTest() {
 	_ = config.InitializeServerRuntime("test", testConfig)
 }
 
-func (suite *UtilsTestSuite) TestGetValidIssuers_WithNilOAuthApp() {
-	// When oauthApp is nil, should return default issuer from config
-	validIssuers := getValidIssuers(nil)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-}
-
-func (suite *UtilsTestSuite) TestGetValidIssuers_WithOnlyDefaultIssuer() {
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Len(suite.T(), validIssuers, 1)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-}
-
-func (suite *UtilsTestSuite) TestGetValidIssuers_WithTokenConfig() {
-	// OAuthApp with a Token config should still use server-level issuer from config
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token:    &inboundmodel.OAuthTokenConfig{},
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Len(suite.T(), validIssuers, 1)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-}
-
-func (suite *UtilsTestSuite) TestGetValidIssuers_WithAccessTokenConfig() {
-	// OAuthApp with Token and AccessToken config should still use server-level issuer from config
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			AccessToken: &inboundmodel.AccessTokenConfig{
-				ValidityPeriod: 7200,
-			},
-		},
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Len(suite.T(), validIssuers, 1)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-}
-
-func (suite *UtilsTestSuite) TestGetValidIssuers_WithIDTokenConfig() {
-	// OAuthApp with Token and IDToken config should still use server-level issuer from config
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			IDToken: &inboundmodel.IDTokenConfig{
-				ValidityPeriod: 3600,
-			},
-		},
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Len(suite.T(), validIssuers, 1)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-}
-
-func (suite *UtilsTestSuite) TestGetValidIssuers_AlwaysUsesServerIssuer() {
-	// Valid issuers always come from server config, never empty strings
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			AccessToken: &inboundmodel.AccessTokenConfig{},
-		},
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	assert.NotNil(suite.T(), validIssuers)
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-	assert.NotContains(suite.T(), validIssuers, "")
-}
-
 // ============================================================================
-// validateIssuer Tests
+// isSelfIssuer Tests
 // ============================================================================
 
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithValidDefaultIssuer() {
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-	}
+func (suite *UtilsTestSuite) TestisSelfIssuer_WithValidDeploymentIssuer() {
+	result := isSelfIssuer("https://thunder.io")
 
-	err := validateIssuer("https://thunder.io", oauthApp)
-
-	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), result)
 }
 
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithServerIssuerAndTokenConfig() {
-	// Server-level issuer is always valid regardless of token config presence
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token:    &inboundmodel.OAuthTokenConfig{},
-	}
+func (suite *UtilsTestSuite) TestisSelfIssuer_WithInvalidIssuer() {
+	result := isSelfIssuer("https://evil.example.com")
 
-	err := validateIssuer("https://thunder.io", oauthApp)
-
-	assert.NoError(suite.T(), err)
+	assert.False(suite.T(), result)
 }
 
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithServerIssuerAndAccessTokenConfig() {
-	// Server-level issuer is always valid regardless of access token config presence
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			AccessToken: &inboundmodel.AccessTokenConfig{
-				ValidityPeriod: 3600,
-			},
-		},
-	}
+func (suite *UtilsTestSuite) TestisSelfIssuer_WithEmptyIssuer() {
+	result := isSelfIssuer("")
 
-	err := validateIssuer("https://thunder.io", oauthApp)
-
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithInvalidIssuer() {
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-	}
-
-	err := validateIssuer("https://evil.example.com", oauthApp)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "not supported")
-	assert.Contains(suite.T(), err.Error(), "https://evil.example.com")
-}
-
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithEmptyIssuer() {
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-	}
-
-	err := validateIssuer("", oauthApp)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "not supported")
-}
-
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithNilOAuthApp() {
-	// Should still validate against default issuer from config
-	err := validateIssuer("https://thunder.io", nil)
-
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *UtilsTestSuite) TestvalidateIssuer_WithNilOAuthAppInvalidIssuer() {
-	err := validateIssuer("https://invalid.com", nil)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "not supported")
-}
-
-func (suite *UtilsTestSuite) TestFederationScenario_OnlyServerIssuerIsValid() {
-	// Only the server-level issuer from config is accepted; app-level issuers are no longer supported
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			AccessToken: &inboundmodel.AccessTokenConfig{},
-		},
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	// Only the server-level issuer from config is returned
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-
-	// Validate the server-level issuer passes
-	assert.NoError(suite.T(), validateIssuer("https://thunder.io", oauthApp))
-
-	// Should reject unknown issuers
-	assert.Error(suite.T(), validateIssuer("https://staging.company.com", oauthApp))
-	assert.Error(suite.T(), validateIssuer("https://unknown.company.com", oauthApp))
-}
-
-func (suite *UtilsTestSuite) TestFederationScenario_FutureExternalIssuerSupport() {
-	// This test documents the intended behavior for future external issuer support
-	// TODO: When external issuer support is added, update GetValidIssuers to include
-	// external federated issuers from configuration
-
-	oauthApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-	}
-
-	validIssuers := getValidIssuers(oauthApp)
-
-	// Currently only the server-level issuer from config is returned
-	assert.Contains(suite.T(), validIssuers, "https://thunder.io")
-
-	// In the future, external issuers should also be included
-	// assert.Contains(suite.T(), validIssuers, "https://external-idp.com")
+	assert.False(suite.T(), result)
 }
 
 func (suite *UtilsTestSuite) TestJoinScopes_WithMultipleScopes() {

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -19,10 +19,12 @@
 package tokenservice
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
 
+	"github.com/asgardeo/thunder/internal/idp"
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
@@ -34,18 +36,21 @@ import (
 type TokenValidatorInterface interface {
 	ValidateAccessToken(token string) (*AccessTokenClaims, error)
 	ValidateRefreshToken(token string, clientID string) (*RefreshTokenClaims, error)
-	ValidateSubjectToken(token string, oauthApp *inboundmodel.OAuthClient) (*SubjectTokenClaims, error)
+	ValidateSubjectToken(ctx context.Context, token string, oauthApp *inboundmodel.OAuthClient) (
+		*SubjectTokenClaims, error)
 }
 
 // TokenValidator implements TokenValidatorInterface.
 type tokenValidator struct {
 	jwtService jwt.JWTServiceInterface
+	idpService idp.IDPServiceInterface
 }
 
 // NewTokenValidator creates a new TokenValidator instance.
-func newTokenValidator(jwtService jwt.JWTServiceInterface) TokenValidatorInterface {
+func newTokenValidator(jwtService jwt.JWTServiceInterface, idpService idp.IDPServiceInterface) TokenValidatorInterface {
 	return &tokenValidator{
 		jwtService: jwtService,
+		idpService: idpService,
 	}
 }
 
@@ -159,6 +164,7 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 
 // ValidateSubjectToken validates a subject token for token exchange.
 func (tv *tokenValidator) ValidateSubjectToken(
+	ctx context.Context,
 	token string,
 	oauthApp *inboundmodel.OAuthClient,
 ) (*SubjectTokenClaims, error) {
@@ -172,14 +178,79 @@ func (tv *tokenValidator) ValidateSubjectToken(
 		return nil, fmt.Errorf("subject token is missing 'iss' claim: %w", err)
 	}
 
-	if err := validateIssuer(iss, oauthApp); err != nil {
-		return nil, err
+	// Try the server's own issuer first.
+	if isSelfIssuer(iss) {
+		if err := tv.verifyTokenSignatureByIssuer(token, iss); err != nil {
+			return nil, fmt.Errorf("invalid subject token signature: %w", err)
+		}
+		return tv.extractSubjectTokenClaims(token, iss, claims, oauthApp)
 	}
 
-	if err := tv.verifyTokenSignatureByIssuer(token, iss, oauthApp); err != nil {
-		return nil, fmt.Errorf("invalid subject token signature: %w", err)
+	// Not a server-issued token — try external IDP issuers.
+	issuerInfo, resolveErr := tv.resolveExternalIssuer(ctx, iss)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("failed to exchange token for issuer %q: %w", iss, resolveErr)
 	}
 
+	svcErr := tv.jwtService.VerifyJWTSignatureWithJWKS(token, issuerInfo.JWKSURL)
+	if svcErr != nil {
+		return nil, fmt.Errorf("invalid subject token signature: %v", svcErr.Error)
+	}
+
+	// Validate that the external token's audience contains this server's issuer.
+	serverIssuer := config.GetServerRuntime().Config.JWT.Issuer
+	auds, audErr := extractAudiences(claims)
+	if audErr != nil {
+		return nil, fmt.Errorf("failed to extract audience from external token: %w", audErr)
+	}
+	if !slices.Contains(auds, serverIssuer) {
+		return nil, fmt.Errorf(
+			"external token audience does not contain expected server issuer %q", serverIssuer)
+	}
+
+	return tv.extractSubjectTokenClaims(token, iss, claims, oauthApp)
+}
+
+// tokenExchangeIssuerInfo holds the resolved properties needed to validate an external token.
+type tokenExchangeIssuerInfo struct {
+	Issuer  string
+	JWKSURL string
+}
+
+// resolveExternalIssuer looks up an external IDP whose issuer property matches the given issuer.
+func (tv *tokenValidator) resolveExternalIssuer(ctx context.Context, issuer string) (
+	*tokenExchangeIssuerInfo, error) {
+	if tv.idpService == nil {
+		return nil, fmt.Errorf("no external issuers configured")
+	}
+
+	idpDTO, svcErr := tv.idpService.GetIdentityProviderByIssuer(ctx, issuer)
+	if svcErr != nil {
+		return nil, fmt.Errorf("no external issuer configured for '%s'", issuer)
+	}
+
+	if idp.GetPropertyValue(idpDTO.Properties, idp.PropTokenExchangeEnabled) != "true" {
+		return nil, fmt.Errorf("token exchange not enabled for issuer '%s'", issuer)
+	}
+
+	jwksURL := idp.GetPropertyValue(idpDTO.Properties, idp.PropJwksEndpoint)
+	if jwksURL == "" {
+		return nil, fmt.Errorf("no JWKS endpoint configured for issuer '%s'", issuer)
+	}
+
+	return &tokenExchangeIssuerInfo{
+		Issuer:  issuer,
+		JWKSURL: jwksURL,
+	}, nil
+}
+
+// extractSubjectTokenClaims extracts and validates claims from a decoded subject token.
+func (tv *tokenValidator) extractSubjectTokenClaims(
+	_ string,
+	iss string,
+	claims map[string]interface{},
+	oauthApp *inboundmodel.OAuthClient,
+) (*SubjectTokenClaims, error) {
 	sub, err := extractStringClaim(claims, "sub")
 	if err != nil {
 		return nil, fmt.Errorf("missing or invalid 'sub' claim: %w", err)
@@ -190,7 +261,6 @@ func (tv *tokenValidator) ValidateSubjectToken(
 		return nil, err
 	}
 
-	// Determine if this is an auth assertion
 	isAuthAssertion := tv.isAuthAssertion(claims)
 
 	// Extract and validate audience claim
@@ -245,19 +315,15 @@ func (tv *tokenValidator) ValidateSubjectToken(
 func (tv *tokenValidator) verifyTokenSignatureByIssuer(
 	token string,
 	issuer string,
-	oauthApp *inboundmodel.OAuthClient,
 ) error {
-	issuers := getValidIssuers(oauthApp)
-	if issuers[issuer] {
-		svcErr := tv.jwtService.VerifyJWTSignature(token)
-		if svcErr != nil {
-			return fmt.Errorf("failed to verify token signature: %v", svcErr.Error)
-		}
-		return nil
+	if !isSelfIssuer(issuer) {
+		return fmt.Errorf("no verification method configured for issuer: %s", issuer)
 	}
-
-	// TODO: Implement JWKS-based verification for external federated issuers
-	return fmt.Errorf("no verification method configured for issuer: %s", issuer)
+	svcErr := tv.jwtService.VerifyJWTSignature(token)
+	if svcErr != nil {
+		return fmt.Errorf("failed to verify token signature: %v", svcErr.Error)
+	}
+	return nil
 }
 
 // validateTimeClaims validates time-based claims (exp, nbf).

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -21,6 +21,7 @@ package tokenservice
 import (
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -30,9 +31,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/idp"
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
+	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 )
 
@@ -128,7 +132,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_BasicToke
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -155,7 +159,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithToken
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, customOAuthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, customOAuthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -178,7 +182,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithoutNb
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -200,7 +204,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithEmpty
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -211,7 +215,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithEmpty
 func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidJWTFormat() {
 	token := invalidJWTFormat
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -221,7 +225,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidJWTF
 func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_MalformedJWT() {
 	token := "not-a-jwt-at-all" //nolint:gosec // Test token, not a real credential
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -239,7 +243,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_MissingIssu
 	}
 	token := suite.createTestJWT(claims)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -253,7 +257,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidIssu
 	}
 	token := suite.createTestJWT(claims)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -269,11 +273,11 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_UntrustedIs
 	}
 	token := suite.createTestJWT(claims)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "not supported")
+	assert.Contains(suite.T(), err.Error(), "failed to exchange token for issuer")
 }
 
 func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidSignature() {
@@ -298,7 +302,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidSign
 			},
 		})
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -321,7 +325,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_MissingSubC
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -340,7 +344,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidSubT
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -360,7 +364,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_ExpiredToke
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -380,7 +384,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_NotYetValid
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -393,25 +397,19 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Success_S
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io", suite.oauthApp)
+	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io")
 
 	assert.NoError(suite.T(), err)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
 func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Success_WithTokenConfig() {
-	// App with token config should still use server-level issuer for signature verification
-	customApp := &inboundmodel.OAuthClient{
-		ClientID: "test-client",
-		Token: &inboundmodel.OAuthTokenConfig{
-			AccessToken: &inboundmodel.AccessTokenConfig{},
-		},
-	}
+	// Server-level issuer is used for signature verification regardless of app token config
 	token := testJWTTokenString
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io", customApp)
+	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io")
 
 	assert.NoError(suite.T(), err)
 	suite.mockJWTService.AssertExpectations(suite.T())
@@ -432,7 +430,7 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Error_Sig
 			},
 		})
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io", suite.oauthApp)
+	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://thunder.io")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to verify token signature")
@@ -443,7 +441,7 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Error_Ext
 	// External issuer (not in trusted server issuers)
 	token := testJWTTokenString
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://external-idp.com", suite.oauthApp)
+	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://external-idp.com")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no verification method configured for issuer")
@@ -466,7 +464,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_DecodeBeforeVerify(
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -485,11 +483,11 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_FailFastOnUntrusted
 	token := suite.createTestJWT(claims)
 
 	// Should not call VerifyJWTSignature because issuer check fails first
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "not supported")
+	assert.Contains(suite.T(), err.Error(), "failed to exchange token for issuer")
 	// VerifyJWTSignature should NOT have been called
 	suite.mockJWTService.AssertNotCalled(suite.T(), "VerifyJWTSignature")
 }
@@ -515,7 +513,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_OnlyServerIssuerIsV
 	suite.mockJWTService.On("VerifyJWTSignature", tokenValid).Return(nil)
 
 	resultValid, errValid := suite.validator.ValidateSubjectToken(
-		tokenValid, appWithTokenConfig)
+		context.Background(), tokenValid, appWithTokenConfig)
 	assert.NoError(suite.T(), errValid)
 	assert.NotNil(suite.T(), resultValid)
 
@@ -528,10 +526,10 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_OnlyServerIssuerIsV
 	tokenInvalid := suite.createTestJWT(claimsInvalid)
 
 	resultInvalid, errInvalid := suite.validator.ValidateSubjectToken(
-		tokenInvalid, appWithTokenConfig)
+		context.Background(), tokenInvalid, appWithTokenConfig)
 	assert.Error(suite.T(), errInvalid)
 	assert.Nil(suite.T(), resultInvalid)
-	assert.Contains(suite.T(), errInvalid.Error(), "not supported")
+	assert.Contains(suite.T(), errInvalid.Error(), "failed to exchange token for issuer")
 	// VerifyJWTSignature should NOT have been called for untrusted issuer
 	suite.mockJWTService.AssertNotCalled(suite.T(), "VerifyJWTSignature", tokenInvalid)
 
@@ -546,7 +544,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_FutureExternalIssue
 	externalIssuer := "https://external-idp.com"
 
 	// Currently returns error because no JWKS support yet
-	err := suite.validator.verifyTokenSignatureByIssuer(token, externalIssuer, suite.oauthApp)
+	err := suite.validator.verifyTokenSignatureByIssuer(token, externalIssuer)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no verification method configured")
@@ -567,7 +565,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Security_RejectsT
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -601,7 +599,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_EdgeCase_VeryLong
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -627,7 +625,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_AuthAssertion_Rej
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -658,7 +656,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_Acce
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, oauthAppWithID)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, oauthAppWithID)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -681,7 +679,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_Tole
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1115,7 +1113,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithAppI
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1145,7 +1143,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithEmpt
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1173,7 +1171,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithScop
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1202,7 +1200,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithUser
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1232,7 +1230,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_MissingAud
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1257,7 +1255,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_AudienceMi
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1283,7 +1281,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithDefa
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1296,7 +1294,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithDefa
 func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidJWTFormat() {
 	token := invalidJWTFormat
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1313,7 +1311,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_MissingIss
 	}
 	token := suite.createTestJWT(claims)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1335,7 +1333,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_ExpiredTok
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1356,11 +1354,11 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidIss
 
 	suite.oauthApp.ID = testAppID
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "is not supported")
+	assert.Contains(suite.T(), err.Error(), "failed to exchange token for issuer")
 }
 
 func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidSignature() {
@@ -1385,7 +1383,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidSig
 		},
 	})
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1408,7 +1406,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidSub
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1431,7 +1429,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_TokenNotYe
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1454,7 +1452,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_MissingExp
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1478,7 +1476,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidAud
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1504,7 +1502,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithEmpt
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1532,7 +1530,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpiredWit
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1553,7 +1551,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpiredBey
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1577,7 +1575,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_NbfInFutur
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1598,7 +1596,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_NbfInFutur
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1651,7 +1649,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_Expiration
 
 			suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil).Once()
 
-			result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+			result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 			assert.Error(suite.T(), err, tc.desc)
 			assert.Nil(suite.T(), result)
@@ -1690,7 +1688,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpJustIns
 
 	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
 
-	result, err := suite.validator.ValidateSubjectToken(token, suite.oauthApp)
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1939,4 +1937,285 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_EmptyClientI
 	assert.Nil(suite.T(), result)
 	assert.Contains(suite.T(), err.Error(), "missing required 'client_id' claim")
 	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// ============================================================================
+// External IDP Token Exchange Tests — audience validates against server issuer
+// ============================================================================
+
+const (
+	testExternalIssuer = "https://external-idp.example.com"
+	testExternalJWKS   = "https://external-idp.example.com/.well-known/jwks.json"
+)
+
+type ExternalIDPValidatorTestSuite struct {
+	suite.Suite
+	mockJWTService *jwtmock.JWTServiceInterfaceMock
+	mockIDPService *idpmock.IDPServiceInterfaceMock
+	validator      *tokenValidator
+	oauthApp       *inboundmodel.OAuthClient
+}
+
+func TestExternalIDPValidatorTestSuite(t *testing.T) {
+	suite.Run(t, new(ExternalIDPValidatorTestSuite))
+}
+
+func (suite *ExternalIDPValidatorTestSuite) SetupTest() {
+	config.ResetServerRuntime()
+	testConfig := &config.Config{
+		JWT: config.JWTConfig{
+			Issuer:         "https://thunder.io",
+			ValidityPeriod: 3600,
+			Audience:       "application",
+			Leeway:         30,
+		},
+	}
+	_ = config.InitializeServerRuntime("test", testConfig)
+
+	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
+	suite.validator = &tokenValidator{
+		jwtService: suite.mockJWTService,
+		idpService: suite.mockIDPService,
+	}
+	suite.oauthApp = &inboundmodel.OAuthClient{
+		ClientID: "test-client",
+	}
+}
+
+// buildExternalIDPDTO builds a minimal idp.IDPDTO for the standard test external IDP.
+func buildExternalIDPDTO() *idp.IDPDTO {
+	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "true", false)
+	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
+	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
+	return &idp.IDPDTO{
+		Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer},
+	}
+}
+
+// createExternalJWT creates a signed-looking JWT for an external IDP test.
+func (suite *ExternalIDPValidatorTestSuite) createExternalJWT(claims map[string]interface{}) string {
+	header := map[string]interface{}{"alg": "RS256", "typ": "JWT"}
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	return fmt.Sprintf("%s.%s.signature", headerB64, claimsB64)
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_AudIsServerIssuer() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "https://thunder.io", // audience is this server's own issuer
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTO := buildExternalIDPDTO()
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+	assert.Equal(suite.T(), testExternalIssuer, result.Iss)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_AudArrayHasServerIssuer() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": []interface{}{"https://thunder.io", "other-audience"}, // array including server issuer
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTO := buildExternalIDPDTO()
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_AudNotServerIssuer() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "some-client-id", // audience is a client_id, not the server issuer
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTO := buildExternalIDPDTO()
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "external token audience does not contain expected server issuer")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_MissingAudClaim() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		// no aud claim
+		"exp": float64(now + 3600),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTO := buildExternalIDPDTO()
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to extract audience from external token")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_InvalidSignature() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "https://thunder.io",
+		"exp": float64(now + 3600),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTO := buildExternalIDPDTO()
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).
+		Return(&serviceerror.ServiceError{
+			Type:  serviceerror.ServerErrorType,
+			Code:  "SIGNATURE_VERIFICATION_FAILED",
+			Error: core.I18nMessage{Key: "error.test.sig_failed", DefaultValue: "Signature verification failed"},
+			ErrorDescription: core.I18nMessage{
+				Key: "error.test.sig_failed_desc", DefaultValue: "JWT signature verification failed",
+			},
+		})
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "invalid subject token signature")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_TokenExchangeNotEnabled() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "https://thunder.io",
+		"exp": float64(now + 3600),
+	}
+	token := suite.createExternalJWT(claims)
+
+	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "false", false)
+	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
+	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
+	idpDTO := &idp.IDPDTO{
+		Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer},
+	}
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "token exchange not enabled")
+	suite.mockIDPService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_NoJWKSEndpoint() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "https://thunder.io",
+		"exp": float64(now + 3600),
+	}
+	token := suite.createExternalJWT(claims)
+
+	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "true", false)
+	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
+	idpDTO := &idp.IDPDTO{
+		Properties: []cmodels.Property{*propTokenExchange, *propIssuer},
+	}
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
+		Return(idpDTO, nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "no JWKS endpoint configured")
+	suite.mockIDPService.AssertExpectations(suite.T())
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_IDPNotFound() {
+	unknownIssuer := "https://unknown-idp.example.com"
+
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": unknownIssuer,
+		"aud": "https://thunder.io",
+		"exp": float64(now + 3600),
+	}
+	token := suite.createExternalJWT(claims)
+
+	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), unknownIssuer).
+		Return(nil, &serviceerror.ServiceError{
+			Type:  serviceerror.ClientErrorType,
+			Code:  "IDP_NOT_FOUND",
+			Error: core.I18nMessage{Key: "error.test.idp_not_found", DefaultValue: "IDP not found"},
+			ErrorDescription: core.I18nMessage{
+				Key: "error.test.idp_not_found_desc", DefaultValue: "No IDP found for the given issuer",
+			},
+		})
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to exchange token for issuer")
+	suite.mockIDPService.AssertExpectations(suite.T())
 }

--- a/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
@@ -238,6 +238,76 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetIdentityProviderByIssuer provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*idp.IDPDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, issuer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderByIssuer")
+	}
+
+	var r0 *idp.IDPDTO
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*idp.IDPDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, issuer)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *idp.IDPDTO); ok {
+		r0 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*idp.IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
+type IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderByIssuer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - issuer string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	return &IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *idp.IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(iDPDTO, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*idp.IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProviderByName provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*idp.IDPDTO, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, idpName)

--- a/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
@@ -220,6 +220,74 @@ func (_c *idpStoreInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetIdentityProviderByIssuer provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*idp.IDPDTO, error) {
+	ret := _mock.Called(ctx, issuer)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderByIssuer")
+	}
+
+	var r0 *idp.IDPDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*idp.IDPDTO, error)); ok {
+		return returnFunc(ctx, issuer)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *idp.IDPDTO); ok {
+		r0 = returnFunc(ctx, issuer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*idp.IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, issuer)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
+type idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderByIssuer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - issuer string
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	return &idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *idp.IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(iDPDTO, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*idp.IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProviderByName provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*idp.IDPDTO, error) {
 	ret := _mock.Called(ctx, idpName)

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
@@ -5,6 +5,8 @@
 package tokenservicemock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/inboundclient/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	mock "github.com/stretchr/testify/mock"
@@ -168,8 +170,8 @@ func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) RunAndReturn(ru
 }
 
 // ValidateSubjectToken provides a mock function for the type TokenValidatorInterfaceMock
-func (_mock *TokenValidatorInterfaceMock) ValidateSubjectToken(token string, oauthApp *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error) {
-	ret := _mock.Called(token, oauthApp)
+func (_mock *TokenValidatorInterfaceMock) ValidateSubjectToken(ctx context.Context, token string, oauthApp *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error) {
+	ret := _mock.Called(ctx, token, oauthApp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateSubjectToken")
@@ -177,18 +179,18 @@ func (_mock *TokenValidatorInterfaceMock) ValidateSubjectToken(token string, oau
 
 	var r0 *tokenservice.SubjectTokenClaims
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error)); ok {
-		return returnFunc(token, oauthApp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error)); ok {
+		return returnFunc(ctx, token, oauthApp)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *model.OAuthClient) *tokenservice.SubjectTokenClaims); ok {
-		r0 = returnFunc(token, oauthApp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.OAuthClient) *tokenservice.SubjectTokenClaims); ok {
+		r0 = returnFunc(ctx, token, oauthApp)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*tokenservice.SubjectTokenClaims)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *model.OAuthClient) error); ok {
-		r1 = returnFunc(token, oauthApp)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *model.OAuthClient) error); ok {
+		r1 = returnFunc(ctx, token, oauthApp)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -201,25 +203,31 @@ type TokenValidatorInterfaceMock_ValidateSubjectToken_Call struct {
 }
 
 // ValidateSubjectToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - token string
 //   - oauthApp *model.OAuthClient
-func (_e *TokenValidatorInterfaceMock_Expecter) ValidateSubjectToken(token interface{}, oauthApp interface{}) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
-	return &TokenValidatorInterfaceMock_ValidateSubjectToken_Call{Call: _e.mock.On("ValidateSubjectToken", token, oauthApp)}
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateSubjectToken(ctx interface{}, token interface{}, oauthApp interface{}) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
+	return &TokenValidatorInterfaceMock_ValidateSubjectToken_Call{Call: _e.mock.On("ValidateSubjectToken", ctx, token, oauthApp)}
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateSubjectToken_Call) Run(run func(token string, oauthApp *model.OAuthClient)) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateSubjectToken_Call) Run(run func(ctx context.Context, token string, oauthApp *model.OAuthClient)) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.OAuthClient
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*model.OAuthClient)
+			arg1 = args[1].(string)
+		}
+		var arg2 *model.OAuthClient
+		if args[2] != nil {
+			arg2 = args[2].(*model.OAuthClient)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -230,7 +238,7 @@ func (_c *TokenValidatorInterfaceMock_ValidateSubjectToken_Call) Return(subjectT
 	return _c
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateSubjectToken_Call) RunAndReturn(run func(token string, oauthApp *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateSubjectToken_Call) RunAndReturn(run func(ctx context.Context, token string, oauthApp *model.OAuthClient) (*tokenservice.SubjectTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateSubjectToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -152,6 +152,118 @@ configuration:
 | JWKS fetch fails | `trusted_issuer.jwks_url` cannot be reached from <ProductName />, or the authorization server uses a certificate <ProductName /> does not trust | Check that the network allows the request, and install the authorization server's CA certificate on <ProductName /> if needed. |
 | Console never redirects to the external authorization server | `consoleClient.trustedIssuer` not set, or `publicUrl`/`hostname` still point at <ProductName /> | Verify the `consoleClient.trustedIssuer` block and re-render the chart. |
 
+## Token Exchange with External Identity Providers
+
+In addition to accepting external tokens for API authentication (above), <ProductName /> supports exchanging external IDP tokens for <ProductName />-issued access tokens via [RFC 8693 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693). This is useful when:
+
+- A client authenticates users via an external OIDC provider (Asgardeo, Google, Azure AD, Keycloak) and needs a <ProductName />-scoped access token.
+- You want to consolidate token issuance through <ProductName /> while delegating authentication to an upstream IDP.
+
+### How It Works
+
+1. Register the external IDP in <ProductName /> with token exchange properties (`issuer`, `jwks_endpoint`, `token_exchange_enabled`).
+2. A client sends the external token to <ProductName />'s token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`.
+3. <ProductName /> resolves the token's `iss` claim to a registered IDP, verifies the signature via the IDP's JWKS endpoint, and validates the audience.
+4. <ProductName /> issues a new access token with the external user's `sub` claim passed through.
+
+### Setup
+
+#### 1. Register an OIDC Identity Provider
+
+Create an IDP via the `/identity-providers` API with the following properties:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `issuer` | Yes | The exact `iss` claim value in tokens from this IDP (e.g., `https://api.asgardeo.io/t/myorg/oauth2/token`). |
+| `jwks_endpoint` | Yes | The IDP's JWKS URL for signature verification. |
+| `token_exchange_enabled` | Yes | Set to `"true"` to enable this IDP for token exchange. |
+
+For token-exchange-only IDPs, only the three properties above are required. The redirect-flow OIDC
+properties (`client_secret`, `redirect_uri`, `authorization_endpoint`, `token_endpoint`) are **not**
+required. They are only needed when the same IDP is also used for redirect-based login.
+
+Example:
+
+```bash
+curl -X POST https://thunder.example.com/identity-providers \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Asgardeo",
+    "type": "OIDC",
+    "properties": [
+      {"name": "issuer", "value": "https://api.asgardeo.io/t/myorg/oauth2/token"},
+      {"name": "jwks_endpoint", "value": "https://api.asgardeo.io/t/myorg/oauth2/jwks"},
+      {"name": "token_exchange_enabled", "value": "true"}
+    ]
+  }'
+```
+
+#### 2. Create an OAuth Application with Token Exchange Grant
+
+The application must include `urn:ietf:params:oauth:grant-type:token-exchange` in its allowed grant types:
+
+```bash
+curl -X POST https://thunder.example.com/applications \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Token Exchange Client",
+    "inboundAuthConfig": [{
+      "type": "oauth2",
+      "config": {
+        "clientId": "te_client",
+        "clientSecret": "te_secret",
+        "grantTypes": ["urn:ietf:params:oauth:grant-type:token-exchange"],
+        "tokenEndpointAuthMethod": "client_secret_basic"
+      }
+    }]
+  }'
+```
+
+#### 3. Exchange the External Token
+
+```bash
+curl -X POST https://thunder.example.com/oauth2/token \
+  -u 'te_client:te_secret' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
+  -d 'subject_token=<JWT_FROM_EXTERNAL_IDP>' \
+  -d 'subject_token_type=urn:ietf:params:oauth:token-type:jwt'
+```
+
+Response:
+
+```json
+{
+  "access_token": "eyJ...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
+}
+```
+
+The issued token's `sub` claim contains the external user's subject identifier from the original token.
+
+### Validation Rules
+
+When processing an external token for exchange, <ProductName />:
+
+1. Extracts the `iss` claim and matches it against IDPs with `token_exchange_enabled=true`.
+2. Fetches the IDP's JWKS and verifies the token signature.
+3. Checks that the token's `aud` claim contains this server's own issuer.
+4. Validates `exp` (and `nbf` if present) with the configured clock-skew leeway.
+5. Extracts `sub` and non-standard claims as user attributes.
+
+If any step fails, the exchange returns HTTP 400 with `error=invalid_request` and a generic `"Invalid subject_token"` message.
+
+### Limitations
+
+- Only JWT tokens are supported for external exchange. Opaque tokens from providers like GitHub cannot be exchanged.
+- The external user's `sub` is passed through as-is — no local user lookup or JIT provisioning is performed.
+- No scope or claim mapping is applied. External token scopes use the existing intersection logic; external claims pass through filtered by the app's `userAttributes` configuration.
+- Trust is global: all token-exchange-enabled IDPs are available to all applications that have the `token-exchange` grant type.
+
 ## Reference
 
 - Configuration reference: [Trusted Issuer Configuration](/docs/next/guides/getting-started/configuration#trusted-issuer-configuration)


### PR DESCRIPTION
### Purpose
Enable Thunder's token exchange endpoint to accept JWT tokens from external identity providers. Adds issuer and token_exchange_enabled IDP properties, resolves external issuers at runtime, and verifies signatures against the IDP's JWKS endpoint with audience validation.

### Related Issue(s)
- https://github.com/asgardeo/thunder/issues/2438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token exchange support: exchange external IDP JWTs for product-issued tokens (RFC 8693).
  * New IDP config options: issuer and token_exchange_enabled, with conditional required properties when enabled.
  * Context-aware subject-token validation that verifies external issuers and JWKS, and stricter audience checks for auth-assertions.
  * IDP lookups cached for faster retrieval with negative-caching.

* **Documentation**
  * Added guide: Token Exchange with External Identity Providers (workflow, validation, limitations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->