### PR TITLE
Align credential schema attribute handling in provisioning

### DIFF
--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -634,14 +634,14 @@ func (s *entityService) validateCredentialKeys(
 		return nil
 	}
 
-	credFields, svcErr := s.entityTypeService.GetCredentialAttributes(ctx,
-		entitytype.TypeCategory(category), entityType)
+	credInfos, svcErr := s.entityTypeService.GetAttributes(ctx,
+		entitytype.TypeCategory(category), entityType, true, false, false)
 	if svcErr != nil {
 		return fmt.Errorf("failed to get credential attributes from schema: %s", svcErr.ErrorDescription)
 	}
-	allowed := make(map[string]struct{}, len(credFields))
-	for _, f := range credFields {
-		allowed[f] = struct{}{}
+	allowed := make(map[string]struct{}, len(credInfos))
+	for _, a := range credInfos {
+		allowed[a.Attribute] = struct{}{}
 	}
 	for key := range updates {
 		if _, ok := allowed[key]; !ok {
@@ -849,13 +849,13 @@ func (s *entityService) extractAndHashSchemaCredentials(ctx context.Context, ent
 		return nil, nil
 	}
 
-	credentialFields, svcErr := s.entityTypeService.GetCredentialAttributes(ctx,
-		entitytype.TypeCategory(entity.Category), entity.Type)
+	credentialInfos, svcErr := s.entityTypeService.GetAttributes(ctx,
+		entitytype.TypeCategory(entity.Category), entity.Type, true, false, false)
 	if svcErr != nil {
 		return nil, fmt.Errorf("failed to get credential attributes from schema: %s", svcErr.ErrorDescription)
 	}
 
-	if len(credentialFields) == 0 {
+	if len(credentialInfos) == 0 {
 		return nil, nil
 	}
 
@@ -865,10 +865,10 @@ func (s *entityService) extractAndHashSchemaCredentials(ctx context.Context, ent
 	}
 
 	plaintextCreds := make(map[string]string)
-	for _, field := range credentialFields {
-		if val, ok := attrsMap[field].(string); ok && val != "" {
-			plaintextCreds[field] = val
-			delete(attrsMap, field)
+	for _, info := range credentialInfos {
+		if val, ok := attrsMap[info.Attribute].(string); ok && val != "" {
+			plaintextCreds[info.Attribute] = val
+			delete(attrsMap, info.Attribute)
 		}
 	}
 

--- a/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
+++ b/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
@@ -180,28 +180,28 @@ func (_c *EntityTypeServiceInterfaceMock_DeleteEntityType_Call) RunAndReturn(run
 	return _c
 }
 
-// GetCredentialAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
-func (_mock *EntityTypeServiceInterfaceMock) GetCredentialAttributes(ctx context.Context, category TypeCategory, entityType string) ([]string, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, category, entityType)
+// GetAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) GetAttributes(ctx context.Context, category TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCredentialAttributes")
+		panic("no return value specified for GetAttributes")
 	}
 
-	var r0 []string
+	var r0 []AttributeInfo
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) ([]string, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string, bool, bool, bool) ([]AttributeInfo, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) []string); ok {
-		r0 = returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string, bool, bool, bool) []AttributeInfo); ok {
+		r0 = returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
+			r0 = ret.Get(0).([]AttributeInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, TypeCategory, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, TypeCategory, string, bool, bool, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -210,20 +210,23 @@ func (_mock *EntityTypeServiceInterfaceMock) GetCredentialAttributes(ctx context
 	return r0, r1
 }
 
-// EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCredentialAttributes'
-type EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call struct {
+// EntityTypeServiceInterfaceMock_GetAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAttributes'
+type EntityTypeServiceInterfaceMock_GetAttributes_Call struct {
 	*mock.Call
 }
 
-// GetCredentialAttributes is a helper method to define mock.On call
+// GetAttributes is a helper method to define mock.On call
 //   - ctx context.Context
 //   - category TypeCategory
 //   - entityType string
-func (_e *EntityTypeServiceInterfaceMock_Expecter) GetCredentialAttributes(ctx interface{}, category interface{}, entityType interface{}) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
-	return &EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call{Call: _e.mock.On("GetCredentialAttributes", ctx, category, entityType)}
+//   - allowCredential bool
+//   - allowNonCredential bool
+//   - requiredOnly bool
+func (_e *EntityTypeServiceInterfaceMock_Expecter) GetAttributes(ctx interface{}, category interface{}, entityType interface{}, allowCredential interface{}, allowNonCredential interface{}, requiredOnly interface{}) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
+	return &EntityTypeServiceInterfaceMock_GetAttributes_Call{Call: _e.mock.On("GetAttributes", ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)}
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Run(run func(ctx context.Context, category TypeCategory, entityType string)) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) Run(run func(ctx context.Context, category TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool)) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -237,21 +240,36 @@ func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Run(run f
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
+			arg4,
+			arg5,
 		)
 	})
 	return _c
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
-	_c.Call.Return(strings, serviceError)
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) Return(vs []AttributeInfo, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
+	_c.Call.Return(vs, serviceError)
 	return _c
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, entityType string) ([]string, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -574,88 +592,6 @@ func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) Return(entityTy
 }
 
 func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, limit int, offset int, includeDisplay bool) (*EntityTypeListResponse, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetNonCredentialAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
-func (_mock *EntityTypeServiceInterfaceMock) GetNonCredentialAttributes(ctx context.Context, category TypeCategory, entityType string, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, category, entityType, requiredOnly)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetNonCredentialAttributes")
-	}
-
-	var r0 []AttributeInfo
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string, bool) ([]AttributeInfo, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, category, entityType, requiredOnly)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string, bool) []AttributeInfo); ok {
-		r0 = returnFunc(ctx, category, entityType, requiredOnly)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]AttributeInfo)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, TypeCategory, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, category, entityType, requiredOnly)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNonCredentialAttributes'
-type EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call struct {
-	*mock.Call
-}
-
-// GetNonCredentialAttributes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - category TypeCategory
-//   - entityType string
-//   - requiredOnly bool
-func (_e *EntityTypeServiceInterfaceMock_Expecter) GetNonCredentialAttributes(ctx interface{}, category interface{}, entityType interface{}, requiredOnly interface{}) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	return &EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call{Call: _e.mock.On("GetNonCredentialAttributes", ctx, category, entityType, requiredOnly)}
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) Run(run func(ctx context.Context, category TypeCategory, entityType string, requiredOnly bool)) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 TypeCategory
-		if args[1] != nil {
-			arg1 = args[1].(TypeCategory)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 bool
-		if args[3] != nil {
-			arg3 = args[3].(bool)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) Return(vs []AttributeInfo, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	_c.Call.Return(vs, serviceError)
-	return _c
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, entityType string, requiredOnly bool) ([]AttributeInfo, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/entitytype/model/credential_test.go
+++ b/backend/internal/entitytype/model/credential_test.go
@@ -83,7 +83,7 @@ func (s *CredentialTestSuite) TestIsCredential_ArrayReturnsFalse() {
 	s.Require().False(schema.properties["tags"].isCredential())
 }
 
-func (s *CredentialTestSuite) TestGetCredentialAttributes_ReturnsOnlyCredentialProperties() {
+func (s *CredentialTestSuite) TestGetAttributes_CredentialOnly_ReturnsOnlyCredentialProperties() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"password": {"type": "string", "credential": true},
 		"apiKey": {"type": "string", "credential": true},
@@ -93,20 +93,25 @@ func (s *CredentialTestSuite) TestGetCredentialAttributes_ReturnsOnlyCredentialP
 	}`))
 	s.Require().NoError(err)
 
-	fields := schema.GetCredentialAttributes()
-	sort.Strings(fields)
-	s.Require().Equal([]string{"apiKey", "password"}, fields)
+	attrs := schema.GetAttributes(true, false, false)
+	names := make([]string, 0, len(attrs))
+	for _, a := range attrs {
+		names = append(names, a.Attribute)
+		s.True(a.Credential, "credential attribute must have Credential=true")
+	}
+	sort.Strings(names)
+	s.Require().Equal([]string{"apiKey", "password"}, names)
 }
 
-func (s *CredentialTestSuite) TestGetCredentialAttributes_EmptyWhenNoCredentials() {
+func (s *CredentialTestSuite) TestGetAttributes_CredentialOnly_EmptyWhenNoCredentials() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"email": {"type": "string"},
 		"age": {"type": "number"}
 	}`))
 	s.Require().NoError(err)
 
-	fields := schema.GetCredentialAttributes()
-	s.Require().Empty(fields)
+	attrs := schema.GetAttributes(true, false, false)
+	s.Require().Empty(attrs)
 }
 
 func (s *CredentialTestSuite) TestCredentialFieldDefaultsFalse() {

--- a/backend/internal/entitytype/model/schema.go
+++ b/backend/internal/entitytype/model/schema.go
@@ -113,21 +113,27 @@ func (cs *Schema) ValidateAsDisplayAttribute(name string) DisplayAttributeStatus
 	return DisplayAttributeValid
 }
 
-// AttributeInfo holds an attribute name, its required status, and its human-readable display label.
-// DisplayName may be empty when the schema definition omits the `displayName` field;
+// AttributeInfo holds an attribute name, its required and credential status, and its human-readable
+// display label. DisplayName may be empty when the schema definition omits the `displayName` field;
 // callers should fall back to Attribute when rendering a label.
 type AttributeInfo struct {
 	Attribute   string
 	DisplayName string
 	Required    bool
+	Credential  bool
 }
 
-// GetNonCredentialAttributes returns top-level properties not marked as credentials.
-// When requiredOnly is true, only required properties are included.
-func (cs *Schema) GetNonCredentialAttributes(requiredOnly bool) []AttributeInfo {
+// GetAttributes returns top-level properties filtered by the provided flags.
+// allowCredential includes credential properties; allowNonCredential includes non-credential
+// properties. When requiredOnly is true, only required properties are included.
+func (cs *Schema) GetAttributes(allowCredential, allowNonCredential, requiredOnly bool) []AttributeInfo {
 	result := make([]AttributeInfo, 0, len(cs.properties))
 	for attr, prop := range cs.properties {
-		if prop.isCredential() {
+		isCredential := prop.isCredential()
+		if isCredential && !allowCredential {
+			continue
+		}
+		if !isCredential && !allowNonCredential {
 			continue
 		}
 		if requiredOnly && !prop.isRequired() {
@@ -137,21 +143,10 @@ func (cs *Schema) GetNonCredentialAttributes(requiredOnly bool) []AttributeInfo 
 			Attribute:   attr,
 			DisplayName: prop.getDisplayName(),
 			Required:    prop.isRequired(),
+			Credential:  isCredential,
 		})
 	}
 	return result
-}
-
-// GetCredentialAttributes returns the names of top-level properties marked as credentials.
-func (cs *Schema) GetCredentialAttributes() []string {
-	var fields []string
-	for name, prop := range cs.properties {
-		if prop.isCredential() {
-			fields = append(fields, name)
-		}
-	}
-
-	return fields
 }
 
 // GetUniqueAttributes returns the names of top-level properties marked as unique.

--- a/backend/internal/entitytype/model/schema_test.go
+++ b/backend/internal/entitytype/model/schema_test.go
@@ -272,7 +272,7 @@ func (s *SchemaValidateTestSuite) TestValidate_SkipCredentialRequired() {
 	s.Require().False(ok, "missing required credential should fail when skipCredentialRequired=false")
 }
 
-func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_ReturnsOnlyRequiredNonCredential() {
+func (s *SchemaValidateTestSuite) TestGetAttributes_NonCredentialRequiredOnly_ReturnsOnlyRequiredNonCredential() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"email":     {"type": "string", "required": true},
 		"firstName": {"type": "string", "required": true, "displayName": "First Name"},
@@ -281,7 +281,7 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_Re
 	}`))
 	s.Require().NoError(err)
 
-	attrs := schema.GetNonCredentialAttributes(true)
+	attrs := schema.GetAttributes(false, true, true)
 
 	// Only email and firstName should be returned — password is credential, age is not required.
 	s.Len(attrs, 2)
@@ -306,27 +306,27 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_Re
 	s.False(hasAge, "age is not required and must be excluded")
 }
 
-func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_EmptySchema() {
+func (s *SchemaValidateTestSuite) TestGetAttributes_NonCredentialRequiredOnly_EmptySchema() {
 	schema := &Schema{properties: map[string]property{}}
 
-	attrs := schema.GetNonCredentialAttributes(true)
+	attrs := schema.GetAttributes(false, true, true)
 
 	s.Empty(attrs, "empty schema should return no required attributes")
 }
 
-func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_RequiredOnly_AllCredential() {
+func (s *SchemaValidateTestSuite) TestGetAttributes_NonCredentialRequiredOnly_AllCredential() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"password": {"type": "string", "required": true, "credential": true},
 		"pin":      {"type": "string", "required": true, "credential": true}
 	}`))
 	s.Require().NoError(err)
 
-	attrs := schema.GetNonCredentialAttributes(true)
+	attrs := schema.GetAttributes(false, true, true)
 
 	s.Empty(attrs, "all required properties are credentials, result should be empty")
 }
 
-func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_AllAttrs_IncludesOptional() {
+func (s *SchemaValidateTestSuite) TestGetAttributes_NonCredentialAllAttrs_IncludesOptional() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"email":     {"type": "string", "required": true},
 		"firstName": {"type": "string", "required": true, "displayName": "First Name"},
@@ -335,7 +335,7 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_AllAttrs_Includ
 	}`))
 	s.Require().NoError(err)
 
-	attrs := schema.GetNonCredentialAttributes(false)
+	attrs := schema.GetAttributes(false, true, false)
 
 	// email, firstName, age — password excluded (credential).
 	s.Len(attrs, 3, "all non-credential attributes should be returned regardless of required flag")
@@ -353,7 +353,7 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_AllAttrs_Includ
 	s.False(hasPassword, "credential must always be excluded")
 }
 
-func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_DisplayNameOnNonStringTypes() {
+func (s *SchemaValidateTestSuite) TestGetAttributes_NonCredentialDisplayNameOnNonStringTypes() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"active":  {"type": "boolean", "displayName": "Active Status"},
 		"score":   {"type": "number",  "displayName": "Score"},
@@ -362,7 +362,7 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_DisplayNameOnNo
 	}`))
 	s.Require().NoError(err)
 
-	attrs := schema.GetNonCredentialAttributes(false)
+	attrs := schema.GetAttributes(false, true, false)
 	s.Len(attrs, 4)
 
 	attrMap := make(map[string]AttributeInfo, len(attrs))
@@ -373,4 +373,66 @@ func (s *SchemaValidateTestSuite) TestGetNonCredentialAttributes_DisplayNameOnNo
 	s.Equal("Score", attrMap["score"].DisplayName)
 	s.Equal("Address", attrMap["address"].DisplayName)
 	s.Equal("Tags", attrMap["tags"].DisplayName)
+}
+
+func (s *SchemaValidateTestSuite) TestGetAttributes_CredentialRequiredOnly_ReturnsOnlyRequiredCredential() {
+	schema, err := CompileSchema(json.RawMessage(`{
+		"password": {"type": "string", "required": true, "credential": true, "displayName": "Password"},
+		"pin":      {"type": "string", "credential": true, "displayName": "PIN"},
+		"email":    {"type": "string", "required": true}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetAttributes(true, false, true)
+
+	s.Len(attrs, 1)
+	s.Equal("password", attrs[0].Attribute)
+	s.Equal("Password", attrs[0].DisplayName)
+	s.True(attrs[0].Required)
+	s.True(attrs[0].Credential)
+}
+
+func (s *SchemaValidateTestSuite) TestGetAttributes_CredentialAllAttrs_IncludesOptional() {
+	schema, err := CompileSchema(json.RawMessage(`{
+		"password": {"type": "string", "required": true, "credential": true, "displayName": "Password"},
+		"pin":      {"type": "string", "credential": true, "displayName": "PIN"},
+		"email":    {"type": "string", "required": true}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetAttributes(true, false, false)
+
+	s.Len(attrs, 2)
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	s.True(attrMap["password"].Required)
+	s.True(attrMap["password"].Credential)
+	s.Equal("Password", attrMap["password"].DisplayName)
+	s.False(attrMap["pin"].Required)
+	s.True(attrMap["pin"].Credential)
+	s.Equal("PIN", attrMap["pin"].DisplayName)
+	_, hasEmail := attrMap["email"]
+	s.False(hasEmail, "non-credential attribute must be excluded")
+}
+
+func (s *SchemaValidateTestSuite) TestGetAttributes_AllAttrs_CredentialFieldSet() {
+	schema, err := CompileSchema(json.RawMessage(`{
+		"password": {"type": "string", "required": true, "credential": true},
+		"email":    {"type": "string", "required": true}
+	}`))
+	s.Require().NoError(err)
+
+	attrs := schema.GetAttributes(true, true, false)
+
+	s.Len(attrs, 2)
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	s.True(attrMap["password"].Credential, "credential attribute must have Credential=true")
+	s.False(attrMap["email"].Credential, "non-credential attribute must have Credential=false")
 }

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -74,18 +74,16 @@ type EntityTypeServiceInterface interface {
 		attributes json.RawMessage,
 		exists func(map[string]interface{}) (bool, error),
 	) (bool, *serviceerror.ServiceError)
-	GetCredentialAttributes(
+	GetAttributes(
 		ctx context.Context, category TypeCategory, entityType string,
-	) ([]string, *serviceerror.ServiceError)
+		allowCredential, allowNonCredential, requiredOnly bool,
+	) ([]AttributeInfo, *serviceerror.ServiceError)
 	GetUniqueAttributes(
 		ctx context.Context, category TypeCategory, entityType string,
 	) ([]string, *serviceerror.ServiceError)
 	GetDisplayAttributesByNames(
 		ctx context.Context, category TypeCategory, names []string,
 	) (map[string]string, *serviceerror.ServiceError)
-	GetNonCredentialAttributes(
-		ctx context.Context, category TypeCategory, entityType string, requiredOnly bool,
-	) ([]AttributeInfo, *serviceerror.ServiceError)
 }
 
 // entityTypeService is the default implementation of the EntityTypeServiceInterface.
@@ -616,10 +614,13 @@ func (us *entityTypeService) ValidateEntityUniqueness(
 	return true, nil
 }
 
-// GetCredentialAttributes returns the names of schema properties marked as credentials for a given entity type.
-func (us *entityTypeService) GetCredentialAttributes(
+// GetAttributes returns schema properties filtered by the provided flags for the given entity type.
+// allowCredential includes credential properties; allowNonCredential includes non-credential properties.
+// When requiredOnly is true, only required properties are included.
+func (us *entityTypeService) GetAttributes(
 	ctx context.Context, category TypeCategory, entityType string,
-) ([]string, *serviceerror.ServiceError) {
+	allowCredential, allowNonCredential, requiredOnly bool,
+) ([]AttributeInfo, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
 
 	if svcErr := validateCategory(category); svcErr != nil {
@@ -631,10 +632,10 @@ func (us *entityTypeService) GetCredentialAttributes(
 		if errors.Is(err, ErrEntityTypeNotFound) {
 			return nil, entityTypeNotFoundErr(category)
 		}
-		return nil, logAndReturnServerError(logger, "Failed to load entity type for credential attributes", err)
+		return nil, logAndReturnServerError(logger, "Failed to load entity type for attribute infos", err)
 	}
 
-	return compiledSchema.GetCredentialAttributes(), nil
+	return compiledSchema.GetAttributes(allowCredential, allowNonCredential, requiredOnly), nil
 }
 
 // GetUniqueAttributes returns the names of schema properties marked as unique for a given entity type.
@@ -678,29 +679,6 @@ func (us *entityTypeService) GetDisplayAttributesByNames(
 	}
 
 	return result, nil
-}
-
-// GetNonCredentialAttributes returns non-credential attributes defined in the schema for the given
-// category and entity type. When requiredOnly is true, only required attributes are returned.
-func (us *entityTypeService) GetNonCredentialAttributes(
-	ctx context.Context, category TypeCategory, entityType string, requiredOnly bool,
-) ([]AttributeInfo, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
-
-	if svcErr := validateCategory(category); svcErr != nil {
-		return nil, svcErr
-	}
-
-	compiledSchema, err := us.getCompiledSchemaForEntityType(ctx, category, entityType, logger)
-	if err != nil {
-		if errors.Is(err, ErrEntityTypeNotFound) {
-			return nil, entityTypeNotFoundErr(category)
-		}
-		return nil, logAndReturnServerError(logger,
-			"Failed to load entity type for non-credential attributes", err)
-	}
-
-	return compiledSchema.GetNonCredentialAttributes(requiredOnly), nil
 }
 
 func (us *entityTypeService) getCompiledSchemaForEntityType(

--- a/backend/internal/entitytype/service_test.go
+++ b/backend/internal/entitytype/service_test.go
@@ -760,7 +760,7 @@ func TestEntityTypeServiceTestSuite(t *testing.T) {
 	suite.Run(t, new(EntityTypeServiceTestSuite))
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_ReturnsCredentialFieldNames() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_Credential_ReturnsCredentialFieldInfos() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "customer").
@@ -778,16 +778,24 @@ func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_ReturnsCredenti
 		transactioner:   &mockTransactioner{},
 	}
 
-	fields, svcErr := service.GetCredentialAttributes(
-		context.Background(), TypeCategoryUser, "customer",
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "customer", true, false, false,
 	)
 
 	s.Require().Nil(svcErr)
-	sort.Strings(fields)
-	s.Require().Equal([]string{"apiKey", "password"}, fields)
+	s.Require().Len(attrs, 2)
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+	_, hasPassword := attrMap["password"]
+	s.True(hasPassword)
+	_, hasAPIKey := attrMap["apiKey"]
+	s.True(hasAPIKey)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestNoCredentials_ReturnsEmpty() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_Credential_NoCredentials_ReturnsEmpty() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "customer").
@@ -803,15 +811,15 @@ func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestNoCredentia
 		transactioner:   &mockTransactioner{},
 	}
 
-	fields, svcErr := service.GetCredentialAttributes(
-		context.Background(), TypeCategoryUser, "customer",
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "customer", true, false, false,
 	)
 
 	s.Require().Nil(svcErr)
-	s.Require().Empty(fields)
+	s.Require().Empty(attrs)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestSchemaNotFound_ReturnsError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_SchemaNotFound_ReturnsError() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "unknown").
@@ -823,16 +831,16 @@ func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestSchemaNotFo
 		transactioner:   &mockTransactioner{},
 	}
 
-	fields, svcErr := service.GetCredentialAttributes(
-		context.Background(), TypeCategoryUser, "unknown",
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "unknown", true, false, false,
 	)
 
-	s.Require().Nil(fields)
+	s.Require().Nil(attrs)
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(ErrorEntityTypeNotFound.Code, svcErr.Code)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestEmptyUserType_ReturnsError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_EmptyEntityType_ReturnsError() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 
 	service := &entityTypeService{
@@ -840,16 +848,16 @@ func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestEmptyUserTy
 		transactioner:   &mockTransactioner{},
 	}
 
-	fields, svcErr := service.GetCredentialAttributes(
-		context.Background(), TypeCategoryUser, "",
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "", true, false, false,
 	)
 
-	s.Require().Nil(fields)
+	s.Require().Nil(attrs)
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(ErrorEntityTypeNotFound.Code, svcErr.Code)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestStoreError_ReturnsInternalError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_StoreError_ReturnsInternalError() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "customer").
@@ -861,13 +869,80 @@ func (s *EntityTypeServiceTestSuite) TestGetCredentialAttributes_TestStoreError_
 		transactioner:   &mockTransactioner{},
 	}
 
-	fields, svcErr := service.GetCredentialAttributes(
-		context.Background(), TypeCategoryUser, "customer",
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "customer", true, false, false,
 	)
 
-	s.Require().Nil(fields)
+	s.Require().Nil(attrs)
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_CredentialRequiredOnly_ReturnsOnlyRequiredCredential() {
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "customer").
+		Return(EntityType{
+			Schema: json.RawMessage(
+				`{"password":{"type":"string","required":true,"credential":true,"displayName":"Password"},` +
+					`"pin":{"type":"string","credential":true,"displayName":"PIN"},` +
+					`"email":{"type":"string","required":true}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "customer", true, false, true,
+	)
+
+	s.Require().Nil(svcErr)
+	s.Require().Len(attrs, 1)
+	s.Equal("password", attrs[0].Attribute)
+	s.Equal("Password", attrs[0].DisplayName)
+	s.True(attrs[0].Required)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_CredentialAllAttrs_IncludesOptional() {
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "customer").
+		Return(EntityType{
+			Schema: json.RawMessage(
+				`{"password":{"type":"string","required":true,"credential":true,"displayName":"Password"},` +
+					`"pin":{"type":"string","credential":true,"displayName":"PIN"},` +
+					`"email":{"type":"string","required":true}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	attrs, svcErr := service.GetAttributes(
+		context.Background(), TypeCategoryUser, "customer", true, false, false,
+	)
+
+	s.Require().Nil(svcErr)
+	s.Require().Len(attrs, 2)
+
+	attrMap := make(map[string]AttributeInfo, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Attribute] = a
+	}
+
+	s.True(attrMap["password"].Required)
+	s.Equal("Password", attrMap["password"].DisplayName)
+	s.False(attrMap["pin"].Required)
+	s.Equal("PIN", attrMap["pin"].DisplayName)
+	_, hasEmail := attrMap["email"]
+	s.False(hasEmail, "non-credential attribute must be excluded")
 }
 
 func (s *EntityTypeServiceTestSuite) TestGetUniqueAttributes_ReturnsUniqueFieldNames() {
@@ -1349,7 +1424,7 @@ func (s *EntityTypeServiceTestSuite) TestGetDisplayAttributesByNames_TestStoreEr
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_RequiredOnly_ReturnsAttributes() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredentialRequiredOnly_ReturnsAttributes() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "INTERNAL").
@@ -1368,7 +1443,7 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_RequiredOnly
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "INTERNAL", true)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false, true, true)
 
 	s.Require().Nil(svcErr)
 	s.Require().Len(attrs, 2)
@@ -1390,7 +1465,7 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_RequiredOnly
 	s.False(hasPassword, "password is credential and must be excluded")
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_TestUnknownUserType_ReturnsError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_UnknownEntityType_ReturnsError() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "unknown").
@@ -1402,27 +1477,27 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_TestUnknownU
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "unknown", true)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "unknown", false, true, true)
 
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(ErrorEntityTypeNotFound.Code, svcErr.Code)
 	s.Require().Nil(attrs)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_TestEmptyUserType_ReturnsError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_EmptyEntityType_ReturnsError() {
 	service := &entityTypeService{
 		entityTypeStore: newEntityTypeStoreInterfaceMock(s.T()),
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "", true)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "", false, true, true)
 
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(ErrorEntityTypeNotFound.Code, svcErr.Code)
 	s.Require().Nil(attrs)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_TestAllCredentials_ReturnsEmpty() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_AllCredentials_ReturnsEmpty() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "INTERNAL").
@@ -1438,13 +1513,13 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_TestAllCrede
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "INTERNAL", true)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false, true, true)
 
 	s.Require().Nil(svcErr)
 	s.Require().Empty(attrs)
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_AllAttrs_IncludesOptional() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredentialAllAttrs_IncludesOptional() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "INTERNAL").
@@ -1462,7 +1537,7 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_AllAttrs_Inc
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false, true, false)
 
 	s.Require().Nil(svcErr)
 	s.Require().Len(attrs, 2, "email and mobileNumber should be returned; password excluded as credential")
@@ -1477,7 +1552,7 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_AllAttrs_Inc
 	s.False(hasPassword, "credential must always be excluded")
 }
 
-func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_StoreError_ReturnsServerError() {
+func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_StoreError_ReturnsServerError() {
 	storeMock := newEntityTypeStoreInterfaceMock(s.T())
 	storeMock.
 		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "INTERNAL").
@@ -1489,7 +1564,7 @@ func (s *EntityTypeServiceTestSuite) TestGetNonCredentialAttributes_StoreError_R
 		transactioner:   &mockTransactioner{},
 	}
 
-	attrs, svcErr := service.GetNonCredentialAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false)
+	attrs, svcErr := service.GetAttributes(context.Background(), TypeCategoryUser, "INTERNAL", false, true, false)
 
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -448,6 +448,12 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 				n.logger.Debug("Updated input required flag from ForwardedData",
 					log.String("identifier", fwdInput.Identifier))
 			}
+			if fwdInput.Type == common.InputTypePassword &&
+				nodeResp.Inputs[idx].Type != common.InputTypePassword {
+				nodeResp.Inputs[idx].Type = common.InputTypePassword
+				n.logger.Debug("Updated input type to password from ForwardedData",
+					log.String("identifier", fwdInput.Identifier))
+			}
 			if fwdInput.Type == common.InputTypeSelect &&
 				nodeResp.Inputs[idx].Type == common.InputTypeSelect &&
 				len(fwdInput.Options) > 0 {
@@ -652,44 +658,49 @@ func filterMetaComponents(comps []interface{}, allowedRefs, knownInputActionRefs
 	return result
 }
 
-// appendSyntheticMetaComponents ensures every input in the list has a corresponding meta
-// component. For inputs whose component already exists (matched by ref or id), the required
-// field is updated in-place if the input marks it required. For inputs with no existing
-// component, a minimal synthetic component is created and inserted into the first BLOCK
-// before any ACTION. If no BLOCK exists, a new one is appended.
-// The label uses DisplayName when set, falling back to Identifier.
-func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inputs []common.Input) interface{} {
-	metaMap, ok := trimmedMeta.(map[string]interface{})
-	if !ok {
-		return trimmedMeta
+// cloneBlockWithChildren returns a shallow copy of compMap with its "components"
+// field replaced by the provided children slice.
+func cloneBlockWithChildren(compMap map[string]interface{}, children []interface{}) map[string]interface{} {
+	newBlock := make(map[string]interface{}, len(compMap))
+	for k, v := range compMap {
+		newBlock[k] = v
 	}
+	newBlock["components"] = children
+	return newBlock
+}
 
-	// Build a set of refs/ids from the node's own configured prompt inputs —
-	// used to suppress synthesis for node-defined inputs with no meta component.
-	nodeInputRefs := make(map[string]struct{})
-	for _, inp := range n.getAllInputs() {
-		if inp.Ref != "" {
-			nodeInputRefs[inp.Ref] = struct{}{}
-		}
-		nodeInputRefs[inp.Identifier] = struct{}{}
-	}
-
-	// Build ref/id → component map for O(1) lookup and in-place required update.
-	metaCompByRef := make(map[string]map[string]interface{})
-	collectMetaComponentMap(metaMap["components"], metaCompByRef)
-
-	// Single pass: update required on existing components; collect synthetic for missing ones.
-	// For each input, try to find its meta component by Identifier first, then by Ref.
-	// Node-configured inputs with no meta component are skipped (no synthesis).
-	synthetic := make([]interface{}, 0, len(inputs))
+// buildSyntheticComponentList separates missing inputs into promoted meta
+// components and newly synthesized component definitions for inputs absent from
+// the meta tree.
+func (n *promptNode) buildSyntheticComponentList(
+	inputs []common.Input,
+	metaCompByRef map[string]map[string]interface{},
+	nodeInputRefs map[string]struct{},
+) (synthetic []interface{}, promotions map[string]map[string]interface{}) {
+	synthetic = make([]interface{}, 0, len(inputs))
+	promotions = make(map[string]map[string]interface{})
 	for _, input := range inputs {
-		comp, inMeta := metaCompByRef[input.Identifier]
+		ref := input.Identifier
+		comp, inMeta := metaCompByRef[ref]
 		if !inMeta && input.Ref != "" {
-			comp, inMeta = metaCompByRef[input.Ref]
+			ref = input.Ref
+			comp, inMeta = metaCompByRef[ref]
 		}
 		if inMeta {
-			if input.Required {
-				comp["required"] = true
+			needsRequired := input.Required && comp["required"] != true
+			needsPassword := input.Type == common.InputTypePassword && comp["type"] != common.InputTypePassword
+			if needsRequired || needsPassword {
+				cloned := make(map[string]interface{}, len(comp))
+				for k, v := range comp {
+					cloned[k] = v
+				}
+				if needsRequired {
+					cloned["required"] = true
+				}
+				if needsPassword {
+					cloned["type"] = common.InputTypePassword
+				}
+				promotions[ref] = cloned
 			}
 			continue
 		}
@@ -712,6 +723,81 @@ func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inpu
 			"required": input.Required,
 		})
 	}
+	return synthetic, promotions
+}
+
+// applyComponentPromotions recursively walks a components slice and replaces any component
+// whose ref or id matches a key in promotions with the corresponding cloned+promoted map.
+// Parent nodes are cloned only when a descendant is actually replaced.
+// Returns the updated slice and whether any replacement was made.
+func applyComponentPromotions(comps []interface{}, promotions map[string]map[string]interface{}) ([]interface{}, bool) {
+	result := make([]interface{}, len(comps))
+	copy(result, comps)
+	changed := false
+	for i, comp := range result {
+		compMap, ok := comp.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if ref, _ := compMap["ref"].(string); ref != "" {
+			if promoted, ok := promotions[ref]; ok {
+				result[i] = promoted
+				changed = true
+				continue
+			}
+		}
+		if id, _ := compMap["id"].(string); id != "" {
+			if promoted, ok := promotions[id]; ok {
+				result[i] = promoted
+				changed = true
+				continue
+			}
+		}
+		children, hasChildren := compMap["components"].([]interface{})
+		if !hasChildren {
+			continue
+		}
+		newChildren, childChanged := applyComponentPromotions(children, promotions)
+		if childChanged {
+			cloned := make(map[string]interface{}, len(compMap))
+			for k, v := range compMap {
+				cloned[k] = v
+			}
+			cloned["components"] = newChildren
+			result[i] = cloned
+			changed = true
+		}
+	}
+	return result, changed
+}
+
+// appendSyntheticMetaComponents ensures every input in the list has a corresponding meta
+// component. For inputs whose component already exists (matched by ref or id), a cloned
+// component with the promoted fields (required, type) is swapped in — the original shared
+// metadata is never mutated. For inputs with no existing component, a minimal synthetic
+// component is created and inserted into the first BLOCK before any ACTION. If no BLOCK
+// exists, a new one is appended.
+// The label uses DisplayName when set, falling back to Identifier.
+func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inputs []common.Input) interface{} {
+	metaMap, ok := trimmedMeta.(map[string]interface{})
+	if !ok {
+		return trimmedMeta
+	}
+
+	// Build a set of refs/ids from the node's own configured prompt inputs —
+	// used to suppress synthesis for node-defined inputs with no meta component.
+	nodeInputRefs := make(map[string]struct{})
+	for _, inp := range n.getAllInputs() {
+		if inp.Ref != "" {
+			nodeInputRefs[inp.Ref] = struct{}{}
+		}
+		nodeInputRefs[inp.Identifier] = struct{}{}
+	}
+
+	metaCompByRef := make(map[string]map[string]interface{})
+	collectMetaComponentMap(metaMap["components"], metaCompByRef)
+
+	synthetic, promotions := n.buildSyntheticComponentList(inputs, metaCompByRef, nodeInputRefs)
 
 	// Walk the meta tree and either replace a DYNAMIC_INPUT_PLACEHOLDER with synthetic
 	// inputs (preferred — exact insertion point), or insert before the first ACTION in
@@ -725,6 +811,10 @@ func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inpu
 	existing, _ := metaMap["components"].([]interface{})
 	updatedComponents := make([]interface{}, len(existing))
 	copy(updatedComponents, existing)
+
+	if len(promotions) > 0 {
+		updatedComponents, _ = applyComponentPromotions(updatedComponents, promotions)
+	}
 
 	placeholderStripped := false
 	inserted := false
@@ -746,12 +836,7 @@ func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inpu
 			newChildren = append(newChildren, children[:j]...)
 			newChildren = append(newChildren, synthetic...)
 			newChildren = append(newChildren, children[j+1:]...)
-			newBlock := make(map[string]interface{}, len(compMap))
-			for k, v := range compMap {
-				newBlock[k] = v
-			}
-			newBlock["components"] = newChildren
-			updatedComponents[i] = newBlock
+			updatedComponents[i] = cloneBlockWithChildren(compMap, newChildren)
 			placeholderStripped = true
 			inserted = true
 			break
@@ -777,17 +862,12 @@ func (n *promptNode) appendSyntheticMetaComponents(trimmedMeta interface{}, inpu
 		newChildren = append(newChildren, children[:insertIdx]...)
 		newChildren = append(newChildren, synthetic...)
 		newChildren = append(newChildren, children[insertIdx:]...)
-		newBlock := make(map[string]interface{}, len(compMap))
-		for k, v := range compMap {
-			newBlock[k] = v
-		}
-		newBlock["components"] = newChildren
-		updatedComponents[i] = newBlock
+		updatedComponents[i] = cloneBlockWithChildren(compMap, newChildren)
 		inserted = true
 		break
 	}
 
-	if len(synthetic) == 0 && !placeholderStripped {
+	if len(synthetic) == 0 && !placeholderStripped && len(promotions) == 0 {
 		return trimmedMeta
 	}
 

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -2390,6 +2390,112 @@ func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_NotAddedWhenMetaComponentExi
 	s.Equal(1, emailCount, "email component must not be duplicated when meta component ref matches identifier")
 }
 
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_ExistingComponentPromotedToPasswordType() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":       "input_pin",
+				"ref":      "pin",
+				"type":     "TEXT_INPUT",
+				"label":    "PIN",
+				"required": false,
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: "pin", Identifier: "pin", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		Verbose:       true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "pin", Type: common.InputTypePassword, Required: true, DisplayName: "PIN"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.NotNil(resp.Meta)
+	s.Require().Len(resp.Inputs, 1)
+	s.Equal(common.InputTypePassword, resp.Inputs[0].Type)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(comps, 1)
+
+	comp, ok := comps[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal(common.InputTypePassword, comp["type"], "existing meta component must be promoted to password type")
+	s.Equal(true, comp["required"], "existing meta component must reflect promoted required flag")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_PromotionDoesNotMutateSharedMeta() {
+	original := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":       "input_pin",
+				"ref":      "pin",
+				"type":     "TEXT_INPUT",
+				"required": false,
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(original)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{{Ref: "pin", Identifier: "pin", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		Verbose:       true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []common.Input{
+				{Identifier: "pin", Type: common.InputTypePassword, Required: true},
+			},
+		},
+	}
+
+	_, err := node.Execute(ctx)
+	s.Require().Nil(err)
+
+	// The original meta map must be untouched after the first execution.
+	origComps, _ := original["components"].([]interface{})
+	origComp, _ := origComps[0].(map[string]interface{})
+	s.Equal("TEXT_INPUT", origComp["type"], "original meta component type must not be mutated by promotion")
+	s.Equal(false, origComp["required"], "original meta component required must not be mutated by promotion")
+
+	// A second execution must still see the correct (unpromoted) original.
+	resp2, err := node.Execute(ctx)
+	s.Require().Nil(err)
+	metaMap, _ := resp2.Meta.(map[string]interface{})
+	comps, _ := metaMap["components"].([]interface{})
+	s.Require().Len(comps, 1)
+	comp, _ := comps[0].(map[string]interface{})
+	s.Equal(common.InputTypePassword, comp["type"], "second execution must still promote the type correctly")
+	s.Equal(true, comp["required"], "second execution must still promote required correctly")
+}
+
 func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_InsertedInsideBlockBeforeAction() {
 	meta := map[string]interface{}{
 		"components": []interface{}{

--- a/backend/internal/flow/executor/credential_setter_test.go
+++ b/backend/internal/flow/executor/credential_setter_test.go
@@ -186,7 +186,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_ServiceError() {
 
 func (suite *CredentialSetterTestSuite) TestExecute_CustomAttribute() {
 	userID := testUserID
-	customAttr := "pin"
+	const customAttr = "pin"
 	pinValue := "1234"
 
 	ctx := &core.NodeContext{

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -108,18 +108,18 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		return execResp, nil
 	}
 
-	userAttributes, err := p.getAttributesForProvisioning(ctx)
+	identifyingAttrs, credentialAttrs, err := p.getAttributesForProvisioning(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(userAttributes) == 0 {
+	if len(identifyingAttrs) == 0 && len(credentialAttrs) == 0 {
 		logger.Debug("No user attributes provided for provisioning")
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "No user attributes provided for provisioning"
 		return execResp, nil
 	}
 
-	userID, err := p.IdentifyUser(userAttributes, execResp)
+	userID, err := p.IdentifyUser(identifyingAttrs, execResp)
 	if err != nil {
 		logger.Error("Failed to identify user", log.Error(err))
 		execResp.Status = common.ExecFailure
@@ -139,9 +139,13 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		}
 	}
 
-	// Create the user in the store.
-	if err := p.appendCredentialAttributes(ctx, &userAttributes); err != nil {
-		return nil, err
+	// Merge identifying and credential attributes for user creation.
+	userAttributes := make(map[string]interface{}, len(identifyingAttrs)+len(credentialAttrs))
+	for k, v := range identifyingAttrs {
+		userAttributes[k] = v
+	}
+	for k, v := range credentialAttrs {
+		userAttributes[k] = v
 	}
 	createdEntity, err := p.createUserInStore(ctx, userAttributes)
 	if err != nil {
@@ -264,9 +268,14 @@ func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID 
 	return true, nil
 }
 
-// HasRequiredInputs checks if the required inputs are provided in the context and appends any
-// missing inputs to the executor response. Returns true if all required inputs — both
-// node-defined and schema-derived — are satisfied, otherwise false.
+// HasRequiredInputs checks whether all schema-driven provisioning inputs are satisfied and appends
+// any missing promptable schema attrs to the executor response. Node inputs influence requiredness
+// and prompt metadata for schema attrs, but schema-absent node inputs are ignored.
+//
+// Missing inputs are ordered as: required non-credentials -> optional non-credentials ->
+// required credentials -> optional credentials. maxPerPrompt caps the forwarded
+// prompt batch after this list is built. includeOptional only affects optional
+// non-credential attrs.
 func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
@@ -276,102 +285,142 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		execResp.RuntimeData = make(map[string]string)
 	}
 
-	// run the base executor check for node-defined inputs.
-	nodeInputsSatisfied := p.checkNodeInputs(ctx, execResp, logger)
+	// Build a lookup map of node-defined inputs for the required/optional override rule:
+	// node can upgrade optional → required, but cannot lower schema-required to optional.
+	nodeInputMap := make(map[string]common.Input, len(ctx.NodeInputs))
+	for _, inp := range ctx.NodeInputs {
+		nodeInputMap[inp.Identifier] = inp
+	}
 
-	// fetch required non-credential attributes from the user type.
-	schemaAttrs, err := p.fetchSchemaAttributes(ctx, logger)
+	// Fetch all schema attributes (credential and non-credential) in a single call.
+	allSchemaAttrs, err := p.fetchSchemaAttributes(ctx, true, true)
 	if err != nil {
+		logger.Warn("Failed to fetch schema attributes for provisioning", log.Any("error", err))
 		execResp.Status = common.ExecFailure
 		return false
 	}
-	if len(schemaAttrs) == 0 {
-		return nodeInputsSatisfied
+	if len(allSchemaAttrs) == 0 {
+		return true
 	}
 
 	// Load the set of optional attrs already prompted in previous iterations so they are not
 	// re-prompted even when the user left them empty.
 	alreadyPromptedOptionalAttrs := p.getPresentedOptionalAttrs(ctx)
+	promptOptional := p.isPromptOptionalAttributesEnabled(ctx)
 
-	// Build required and optional missing lists separately so required ones are always shown first.
-	requiredMissing := make([]common.Input, 0, len(schemaAttrs))
-	optionalMissing := make([]common.Input, 0, len(schemaAttrs))
+	credRequiredMissing, credOptionalMissing, ncRequiredMissing, ncOptionalMissing :=
+		p.buildMissingInputs(ctx, allSchemaAttrs, nodeInputMap, alreadyPromptedOptionalAttrs, promptOptional)
+
+	// Build the full schema missing list: required non-creds first, then optional non-creds,
+	// followed by required creds, then optional creds.
+	// Node-defined inputs not present in the schema are ignored — provisioning is schema-driven
+	// and can only store attributes defined by the entity type.
+	allSchemaMissing := make([]common.Input, 0,
+		len(ncRequiredMissing)+len(credRequiredMissing)+len(ncOptionalMissing)+len(credOptionalMissing))
+	allSchemaMissing = append(allSchemaMissing, ncRequiredMissing...)
+	allSchemaMissing = append(allSchemaMissing, ncOptionalMissing...)
+	allSchemaMissing = append(allSchemaMissing, credRequiredMissing...)
+	allSchemaMissing = append(allSchemaMissing, credOptionalMissing...)
+
+	if len(allSchemaMissing) == 0 {
+		return true
+	}
+
+	// Apply maxPerPrompt to the forwarded prompt batch.
+	toForward := allSchemaMissing
+	if maxInputs := p.getMaxDynamicInputs(ctx); maxInputs > 0 && len(toForward) > maxInputs {
+		toForward = toForward[:maxInputs]
+	}
+
+	// Record which optional schema attrs are being presented this iteration so future
+	// iterations know not to re-prompt them if the user left them empty.
+	p.storePresentedOptionalAttrs(execResp, toForward, alreadyPromptedOptionalAttrs)
+
+	execResp.Inputs = allSchemaMissing
+	if execResp.ForwardedData == nil {
+		execResp.ForwardedData = make(map[string]interface{})
+	}
+	execResp.ForwardedData[common.ForwardedDataKeyInputs] = toForward
+	logger.Debug("Schema attributes are missing, requesting via prompt",
+		log.Int("missingCount", len(allSchemaMissing)))
+	return false
+}
+
+// buildMissingInputs categorizes all schema attributes into four missing-input buckets in a single
+// pass. attr.Credential drives the input type (password vs text) and optional-inclusion rules.
+func (p *provisioningExecutor) buildMissingInputs(
+	ctx *core.NodeContext,
+	schemaAttrs []entitytype.AttributeInfo,
+	nodeInputMap map[string]common.Input,
+	alreadyPromptedOptionalAttrs map[string]bool,
+	promptOptional bool,
+) (credRequired, credOptional, ncRequired, ncOptional []common.Input) {
 	for _, attr := range schemaAttrs {
 		if p.isAttrSatisfied(ctx, attr.Attribute) {
 			continue
 		}
-		if !attr.Required && alreadyPromptedOptionalAttrs[attr.Attribute] {
-			continue
+		nodeInp, inNodeInputs := nodeInputMap[attr.Attribute]
+		effectiveRequired := attr.Required
+		if inNodeInputs {
+			effectiveRequired = attr.Required || nodeInp.Required
 		}
-		input := common.Input{
-			Identifier:  attr.Attribute,
-			Type:        common.InputTypeText,
-			Required:    attr.Required,
-			DisplayName: attr.DisplayName,
-		}
-		if attr.Required {
-			requiredMissing = append(requiredMissing, input)
+
+		if attr.Credential {
+			if !attr.Required && !inNodeInputs {
+				continue
+			}
+			if !effectiveRequired && alreadyPromptedOptionalAttrs[attr.Attribute] {
+				continue
+			}
+			input := common.Input{
+				Identifier:  attr.Attribute,
+				Type:        common.InputTypePassword,
+				Required:    effectiveRequired,
+				DisplayName: attr.DisplayName,
+			}
+			if effectiveRequired {
+				credRequired = append(credRequired, input)
+			} else {
+				credOptional = append(credOptional, input)
+			}
 		} else {
-			optionalMissing = append(optionalMissing, input)
+			if !attr.Required && !promptOptional && !inNodeInputs {
+				continue
+			}
+			if !effectiveRequired && alreadyPromptedOptionalAttrs[attr.Attribute] {
+				continue
+			}
+			input := common.Input{
+				Identifier:  attr.Attribute,
+				Type:        common.InputTypeText,
+				DisplayName: attr.DisplayName,
+			}
+			if inNodeInputs {
+				input = nodeInp
+				input.Identifier = attr.Attribute
+				if input.Type == "" {
+					input.Type = common.InputTypeText
+				}
+				if input.DisplayName == "" {
+					input.DisplayName = attr.DisplayName
+				}
+			}
+			input.Required = effectiveRequired
+			if effectiveRequired {
+				ncRequired = append(ncRequired, input)
+			} else {
+				ncOptional = append(ncOptional, input)
+			}
 		}
 	}
-
-	schemaMissingAttrs := make([]common.Input, 0, len(requiredMissing)+len(optionalMissing))
-	schemaMissingAttrs = append(schemaMissingAttrs, requiredMissing...)
-	schemaMissingAttrs = append(schemaMissingAttrs, optionalMissing...)
-	if len(schemaMissingAttrs) == 0 {
-		return nodeInputsSatisfied
-	}
-
-	if maxInputs := p.getMaxDynamicInputs(ctx); maxInputs > 0 && len(schemaMissingAttrs) > maxInputs {
-		schemaMissingAttrs = schemaMissingAttrs[:maxInputs]
-	}
-
-	// Record which optional attrs are being presented in this iteration so future iterations
-	// know not to re-prompt them even if the user left the value empty.
-	p.storePresentedOptionalAttrs(execResp, schemaMissingAttrs, alreadyPromptedOptionalAttrs)
-
-	execResp.Inputs = upsertInputs(execResp.Inputs, schemaMissingAttrs)
-	if execResp.ForwardedData == nil {
-		execResp.ForwardedData = make(map[string]interface{})
-	}
-	execResp.ForwardedData[common.ForwardedDataKeyInputs] = schemaMissingAttrs
-	logger.Debug("Schema attributes are missing, requesting via prompt",
-		log.Int("missingCount", len(schemaMissingAttrs)))
-	return false
+	return credRequired, credOptional, ncRequired, ncOptional
 }
 
-// checkNodeInputs runs the base executor's input check, then clears any inputs satisfied by authenticated user attrs.
-func (p *provisioningExecutor) checkNodeInputs(ctx *core.NodeContext,
-	execResp *common.ExecutorResponse, logger *log.Logger) bool {
-	nodeInputsSatisfied := p.ExecutorInterface.HasRequiredInputs(ctx, execResp)
-	if nodeInputsSatisfied || len(execResp.Inputs) == 0 {
-		return nodeInputsSatisfied
-	}
-
-	authnAttrs := ctx.AuthenticatedUser.Attributes
-	if len(authnAttrs) == 0 {
-		return false
-	}
-
-	logger.Debug("Authenticated user attributes found, checking missing node inputs")
-	remaining := execResp.Inputs[:0]
-	for _, input := range execResp.Inputs {
-		val, exists := authnAttrs[input.Identifier]
-		strVal, isStr := val.(string)
-		if exists && isStr && strVal != "" {
-			continue
-		}
-		remaining = append(remaining, input)
-	}
-	execResp.Inputs = remaining
-	return len(remaining) == 0
-}
-
-// fetchSchemaAttributes retrieves non-credential attributes from the entity type service.
-// When promptOptionalAttributes is true it fetches all attributes; otherwise only required ones.
+// fetchSchemaAttributes retrieves schema attributes from the entity type service for the
+// current user type. allowCredential and allowNonCredential control which attribute classes
+// are returned.
 func (p *provisioningExecutor) fetchSchemaAttributes(
-	ctx *core.NodeContext, logger *log.Logger,
+	ctx *core.NodeContext, allowCredential, allowNonCredential bool,
 ) ([]entitytype.AttributeInfo, error) {
 	if p.entityTypeService == nil {
 		return nil, nil
@@ -380,13 +429,11 @@ func (p *provisioningExecutor) fetchSchemaAttributes(
 	if userType == "" {
 		return nil, fmt.Errorf("user type not found")
 	}
-	requiredOnly := !p.isPromptOptionalAttributesEnabled(ctx)
-	attrs, svcErr := p.entityTypeService.GetNonCredentialAttributes(ctx.Context,
-		entitytype.TypeCategoryUser, userType, requiredOnly)
+	attrs, svcErr := p.entityTypeService.GetAttributes(ctx.Context,
+		entitytype.TypeCategoryUser, userType, allowCredential, allowNonCredential, false)
 	if svcErr != nil {
-		logger.Warn("Failed to fetch schema attributes for provisioning, skipping schema check",
-			log.Any("error", svcErr))
-		return nil, nil
+		return nil, fmt.Errorf("failed to fetch schema attributes for user type %q: %s",
+			userType, svcErr.Error.DefaultValue)
 	}
 	return attrs, nil
 }
@@ -471,121 +518,47 @@ func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr strin
 	return false
 }
 
-// getAttributesForProvisioning returns the user profile attributes to store.
-// Schema is the whitelist: required attrs always collected, optional attrs only if in node inputs
-// or if promptOptionalAttributes is enabled.
-func (p *provisioningExecutor) getAttributesForProvisioning(ctx *core.NodeContext) (map[string]interface{}, error) {
-	nodeInputAttrs := p.GetRequiredInputs(ctx)
-	schemaAttrs, err := p.fetchAllNonCredentialAttributes(ctx)
-	if err != nil {
-		return nil, err
+// getAttributesForProvisioning collects user attributes from context in a single schema pass,
+// returning identifying (non-credential) and credential attributes as separate maps.
+// Schema is the whitelist for both maps.
+// Credential values are resolved from UserInputs then RuntimeData only.
+// Non-credential values additionally fall back to AuthenticatedUser.Attributes.
+func (p *provisioningExecutor) getAttributesForProvisioning(
+	ctx *core.NodeContext,
+) (identifyingAttrs map[string]interface{}, credentialAttrs map[string]interface{}, err error) {
+	schemaAttrs, fetchErr := p.fetchSchemaAttributes(ctx, true, true)
+	if fetchErr != nil {
+		return nil, nil, fetchErr
 	}
+
+	identifyingAttrs = make(map[string]interface{})
+	credentialAttrs = make(map[string]interface{})
+
 	if len(schemaAttrs) == 0 {
-		return make(map[string]interface{}), nil
+		return identifyingAttrs, credentialAttrs, nil
 	}
-	nodeInputSet := make(map[string]struct{}, len(nodeInputAttrs))
-	for _, inp := range nodeInputAttrs {
-		nodeInputSet[inp.Identifier] = struct{}{}
-	}
-	promptOptional := p.isPromptOptionalAttributesEnabled(ctx)
 
-	attributesMap := make(map[string]interface{})
 	for _, a := range schemaAttrs {
-		_, inNodeInputs := nodeInputSet[a.Attribute]
-		if len(nodeInputSet) > 0 && !a.Required && !inNodeInputs && !promptOptional {
-			continue
-		}
-
-		if value, exists := ctx.UserInputs[a.Attribute]; exists && value != "" {
-			attributesMap[a.Attribute] = value
-		} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
-			attributesMap[a.Attribute] = runtimeValue
-		} else if authnValue, exists := ctx.AuthenticatedUser.Attributes[a.Attribute]; exists {
-			if strVal, ok := authnValue.(string); ok && strVal != "" {
-				attributesMap[a.Attribute] = authnValue
+		if a.Credential {
+			if value, exists := ctx.UserInputs[a.Attribute]; exists {
+				credentialAttrs[a.Attribute] = value
+			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists {
+				credentialAttrs[a.Attribute] = runtimeValue
+			}
+		} else {
+			if value, exists := ctx.UserInputs[a.Attribute]; exists && value != "" {
+				identifyingAttrs[a.Attribute] = value
+			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
+				identifyingAttrs[a.Attribute] = runtimeValue
+			} else if authnValue, exists := ctx.AuthenticatedUser.Attributes[a.Attribute]; exists {
+				if strVal, ok := authnValue.(string); ok && strVal != "" {
+					identifyingAttrs[a.Attribute] = authnValue
+				}
 			}
 		}
 	}
 
-	return attributesMap, nil
-}
-
-// fetchAllNonCredentialAttributes retrieves all non-credential schema attributes with their required status.
-func (p *provisioningExecutor) fetchAllNonCredentialAttributes(
-	ctx *core.NodeContext,
-) ([]entitytype.AttributeInfo, error) {
-	if p.entityTypeService == nil {
-		return nil, nil
-	}
-	userType := p.getUserType(ctx)
-	if userType == "" {
-		return nil, fmt.Errorf("user type not found")
-	}
-	attrs, svcErr := p.entityTypeService.GetNonCredentialAttributes(ctx.Context,
-		entitytype.TypeCategoryUser, userType, false)
-	if svcErr != nil {
-		return nil, fmt.Errorf("failed to fetch schema attributes for user type %q: %s",
-			userType, svcErr.Error.DefaultValue)
-	}
-	return attrs, nil
-}
-
-// appendCredentialAttributes appends credential attributes defined in the user type to the provided
-// attributes map. If the node declares specific credential inputs, only those are collected; otherwise
-// all schema credential attributes are collected. Values are resolved from UserInputs then RuntimeData.
-func (p *provisioningExecutor) appendCredentialAttributes(ctx *core.NodeContext,
-	attributes *map[string]interface{}) error {
-	schemaCredAttrs, err := p.fetchCredentialAttributes(ctx)
-	if err != nil {
-		return err
-	}
-	if len(schemaCredAttrs) == 0 {
-		return nil
-	}
-
-	credentialAttrSet := make(map[string]struct{}, len(schemaCredAttrs))
-	for _, attr := range schemaCredAttrs {
-		credentialAttrSet[attr] = struct{}{}
-	}
-
-	var nodeCredentialInputs []string
-	for _, input := range ctx.NodeInputs {
-		if _, ok := credentialAttrSet[input.Identifier]; ok {
-			nodeCredentialInputs = append(nodeCredentialInputs, input.Identifier)
-		}
-	}
-
-	attrsToPopulate := schemaCredAttrs
-	if len(nodeCredentialInputs) > 0 {
-		attrsToPopulate = nodeCredentialInputs
-	}
-
-	for _, attr := range attrsToPopulate {
-		if value, exists := ctx.UserInputs[attr]; exists {
-			(*attributes)[attr] = value
-		} else if runtimeValue, exists := ctx.RuntimeData[attr]; exists {
-			(*attributes)[attr] = runtimeValue
-		}
-	}
-
-	return nil
-}
-
-// fetchCredentialAttributes retrieves credential attribute names from the entity type service.
-func (p *provisioningExecutor) fetchCredentialAttributes(ctx *core.NodeContext) ([]string, error) {
-	if p.entityTypeService == nil {
-		return nil, nil
-	}
-	userType := p.getUserType(ctx)
-	if userType == "" {
-		return nil, fmt.Errorf("user type not found")
-	}
-	attrs, svcErr := p.entityTypeService.GetCredentialAttributes(ctx.Context, entitytype.TypeCategoryUser, userType)
-	if svcErr != nil {
-		return nil, fmt.Errorf("failed to fetch credential attributes for user type %q: %s",
-			userType, svcErr.Error.DefaultValue)
-	}
-	return attrs, nil
+	return identifyingAttrs, credentialAttrs, nil
 }
 
 // createUserInStore creates a new user in the user store with the provided attributes.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
@@ -85,21 +86,15 @@ func (suite *ProvisioningExecutorTestSuite) SetupTest() {
 }
 
 // expectSchemaForProvisioning sets up the schema service mocks for Execute tests.
-// GetRequiredNonCredentialAttributes returns empty (no schema prompting needed).
-// GetNonCredentialAttributes returns a broad required-attr set covering all Execute test contexts;
-// only attrs that actually have values in the test context will be collected.
-// GetCredentialAttributes returns ["password"] as the default credential attribute.
+// The (true,true) mock covers both HasRequiredInputs and getAttributesForProvisioning.
 func (suite *ProvisioningExecutorTestSuite) expectSchemaForProvisioning() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
-		Return([]model.AttributeInfo{}, nil).Maybe()
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
-			{Attribute: "username", Required: true},
-			{Attribute: "email", Required: true},
-			{Attribute: "sub", Required: true},
+			{Attribute: "username", Required: false},
+			{Attribute: "email", Required: false},
+			{Attribute: "sub", Required: false},
+			{Attribute: "password", Credential: true},
 		}, nil).Maybe()
-	suite.mockEntityTypeService.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-		Return([]string{"password"}, nil).Maybe()
 }
 
 func (suite *ProvisioningExecutorTestSuite) createMockIdentifyingExecutor() core.ExecutorInterface {
@@ -291,7 +286,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFromAuthUser() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -305,7 +300,6 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFrom
 	}
 
 	execResp := &common.ExecutorResponse{
-		Inputs:      []common.Input{{Identifier: "email", Type: "string", Required: true}},
 		RuntimeData: make(map[string]string),
 	}
 
@@ -324,7 +318,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Empty(suite.T(), result)
 }
@@ -332,7 +326,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 // TestGetAttributesForProvisioning_SchemaWhitelist_ExcludesNonSchemaAttrs verifies that the schema
 // acts as a whitelist — attributes not in the schema are excluded even if present in context.
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaWhitelist_ExcludesNonSchemaAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{{Attribute: "username", Required: true}}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -346,7 +340,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.NotContains(suite.T(), result, "userID")
@@ -357,7 +351,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 // TestGetAttributesForProvisioning_RequiredAttrsFromMultipleSources verifies that required schema
 // attributes are resolved from UserInputs, AuthenticatedUser.Attributes, and RuntimeData.
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_RequiredAttrsFromMultipleSources() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "username", Required: true},
 			{Attribute: "email", Required: true},
@@ -380,7 +374,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Req
 		NodeInputs: []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "auth@example.com", result["email"])
@@ -391,7 +385,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Req
 // TestGetAttributesForProvisioning_ContextPriority verifies priority: UserInputs wins over
 // AuthenticatedUser.Attributes which wins over RuntimeData (first non-empty source wins).
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_ContextPriority() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "name", Required: true},
@@ -414,7 +408,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Con
 		NodeInputs: []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	// UserInputs is checked first — wins for email.
 	assert.Equal(suite.T(), "userinput@example.com", result["email"])
@@ -427,7 +421,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Con
 // TestGetAttributesForProvisioning_AllAttrsCollectedWhenNoNodeInputs verifies that when
 // node inputs are empty, all schema attrs with available values are collected (both required and optional).
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_AllAttrsCollectedWhenNoNodeInputs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "phone", Required: false},
@@ -442,7 +436,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_All
 		NodeInputs: []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result["email"])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -458,7 +452,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "phone", Required: false},
@@ -473,7 +467,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result["email"])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -507,7 +501,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "username", Required: true},
 			{Attribute: "email", Required: true},
@@ -524,7 +518,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "test@example.com", result["email"])
@@ -538,7 +532,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "username", Required: true},
 			{Attribute: "email", Required: true},
@@ -559,7 +553,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "federated@example.com", result["email"])
@@ -573,7 +567,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "username", Required: true},
@@ -591,7 +585,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 		NodeInputs:  nodeInputs,
 	}
 
-	result, _ := exec.getAttributesForProvisioning(ctx)
+	result, _, _ := exec.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "userinput@example.com", result["email"],
 		"UserInputs must win over AuthenticatedUser.Attributes for the same key")
@@ -786,117 +780,6 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_
 	assert.Equal(suite.T(), dataValueTrue, resp.RuntimeData[common.RuntimeKeyUserAutoProvisioned],
 		"userAutoProvisioned flag should be set to true after successful provisioning")
 	suite.mockEntityProvider.AssertExpectations(suite.T())
-}
-
-func (suite *ProvisioningExecutorTestSuite) TestAppendCredentialAttributes() {
-	tests := []struct {
-		name            string
-		schemaCredAttrs []string
-		schemaErr       *serviceerror.ServiceError
-		nodeInputs      []common.Input
-		userInputs      map[string]string
-		runtimeData     map[string]string
-		expectedAttrs   map[string]interface{}
-		expectError     bool
-	}{
-		{
-			name:            "PasswordFromUserInputs",
-			schemaCredAttrs: []string{"password"},
-			nodeInputs:      []common.Input{},
-			userInputs:      map[string]string{"username": "testuser", "password": "secure123"},
-			runtimeData:     map[string]string{userTypeKey: testUserType},
-			expectedAttrs:   map[string]interface{}{"username": "testuser", "password": "secure123"},
-		},
-		{
-			name:            "PasswordFromRuntimeData",
-			schemaCredAttrs: []string{"password"},
-			nodeInputs:      []common.Input{},
-			userInputs:      map[string]string{"username": "testuser"},
-			runtimeData:     map[string]string{userTypeKey: testUserType, "password": "runtime-pass"},
-			expectedAttrs:   map[string]interface{}{"username": "testuser", "password": "runtime-pass"},
-		},
-		{
-			name:            "NoValueForCredentialAttr_NotAdded",
-			schemaCredAttrs: []string{"password"},
-			nodeInputs:      []common.Input{},
-			userInputs:      map[string]string{"username": "testuser"},
-			runtimeData:     map[string]string{userTypeKey: testUserType},
-			expectedAttrs:   map[string]interface{}{"username": "testuser"},
-		},
-		{
-			name:            "MultipleCredentialAttrs_NoNodeInputs_AllAdded",
-			schemaCredAttrs: []string{"password", "pin"},
-			nodeInputs:      []common.Input{},
-			userInputs:      map[string]string{"password": "pass123", "pin": "1234"},
-			runtimeData:     map[string]string{userTypeKey: testUserType},
-			expectedAttrs:   map[string]interface{}{"username": "testuser", "password": "pass123", "pin": "1234"},
-		},
-		{
-			name:            "MultipleCredentialAttrs_NodeInputsFilter_OnlyDeclaredAdded",
-			schemaCredAttrs: []string{"password", "pin"},
-			nodeInputs: []common.Input{
-				{Identifier: "password", Type: common.InputTypePassword, Required: true},
-			},
-			userInputs:    map[string]string{"password": "pass123", "pin": "1234"},
-			runtimeData:   map[string]string{userTypeKey: testUserType},
-			expectedAttrs: map[string]interface{}{"username": "testuser", "password": "pass123"},
-		},
-		{
-			name:            "SchemaReturnsNoCredentials_NothingAdded",
-			schemaCredAttrs: []string{},
-			nodeInputs:      []common.Input{},
-			userInputs:      map[string]string{"password": "pass123"},
-			runtimeData:     map[string]string{userTypeKey: testUserType},
-			expectedAttrs:   map[string]interface{}{"username": "testuser"},
-		},
-		{
-			name:        "SchemaServiceError_ReturnsError",
-			schemaErr:   &serviceerror.ServiceError{Error: i18ncore.I18nMessage{DefaultValue: "service error"}},
-			nodeInputs:  []common.Input{},
-			userInputs:  map[string]string{},
-			runtimeData: map[string]string{userTypeKey: testUserType},
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			mockSvc := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-			if tt.schemaErr != nil {
-				mockSvc.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-					Return(nil, tt.schemaErr).Once()
-			} else {
-				mockSvc.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-					Return(tt.schemaCredAttrs, nil).Once()
-			}
-
-			exec := &provisioningExecutor{
-				ExecutorInterface:            suite.executor.ExecutorInterface,
-				identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
-				entityProvider:               suite.executor.entityProvider,
-				groupService:                 suite.executor.groupService,
-				roleService:                  suite.executor.roleService,
-				entityTypeService:            mockSvc,
-				logger:                       suite.executor.logger,
-			}
-
-			ctx := &core.NodeContext{
-				UserInputs:  tt.userInputs,
-				RuntimeData: tt.runtimeData,
-				NodeInputs:  tt.nodeInputs,
-			}
-
-			attributes := map[string]interface{}{"username": "testuser"}
-			err := exec.appendCredentialAttributes(ctx, &attributes)
-
-			if tt.expectError {
-				assert.Error(suite.T(), err)
-			} else {
-				assert.NoError(suite.T(), err)
-				assert.Equal(suite.T(), tt.expectedAttrs, attributes)
-			}
-		})
-	}
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_RegistrationFlow_SkipProvisioningWithExistingUser() {
@@ -1127,7 +1010,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetUserType() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AllAttributesInRuntimeData() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -1916,7 +1799,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_GetUserError() {
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByUserInputs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: "Email"}}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -1934,7 +1817,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSati
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByRuntimeData() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: ""}}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -1951,7 +1834,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSati
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSatisfiedByAuthnAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email"},
 			{Attribute: "firstName", DisplayName: "First Name"},
@@ -1977,7 +1860,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrSati
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMissing_AppendedToInputsAndForwardedData() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email Address", Required: true},
 			{Attribute: "firstName", DisplayName: "", Required: true},
@@ -2018,7 +1901,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrMiss
 // TestHasRequiredInputs_IncludeOptionalTrue_OptionalRenderedAsNotRequired verifies that when
 // includeOptional=true, optional schema attrs are forwarded with Required=false.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_OptionalRenderedAsNotRequired() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email", Required: true},
 			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
@@ -2050,7 +1933,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 // includeOptional=true an optional attr recorded as already presented in RuntimeData
 // is not re-prompted, even if the user left it empty.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_SkipsOptionalAlreadyPresented() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email", Required: true},
 			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
@@ -2081,7 +1964,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 // TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals verifies that optional attrs
 // included in the prompt batch are written to RuntimeData for tracking across iterations.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email", Required: true},
 			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
@@ -2109,7 +1992,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 // TestHasRequiredInputs_IncludeOptionalTrue_RequiredBeforeOptional verifies that required missing
 // attrs always appear before optional ones in the prompted list.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_RequiredBeforeOptional() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
 			{Attribute: "email", DisplayName: "Email", Required: true},
@@ -2141,7 +2024,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrCoveredByNodeInput_NotDuplicated() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: "Email"}}, nil).Once()
 
 	// email is already a node-defined input — schema must not create a second copy
@@ -2165,8 +2048,8 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaAttrCove
 	assert.Equal(suite.T(), 1, emailCount, "email must appear exactly once, not duplicated by schema")
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MissingNodeInput_SchemaAttrsSatisfied_ReturnsFalse() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IgnoresAbsentNodeInputWhenSchemaAttrsSatisfied() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{{Attribute: "email", DisplayName: ""}}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -2179,11 +2062,11 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MissingNodeInp
 
 	result := suite.executor.HasRequiredInputs(ctx, execResp)
 
-	assert.False(suite.T(), result, "node input username is missing so overall must be false")
+	assert.True(suite.T(), result, "schema-absent node input must be ignored; all schema attrs are satisfied")
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaServiceError_FallsThrough() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaServiceError_ReturnsFailure() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
 
 	ctx := &core.NodeContext{
@@ -2195,12 +2078,306 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaServiceE
 
 	result := suite.executor.HasRequiredInputs(ctx, execResp)
 
-	assert.True(suite.T(), result, "schema service error should not fail the executor")
+	assert.False(suite.T(), result, "schema service error must fail the executor")
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Empty(suite.T(), execResp.Inputs)
 }
 
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_RequiredCredential_PromptedAsPassword() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "password", DisplayName: "Password", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), "password", execResp.Inputs[0].Identifier)
+	assert.Equal(suite.T(), common.InputTypePassword, execResp.Inputs[0].Type)
+	assert.True(suite.T(), execResp.Inputs[0].Required)
+
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	assert.Len(suite.T(), fwdInputs, 1)
+	assert.Equal(suite.T(), common.InputTypePassword, fwdInputs[0].Type)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_RequiredCredentialSatisfied_ReturnsTrue() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "password", DisplayName: "Password", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"password": "secret"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result)
+	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_OptionalCredential_InNodeInputs_Prompted() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		// pin is explicitly listed in node inputs — so it must be prompted even though optional in schema.
+		NodeInputs: []common.Input{{Identifier: "pin", Type: common.InputTypePassword, Required: false}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	pinFound := false
+	for _, inp := range execResp.Inputs {
+		if inp.Identifier == "pin" {
+			pinFound = true
+			assert.Equal(suite.T(), common.InputTypePassword, inp.Type)
+			assert.False(suite.T(), inp.Required)
+		}
+	}
+	assert.True(suite.T(), pinFound, "optional credential listed in node inputs must be prompted")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_OptionalCredential_NotInNodeInputs_Skipped() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		// pin is NOT in node inputs — optional credential must be skipped.
+		NodeInputs: []common.Input{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result, "optional credential not in node inputs must not block")
+	for _, inp := range execResp.Inputs {
+		assert.NotEqual(suite.T(), "pin", inp.Identifier, "optional credential not in node inputs must not appear")
+	}
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptional_DoesNotAffectCredentials() {
+	// includeOptional=true must only pull in optional non-credential attrs, not optional credentials.
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+		// pin not in node inputs — includeOptional must NOT pull it in.
+		NodeInputs: []common.Input{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	for _, inp := range execResp.Inputs {
+		assert.NotEqual(suite.T(), "pin", inp.Identifier,
+			"includeOptional must not prompt optional credentials not listed in node inputs")
+	}
+	nicknameFound := false
+	for _, inp := range execResp.Inputs {
+		if inp.Identifier == "nickname" {
+			nicknameFound = true
+		}
+	}
+	assert.True(suite.T(), nicknameFound, "includeOptional must still prompt optional non-credential attrs")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NodeInputUpgradesOptionalCredentialToRequired() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		// Node marks pin as required even though schema says optional.
+		NodeInputs: []common.Input{{Identifier: "pin", Type: common.InputTypePassword, Required: true}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	pinFound := false
+	for _, inp := range execResp.Inputs {
+		if inp.Identifier == "pin" {
+			pinFound = true
+			assert.True(
+				suite.T(), inp.Required,
+				"node input upgrading optional credential to required must be honored",
+			)
+			assert.Equal(suite.T(), common.InputTypePassword, inp.Type)
+		}
+	}
+	assert.True(suite.T(), pinFound)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AlreadyPromptedOptionalCredential_Skipped() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			userTypeKey:                             testUserType,
+			common.RuntimeKeyPresentedOptionalAttrs: "pin",
+		},
+		NodeInputs: []common.Input{{Identifier: "pin", Type: common.InputTypePassword, Required: false}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.True(suite.T(), result, "already-prompted optional credential should not block progress")
+	for _, inp := range execResp.Inputs {
+		assert.NotEqual(
+			suite.T(), "pin", inp.Identifier,
+			"already-prompted optional credential must not be re-prompted",
+		)
+	}
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_SchemaRequiredCredentialNotLoweredByNodeInput() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "password", DisplayName: "Password", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		// Node tries to mark schema-required credential as optional — schema wins.
+		NodeInputs: []common.Input{{Identifier: "password", Type: common.InputTypePassword, Required: false}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	for _, inp := range execResp.Inputs {
+		if inp.Identifier == "password" {
+			assert.True(suite.T(), inp.Required,
+				"schema-required credential cannot be lowered to optional by node input")
+		}
+	}
+}
+
+// TestHasRequiredInputs_Ordering verifies the required non-credentials → optional
+// non-credentials → required credentials → optional credentials ordering.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_Ordering_NonCredFirst_CredNext() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "pin", DisplayName: "PIN", Required: false, Credential: true},
+			{Attribute: "password", DisplayName: "Password", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyDynamicInputsIncludeOptional: true,
+		},
+		// pin is optional credential listed in node inputs so it will be prompted.
+		NodeInputs: []common.Input{{Identifier: "pin", Type: common.InputTypePassword, Required: false}},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	// Expected order: email (req non-cred) → nickname (opt non-cred) → password
+	// (req cred) → pin (opt cred)
+	identifiers := make([]string, 0, len(execResp.Inputs))
+	for _, inp := range execResp.Inputs {
+		identifiers = append(identifiers, inp.Identifier)
+	}
+	assert.Equal(suite.T(), []string{"email", "nickname", "password", "pin"}, identifiers)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_CapsForwardedPromptBatchOnly() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "phone", DisplayName: "Phone", Required: true},
+			{Attribute: "firstName", DisplayName: "First Name", Required: true},
+			{Attribute: "password", DisplayName: "Password", Required: true, Credential: true},
+			{Attribute: "pin", DisplayName: "PIN", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeProperties: map[string]interface{}{
+			propertyKeyMaxDynamicInputsPerPrompt: 1,
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	suite.executor.HasRequiredInputs(ctx, execResp)
+
+	credCount, ncCount := 0, 0
+	for _, inp := range execResp.Inputs {
+		if inp.Type == common.InputTypePassword {
+			credCount++
+		} else {
+			ncCount++
+		}
+	}
+	assert.Equal(suite.T(), 2, credCount, "full missing set should retain all credential inputs")
+	assert.Equal(suite.T(), 3, ncCount, "full missing set should retain all non-credential inputs")
+
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	assert.Len(suite.T(), fwdInputs, 1, "prompt batch should be capped by maxPerPrompt")
+	assert.NotEqual(suite.T(), common.InputTypePassword, fwdInputs[0].Type,
+		"first forwarded input should be a non-credential (non-credentials come first)")
+}
+
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaFilteredNoNodeInputs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "username", Required: true},
 			{Attribute: "email", Required: true},
@@ -2220,7 +2397,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.Equal(suite.T(), "test@example.com", result["email"])
@@ -2229,7 +2406,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrCollectedWhenNoNodeInputs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "phone", Required: false},
@@ -2241,7 +2418,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  []common.Input{},
 	}
 
-	result, _ := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Equal(suite.T(), "user@example.com", result["email"])
 	assert.Equal(suite.T(), "+1234567890", result["phone"],
@@ -2249,7 +2426,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaServiceError_ReturnsError() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
 
 	ctx := &core.NodeContext{
@@ -2258,17 +2435,17 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 		NodeInputs:  []common.Input{},
 	}
 
-	result, err := suite.executor.getAttributesForProvisioning(ctx)
+	result, _, err := suite.executor.getAttributesForProvisioning(ctx)
 
 	assert.Nil(suite.T(), result, "schema service error must return nil map")
 	assert.Error(suite.T(), err, "schema service error must propagate as an error")
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrSkippedWhenNotInNodeInputs() {
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_OptionalAttrCollectedWithoutNodeInput() {
 	nodeInputs := []common.Input{{Identifier: "email", Required: true}}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "phone", Required: false},
@@ -2280,37 +2457,18 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		NodeInputs:  nodeInputs,
 	}
 
-	result, err := exec.getAttributesForProvisioning(ctx)
+	result, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result["email"])
-	assert.NotContains(suite.T(), result, "phone",
-		"optional attr not in nodeInputSet must be skipped when nodeInputSet is non-empty")
-}
-
-func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingNodeInputs_ExecUserInputRequired() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
-		Return([]model.AttributeInfo{}, nil).Once()
-
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    common.FlowTypeRegistration,
-		UserInputs:  map[string]string{},
-		RuntimeData: map[string]string{userTypeKey: testUserType},
-		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
-	}
-
-	resp, err := suite.executor.Execute(ctx)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), resp)
-	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), "+1234567890", result["phone"],
+		"optional schema attr with a value must be collected even when nodeInputSet is non-empty")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_GetAttributesError_ReturnsServerError() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
 
 	ctx := &core.NodeContext{
@@ -2328,9 +2486,9 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GetAttributesError_Retur
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_EmptySchemaAttrs_NoUserAttributes() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -2406,7 +2564,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UnmarshalAttributesError
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NilRuntimeData_IsInitialized() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()
 
 	ctx := &core.NodeContext{
@@ -2420,28 +2578,6 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NilRuntimeData
 	suite.executor.HasRequiredInputs(ctx, execResp)
 
 	assert.NotNil(suite.T(), execResp.RuntimeData)
-}
-
-func (suite *ProvisioningExecutorTestSuite) TestCheckNodeInputs_InputNotSatisfiedByAuthnAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
-		Return([]model.AttributeInfo{}, nil).Once()
-
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		UserInputs:  map[string]string{},
-		RuntimeData: map[string]string{userTypeKey: testUserType},
-		NodeInputs:  []common.Input{{Identifier: "username", Required: true}},
-		AuthenticatedUser: authncm.AuthenticatedUser{
-			Attributes: map[string]interface{}{"email": "test@example.com"},
-		},
-	}
-	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
-
-	result := suite.executor.HasRequiredInputs(ctx, execResp)
-
-	assert.False(suite.T(), result)
-	assert.Len(suite.T(), execResp.Inputs, 1)
-	assert.Equal(suite.T(), "username", execResp.Inputs[0].Identifier)
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestGetGroupToAssign_NonStringValue_ReturnsEmpty() {
@@ -2468,7 +2604,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetRoleToAssign_NonStringValue_R
 	assert.Equal(suite.T(), "", result)
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributes_NilService_ReturnsNil() {
+func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributeInfos_NilService_ReturnsNil() {
 	pe := &provisioningExecutor{
 		ExecutorInterface:            suite.executor.ExecutorInterface,
 		identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
@@ -2483,31 +2619,40 @@ func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributes_NilService
 		RuntimeData: map[string]string{userTypeKey: testUserType},
 	}
 
-	attrs, err := pe.fetchSchemaAttributes(ctx, pe.logger)
+	attrs, err := pe.fetchSchemaAttributes(ctx, false, true)
 
 	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), attrs)
 }
 
-func (suite *ProvisioningExecutorTestSuite) TestFetchAllNonCredentialAttributes_NilService_ReturnsNil() {
-	pe := &provisioningExecutor{
-		ExecutorInterface:            suite.executor.ExecutorInterface,
-		identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
-		entityProvider:               suite.executor.entityProvider,
-		groupService:                 suite.executor.groupService,
-		roleService:                  suite.executor.roleService,
-		entityTypeService:            nil,
-		logger:                       suite.executor.logger,
-	}
+func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributeInfos_NonCred_ServiceError_ReturnsError() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, false, true, false).
+		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
 
 	ctx := &core.NodeContext{
 		RuntimeData: map[string]string{userTypeKey: testUserType},
 	}
 
-	attrs, err := pe.fetchAllNonCredentialAttributes(ctx)
+	attrs, err := suite.executor.fetchSchemaAttributes(ctx, false, true)
 
-	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), attrs)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to fetch schema attributes for user type")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestFetchSchemaAttributeInfos_Cred_ServiceError_ReturnsError() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return(nil, &serviceerror.ServiceError{Code: "internal_error"}).Once()
+
+	ctx := &core.NodeContext{
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+
+	attrs, err := suite.executor.fetchSchemaAttributes(ctx, true, false)
+
+	assert.Nil(suite.T(), attrs)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to fetch schema attributes for user type")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestCreateUserInStore_MissingUserType_ReturnsError() {
@@ -2523,10 +2668,24 @@ func (suite *ProvisioningExecutorTestSuite) TestCreateUserInStore_MissingUserTyp
 	assert.Contains(suite.T(), err.Error(), "user type not found")
 }
 
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MissingUserType_ReturnsFailure() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+}
+
 // TestHasRequiredInputs_IncludeOptionalTrue_PromptsOptionals verifies that when
 // includeOptional=true, missing optional schema attributes are also requested via prompt.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_PromptsOptionals() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email", Required: true},
 			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
@@ -2558,7 +2717,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 // TestHasRequiredInputs_IncludeOptionalFalse_SkipsOptionals verifies the default
 // behavior: optional schema attrs are not prompted when includeOptional is absent or false.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalFalse_SkipsOptionals() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", DisplayName: "Email", Required: true},
 		}, nil).Once()
@@ -2578,10 +2737,44 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 	assert.Empty(suite.T(), execResp.Inputs)
 }
 
+// TestHasRequiredInputs_NodeOptionalAttr_PromptedWithoutIncludeOptional
+// verifies that a schema-optional non-credential attr still prompts when the node explicitly asks
+// for it, even if includeOptional is absent or false.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NodeOptionalAttr_PromptedWithoutIncludeOptional() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: "email", DisplayName: "Email", Required: true},
+			{Attribute: "nickname", DisplayName: "Nickname", Required: false},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"email": "user@example.com"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs: []common.Input{
+			{Identifier: "nickname", Type: common.InputTypeText, Required: false},
+		},
+		NodeProperties: map[string]interface{}{},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	require.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), "nickname", execResp.Inputs[0].Identifier)
+	assert.False(suite.T(), execResp.Inputs[0].Required)
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	require.Len(suite.T(), fwdInputs, 1)
+	assert.Equal(suite.T(), "nickname", fwdInputs[0].Identifier)
+}
+
 // TestHasRequiredInputs_MaxPerPrompt_LimitsPromptedAttrs verifies that when maxPerPrompt=1,
-// only one missing schema attribute is prompted per iteration.
+// only one missing schema attribute is forwarded to the prompt per iteration.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_LimitsPromptedAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "firstName", DisplayName: "First Name", Required: true},
 			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
@@ -2602,14 +2795,17 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_L
 	result := suite.executor.HasRequiredInputs(ctx, execResp)
 
 	assert.False(suite.T(), result)
-	assert.Len(suite.T(), execResp.Inputs, 1, "only one input should be prompted per iteration")
-	assert.Equal(suite.T(), "firstName", execResp.Inputs[0].Identifier)
+	assert.Len(suite.T(), execResp.Inputs, 3, "full missing set should be retained on the executor response")
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	assert.Len(suite.T(), fwdInputs, 1, "only one input should be forwarded to the prompt per iteration")
+	assert.Equal(suite.T(), "firstName", fwdInputs[0].Identifier)
 }
 
 // TestHasRequiredInputs_MaxPerPrompt_Zero_PromptsAllMissingAttrs verifies that maxPerPrompt=0
 // (the default) prompts all missing attributes at once.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_Zero_PromptsAllMissingAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "firstName", DisplayName: "First Name", Required: true},
 			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
@@ -2630,15 +2826,15 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_Z
 	assert.Len(suite.T(), execResp.Inputs, 2, "all missing inputs should be prompted when maxPerPrompt is not set")
 }
 
-// TestGetAttributesForProvisioning_IncludeOptionalTrue_CollectsOptionals verifies that when
-// includeOptional=true, optional schema attrs are collected even when node inputs are set.
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalTrue_CollectsOptionals() {
+// TestGetAttributesForProvisioning_IncludeOptionalTrue_NoEffect verifies that
+// includeOptional=true does not alter schema-backed attribute collection.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalTrue_NoEffect() {
 	nodeInputs := []common.Input{
 		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "nickname", Required: false},
@@ -2656,23 +2852,23 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Inc
 		},
 	}
 
-	result, err := exec.getAttributesForProvisioning(ctx)
+	result, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result["email"])
 	assert.Equal(suite.T(), "nick", result["nickname"],
-		"optional attr must be collected when includeOptional=true")
+		"optional attr with a value must be collected regardless of includeOptional")
 }
 
-// TestGetAttributesForProvisioning_IncludeOptionalFalse_ExcludesOptionals verifies the default
-// behavior: optional attrs not in node inputs are excluded when includeOptional=false.
-func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalFalse_ExcludesOptionals() {
+// TestGetAttributesForProvisioning_IncludeOptionalFalse_CollectsOptionals verifies that
+// includeOptional=false does not exclude schema-backed values during collection.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_IncludeOptionalFalse_CollectsOptionals() {
 	nodeInputs := []common.Input{
 		{Identifier: "email", Type: "EMAIL_INPUT", Required: true},
 	}
 	exec := suite.newExecutorWithNodeInputs(nodeInputs)
 
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "email", Required: true},
 			{Attribute: "nickname", Required: false},
@@ -2688,18 +2884,19 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Inc
 		NodeProperties: map[string]interface{}{},
 	}
 
-	result, err := exec.getAttributesForProvisioning(ctx)
+	result, _, err := exec.getAttributesForProvisioning(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "user@example.com", result["email"])
-	assert.NotContains(suite.T(), result, "nickname",
-		"optional attr not in node inputs must be excluded when includeOptional=false")
+	assert.Equal(suite.T(), "nick", result["nickname"],
+		"optional attr with a value must be collected regardless of includeOptional")
 }
 
 // TestHasRequiredInputs_MaxPerPrompt_Float64_LimitsPromptedAttrs verifies that maxPerPrompt
-// supplied as float64 (the type JSON unmarshalling produces) is handled correctly.
+// supplied as float64 (the type JSON unmarshalling produces) is handled correctly for the
+// forwarded prompt batch.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_Float64_LimitsPromptedAttrs() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "firstName", DisplayName: "First Name", Required: true},
 			{Attribute: "lastName", DisplayName: "Last Name", Required: true},
@@ -2719,20 +2916,22 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_MaxPerPrompt_F
 	result := suite.executor.HasRequiredInputs(ctx, execResp)
 
 	assert.False(suite.T(), result)
-	assert.Len(suite.T(), execResp.Inputs, 1,
-		"float64 maxPerPrompt value (from JSON) must be handled correctly")
+	assert.Len(suite.T(), execResp.Inputs, 2,
+		"full missing set should be retained on the executor response")
+	fwdInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs].([]common.Input)
+	assert.True(suite.T(), ok)
+	assert.Len(suite.T(), fwdInputs, 1,
+		"float64 maxPerPrompt value (from JSON) must cap the forwarded prompt batch")
 }
 
-// TestExecute_AppendCredentialAttributesFails_ReturnsServerError verifies that when
-// fetchCredentialAttributes fails (schema service error), Execute propagates it as a server error.
-func (suite *ProvisioningExecutorTestSuite) TestExecute_AppendCredentialAttributesFails_ReturnsServerError() {
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
-		Return([]model.AttributeInfo{}, nil).Once()
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, false).
-		Return([]model.AttributeInfo{
-			{Attribute: "username", Required: true},
-		}, nil).Once()
-	suite.mockEntityTypeService.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
+// TestExecute_SchemaErrorOnProvisioning_ReturnsServerError verifies that when getAttributesForProvisioning
+// fails with a schema service error, Execute propagates it as a server error.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_SchemaErrorOnProvisioning_ReturnsServerError() {
+	// HasRequiredInputs: username is satisfied so execution proceeds.
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{{Attribute: "username", Required: true}}, nil).Once()
+	// getAttributesForProvisioning: schema service fails.
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return(nil, &serviceerror.ServiceError{Error: i18ncore.I18nMessage{DefaultValue: "schema unavailable"}}).Once()
 
 	ctx := &core.NodeContext{
@@ -2743,9 +2942,6 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AppendCredentialAttribut
 		NodeInputs:  []common.Input{{Identifier: "username", Type: "string", Required: true}},
 	}
 
-	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{"username": "newuser"}).
-		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
-
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.Nil(suite.T(), resp)
@@ -2753,51 +2949,10 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AppendCredentialAttribut
 	suite.mockEntityProvider.AssertNotCalled(suite.T(), "CreateEntity")
 }
 
-// TestFetchCredentialAttributes_NilService_ReturnsNil verifies that when entityTypeService is nil,
-// appendCredentialAttributes is a no-op and returns no error.
-func (suite *ProvisioningExecutorTestSuite) TestFetchCredentialAttributes_NilService_ReturnsNil() {
-	pe := &provisioningExecutor{
-		ExecutorInterface:            suite.executor.ExecutorInterface,
-		identifyingExecutorInterface: suite.executor.identifyingExecutorInterface,
-		entityProvider:               suite.executor.entityProvider,
-		groupService:                 suite.executor.groupService,
-		roleService:                  suite.executor.roleService,
-		entityTypeService:            nil,
-		logger:                       suite.executor.logger,
-	}
-
-	ctx := &core.NodeContext{
-		UserInputs:  map[string]string{"password": "secret"},
-		RuntimeData: map[string]string{userTypeKey: testUserType},
-	}
-
-	attrs := map[string]interface{}{"username": "testuser"}
-	err := pe.appendCredentialAttributes(ctx, &attrs)
-
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), map[string]interface{}{"username": "testuser"}, attrs)
-}
-
-// TestFetchCredentialAttributes_MissingUserType_ReturnsError verifies that when userType is absent
-// from runtime data, appendCredentialAttributes propagates the error.
-func (suite *ProvisioningExecutorTestSuite) TestFetchCredentialAttributes_MissingUserType_ReturnsError() {
-	ctx := &core.NodeContext{
-		UserInputs:  map[string]string{"password": "secret"},
-		RuntimeData: map[string]string{},
-	}
-
-	attrs := map[string]interface{}{"username": "testuser"}
-	err := suite.executor.appendCredentialAttributes(ctx, &attrs)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "user type not found")
-}
-
 // TestHasRequiredInputs_NoProperties_DefaultBehavior verifies that when no properties are set the
 // executor falls back to prompting only required schema attributes, all at once.
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NoProperties_DefaultBehavior() {
-	// requiredOnly=true: service returns only required attrs (optional ones are filtered by the service).
-	suite.mockEntityTypeService.On("GetNonCredentialAttributes", mock.Anything, mock.Anything, testUserType, true).
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: "firstName", DisplayName: "First Name", Required: true},
 			{Attribute: "lastName", DisplayName: "Last Name", Required: true},

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -25,7 +25,6 @@ import (
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/entityprovider"
-	"github.com/asgardeo/thunder/internal/flow/common"
 )
 
 // getAuthnServiceName returns the authn service name for an executor.
@@ -60,21 +59,4 @@ func GetUserAttribute(user *entityprovider.Entity, attributeKey string) (string,
 	}
 
 	return "", fmt.Errorf("attribute '%s' not found or is empty", attributeKey)
-}
-
-// upsertInputs merges incoming inputs into existing: replaces entries with a matching
-// Identifier in-place, appends entries that are not yet present.
-func upsertInputs(existing []common.Input, incoming []common.Input) []common.Input {
-	idxMap := make(map[string]int, len(existing))
-	for i, inp := range existing {
-		idxMap[inp.Identifier] = i
-	}
-	for _, inp := range incoming {
-		if idx, exists := idxMap[inp.Identifier]; exists {
-			existing[idx] = inp
-		} else {
-			existing = append(existing, inp)
-		}
-	}
-	return existing
 }

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -1031,8 +1031,8 @@ func (s *inboundClientService) validateUserAttributesAgainstAllowedTypes(
 
 	validAttrs := make(map[string]bool)
 	for _, entityTypeName := range allowedEntityTypes {
-		attrInfos, svcErr := s.entityType.GetNonCredentialAttributes(
-			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, entityTypeName, false)
+		attrInfos, svcErr := s.entityType.GetAttributes(
+			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, entityTypeName, false, true, false)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
 				return ErrUserSchemaLookupFailed

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -1809,7 +1809,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_NoOpWhenN
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAssertionAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}, {Attribute: "name"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1820,7 +1820,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAsse
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAssertionAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1831,7 +1831,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAs
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAccessTokenAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1846,7 +1846,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAcce
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAccessTokenAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1861,7 +1861,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAc
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidIDTokenAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1876,7 +1876,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidID
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidUserInfoAttribute() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1889,7 +1889,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidUs
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ClientErrorMapsToFKError() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return(nil, &serviceerror.ServiceError{Type: serviceerror.ClientErrorType, Code: "ERR"})
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1900,7 +1900,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ClientErr
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ServerErrorMapsToLookupFailed() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return(nil, &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "SRV"})
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1911,9 +1911,9 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ServerErr
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_UnionAcrossMultipleTypes() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "contractor", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "contractor", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "agency_name"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1925,7 +1925,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_UnionAcro
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ComputedAttributesSkipSchemaCheck() {
 	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 
@@ -1961,7 +1961,7 @@ func (suite *InboundClientServiceTestSuite) TestCreateInboundClient_RejectsInval
 			TotalResults: 1,
 			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 
 	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)
@@ -1985,7 +1985,7 @@ func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_RejectsInval
 			TotalResults: 1,
 			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 
 	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)
@@ -2009,7 +2009,7 @@ func (suite *InboundClientServiceTestSuite) TestValidate_RejectsInvalidUserAttri
 			TotalResults: 1,
 			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
-	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
 
 	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -589,8 +589,8 @@ func (us *userService) UpdateUserAttributes(
 		logger.Error("Entity type service is not configured for user operations")
 		return nil, &serviceerror.InternalServerError
 	}
-	schemaCredentialAttributes, svcErr := us.entityTypeService.GetCredentialAttributes(ctx,
-		entitytype.TypeCategoryUser, existingUser.Type)
+	schemaCredentialInfos, svcErr := us.entityTypeService.GetAttributes(ctx,
+		entitytype.TypeCategoryUser, existingUser.Type, true, false, false)
 	if svcErr != nil {
 		if svcErr.Code == entitytype.ErrorEntityTypeNotFound.Code {
 			return nil, &ErrorEntityTypeNotFound
@@ -599,13 +599,13 @@ func (us *userService) UpdateUserAttributes(
 			fmt.Errorf("schema service error: %s", svcErr.ErrorDescription.DefaultValue),
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
-	if len(schemaCredentialAttributes) > 0 {
+	if len(schemaCredentialInfos) > 0 {
 		var attrs map[string]any
 		if err := json.Unmarshal(attributes, &attrs); err != nil {
 			return nil, &ErrorInvalidRequestFormat
 		}
-		for _, credField := range schemaCredentialAttributes {
-			if _, ok := attrs[credField]; ok {
+		for _, credInfo := range schemaCredentialInfos {
+			if _, ok := attrs[credInfo.Attribute]; ok {
 				return nil, &ErrorInvalidRequestFormat
 			}
 		}

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -699,8 +699,8 @@ func TestUserService_UpdateUserAttributes_SchemaValidationFails(t *testing.T) {
 		Once()
 
 	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*serviceerror.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -728,8 +728,8 @@ func TestUserService_UpdateUserAttributes_Succeeds(t *testing.T) {
 		Once()
 
 	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*serviceerror.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -754,8 +754,8 @@ func TestUserService_UpdateUserAttributes_RejectsCredentialAttributes(t *testing
 			Attributes: json.RawMessage(`{"email":"old@example.com"}`)}, nil).Once()
 
 	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*serviceerror.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -1776,8 +1776,8 @@ func TestUserService_MoreErrorCases(t *testing.T) {
 			Return((*entitypkg.Entity)(nil), errors.New("db error")).Once()
 
 		// Mock all validation steps with broad matches to ensure they hit
-		entityTypeMock.On("GetCredentialAttributes", mock.Anything, mock.Anything).
-			Return([]string{}, (*serviceerror.ServiceError)(nil)).Maybe()
+		entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, mock.Anything, true, false, false).
+			Return([]entitytype.AttributeInfo{}, (*serviceerror.ServiceError)(nil)).Maybe()
 		ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		ouServiceMock.On("IsParent", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, mock.Anything).
@@ -2535,8 +2535,8 @@ func TestUserService_UpdateUserAttributes_PreFetchAndAuthzChecks(t *testing.T) {
 					}, nil).Once()
 
 				schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-				schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-					Return([]string{}, (*serviceerror.ServiceError)(nil)).Once()
+				schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*serviceerror.ServiceError)(nil)).Once()
 
 				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
 				authzMock.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
@@ -2563,8 +2563,8 @@ func TestUserService_UpdateUserAttributes_PreFetchAndAuthzChecks(t *testing.T) {
 					}, nil).Once()
 
 				schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-				schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, testUserType).
-					Return([]string{}, (*serviceerror.ServiceError)(nil)).Once()
+				schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*serviceerror.ServiceError)(nil)).Once()
 
 				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
 				authzMock.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
@@ -2870,8 +2870,8 @@ func TestUpdateUserAttributes_DeclarativeResource(t *testing.T) {
 	storeMock.On("IsEntityDeclarative", mock.Anything, userID).Return(true, nil).Once()
 
 	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, "employee").
-		Return([]string{}, (*serviceerror.ServiceError)(nil)).Once()
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, "employee", true, false, false).
+		Return([]entitytype.AttributeInfo{}, (*serviceerror.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -2902,8 +2902,8 @@ func TestUpdateUserAttributes_DeclarativeCheckError(t *testing.T) {
 	storeMock.On("IsEntityDeclarative", mock.Anything, userID).Return(false, storeErr).Once()
 
 	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	schemaMock.On("GetCredentialAttributes", mock.Anything, mock.Anything, "employee").
-		Return([]string{}, (*serviceerror.ServiceError)(nil)).Once()
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, "employee", true, false, false).
+		Return([]entitytype.AttributeInfo{}, (*serviceerror.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,

--- a/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
+++ b/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
@@ -181,28 +181,28 @@ func (_c *EntityTypeServiceInterfaceMock_DeleteEntityType_Call) RunAndReturn(run
 	return _c
 }
 
-// GetCredentialAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
-func (_mock *EntityTypeServiceInterfaceMock) GetCredentialAttributes(ctx context.Context, category entitytype.TypeCategory, entityType string) ([]string, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, category, entityType)
+// GetAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) GetAttributes(ctx context.Context, category entitytype.TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCredentialAttributes")
+		panic("no return value specified for GetAttributes")
 	}
 
-	var r0 []string
+	var r0 []entitytype.AttributeInfo
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) ([]string, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string, bool, bool, bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) []string); ok {
-		r0 = returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string, bool, bool, bool) []entitytype.AttributeInfo); ok {
+		r0 = returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
+			r0 = ret.Get(0).([]entitytype.AttributeInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, entitytype.TypeCategory, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, category, entityType)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, entitytype.TypeCategory, string, bool, bool, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -211,20 +211,23 @@ func (_mock *EntityTypeServiceInterfaceMock) GetCredentialAttributes(ctx context
 	return r0, r1
 }
 
-// EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCredentialAttributes'
-type EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call struct {
+// EntityTypeServiceInterfaceMock_GetAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAttributes'
+type EntityTypeServiceInterfaceMock_GetAttributes_Call struct {
 	*mock.Call
 }
 
-// GetCredentialAttributes is a helper method to define mock.On call
+// GetAttributes is a helper method to define mock.On call
 //   - ctx context.Context
 //   - category entitytype.TypeCategory
 //   - entityType string
-func (_e *EntityTypeServiceInterfaceMock_Expecter) GetCredentialAttributes(ctx interface{}, category interface{}, entityType interface{}) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
-	return &EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call{Call: _e.mock.On("GetCredentialAttributes", ctx, category, entityType)}
+//   - allowCredential bool
+//   - allowNonCredential bool
+//   - requiredOnly bool
+func (_e *EntityTypeServiceInterfaceMock_Expecter) GetAttributes(ctx interface{}, category interface{}, entityType interface{}, allowCredential interface{}, allowNonCredential interface{}, requiredOnly interface{}) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
+	return &EntityTypeServiceInterfaceMock_GetAttributes_Call{Call: _e.mock.On("GetAttributes", ctx, category, entityType, allowCredential, allowNonCredential, requiredOnly)}
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Run(run func(ctx context.Context, category entitytype.TypeCategory, entityType string)) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) Run(run func(ctx context.Context, category entitytype.TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool)) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -238,21 +241,36 @@ func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Run(run f
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
+			arg4,
+			arg5,
 		)
 	})
 	return _c
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
-	_c.Call.Return(strings, serviceError)
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) Return(vs []entitytype.AttributeInfo, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
+	_c.Call.Return(vs, serviceError)
 	return _c
 }
 
-func (_c *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, entityType string) ([]string, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetCredentialAttributes_Call {
+func (_c *EntityTypeServiceInterfaceMock_GetAttributes_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, entityType string, allowCredential bool, allowNonCredential bool, requiredOnly bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetAttributes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -575,88 +593,6 @@ func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) Return(entityTy
 }
 
 func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, limit int, offset int, includeDisplay bool) (*entitytype.EntityTypeListResponse, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetNonCredentialAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
-func (_mock *EntityTypeServiceInterfaceMock) GetNonCredentialAttributes(ctx context.Context, category entitytype.TypeCategory, entityType string, requiredOnly bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, category, entityType, requiredOnly)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetNonCredentialAttributes")
-	}
-
-	var r0 []entitytype.AttributeInfo
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string, bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, category, entityType, requiredOnly)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string, bool) []entitytype.AttributeInfo); ok {
-		r0 = returnFunc(ctx, category, entityType, requiredOnly)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]entitytype.AttributeInfo)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, entitytype.TypeCategory, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, category, entityType, requiredOnly)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNonCredentialAttributes'
-type EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call struct {
-	*mock.Call
-}
-
-// GetNonCredentialAttributes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - category entitytype.TypeCategory
-//   - entityType string
-//   - requiredOnly bool
-func (_e *EntityTypeServiceInterfaceMock_Expecter) GetNonCredentialAttributes(ctx interface{}, category interface{}, entityType interface{}, requiredOnly interface{}) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	return &EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call{Call: _e.mock.On("GetNonCredentialAttributes", ctx, category, entityType, requiredOnly)}
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) Run(run func(ctx context.Context, category entitytype.TypeCategory, entityType string, requiredOnly bool)) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 entitytype.TypeCategory
-		if args[1] != nil {
-			arg1 = args[1].(entitytype.TypeCategory)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 bool
-		if args[3] != nil {
-			arg3 = args[3].(bool)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) Return(vs []entitytype.AttributeInfo, serviceError *serviceerror.ServiceError) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
-	_c.Call.Return(vs, serviceError)
-	return _c
-}
-
-func (_c *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, entityType string, requiredOnly bool) ([]entitytype.AttributeInfo, *serviceerror.ServiceError)) *EntityTypeServiceInterfaceMock_GetNonCredentialAttributes_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This PR fixes registration provisioning when credential attributes are defined dynamically in the user schema. Previously, credential inputs could be prompted to the user but then be missed during user provisioning because the executor only persisted credential attributes based on node inputs instead of the schema-backed credential set.

This change also makes credential schema handling consistent with non-credential schema handling by exposing credential attribute metadata with a `requiredOnly` option and using that metadata in the provisioning executor when building dynamic prompt inputs.

### Approach
Updated the userschema contract to support `GetCredentialAttributeInfos(..., requiredOnly)` similar to `GetNonCredentialAttributes(..., requiredOnly)`, and propagated that change through the service layer and generated mocks.

In the provisioning executor, credential prompting and credential persistence are now handled as two explicit paths:
- Prompt-time credential resolution uses credential schema metadata, including required/display name information, so dynamic prompt inputs are built correctly.
- Provisioning-time credential persistence fetches schema credential attribute names and persists any available values from the execution context instead of limiting persistence to credential node inputs only.

The executor logic was also clarified by separating prompt-side non-credential and credential schema fetch helpers, and tests were expanded to cover:
- optional credential overridden to required by node input
- capped forwarded dynamic prompt inputs
- credential attribute persistence during provisioning
- required-only vs all-attributes behavior for credential schema metadata in schema and service layers

### Related Issues
- https://github.com/asgardeo/thunder/issues/2633

### Related PRs
- https://github.com/asgardeo/thunder/pull/2537


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced provisioning prompts: separate required/optional credential and non-credential pools with max-per-prompt batching.
  * Improved password-field synchronization for forwarded inputs.

* **Bug Fixes**
  * Prevent re-prompting of already-present optional attributes.
  * Ensure promotions to password type don't mutate shared meta across runs.
  * Better error handling when credential attribute retrieval fails.

* **Tests**
  * Expanded tests for credential handling, prompting limits, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->