### PR TITLE
Add executor input configuration UI to flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -652,6 +652,11 @@ function collectInputsForExecutionNodes(
       return flowNode;
     }
 
+    // If executor already has user-configured inputs, preserve them
+    if (flowNode.executor?.inputs && flowNode.executor.inputs.length > 0) {
+      return flowNode;
+    }
+
     const executorName = flowNode.executor?.name;
 
     // OAuth/OIDC executors get a standard 'code' input for OAuth callback

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
-import {useMemo, type ReactNode} from 'react';
+import {Stack} from '@wso2/oxygen-ui';
+import {useCallback, useMemo, type ReactNode} from 'react';
 import ConsentProperties from './execution-properties/ConsentProperties';
-import {EXECUTOR_TO_IDP_TYPE_MAP} from './execution-properties/constants';
+import {EXECUTOR_TO_IDP_TYPE_MAP, EXECUTORS_WITH_FIXED_INPUTS} from './execution-properties/constants';
 import EmailProperties from './execution-properties/EmailProperties';
+import ExecutorInputsEditor from './execution-properties/ExecutorInputsEditor';
 import FederationProperties from './execution-properties/FederationProperties';
 import HttpRequestProperties from './execution-properties/HttpRequestProperties';
 import IdentifyingProperties from './execution-properties/IdentifyingProperties';
@@ -34,6 +36,7 @@ import SmsOtpProperties from './execution-properties/SmsOtpProperties';
 import SmsProperties from './execution-properties/SmsProperties';
 import UserTypeResolverProperties from './execution-properties/UserTypeResolverProperties';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/ResourceProperties';
+import type {FlowNodeInput} from '@/features/flows/models/responses';
 import {ExecutionTypes} from '@/features/flows/models/steps';
 import type {StepData} from '@/features/flows/models/steps';
 
@@ -55,51 +58,85 @@ function ExecutionExtendedProperties({resource, onChange}: ExecutionExtendedProp
     return stepData?.action?.executor?.name;
   }, [resource]);
 
+  const currentInputs = useMemo((): FlowNodeInput[] => {
+    const stepData = resource?.data as StepData | undefined;
+    return (stepData?.action?.executor as {inputs?: FlowNodeInput[]} | undefined)?.inputs ?? [];
+  }, [resource]);
+
+  const handleInputsChange = useCallback(
+    (inputs: FlowNodeInput[]) => {
+      onChange('data.action.executor.inputs', inputs.length > 0 ? inputs : undefined, resource);
+    },
+    [onChange, resource],
+  );
+
   if (!executorName) {
     return null;
   }
 
+  const showInputsEditor = !EXECUTORS_WITH_FIXED_INPUTS.has(executorName);
+
+  let executorSpecificProperties: ReactNode = null;
+
   switch (executorName) {
     case ExecutionTypes.SMSOTPAuth:
-      return <SmsOtpProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <SmsOtpProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.ConsentExecutor:
-      return <ConsentProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <ConsentProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.IdentifyingExecutor:
-      return <IdentifyingProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <IdentifyingProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.PasskeyAuth:
-      return <PasskeyProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <PasskeyProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.OUResolverExecutor:
-      return <OUResolverProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <OUResolverProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.InviteExecutor:
-      return <InviteProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <InviteProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.EmailExecutor:
-      return <EmailProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <EmailProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.SMSExecutor:
-      return <SmsProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <SmsProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.PermissionValidator:
-      return <PermissionValidatorProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <PermissionValidatorProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.ProvisioningExecutor:
-      return <ProvisioningProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <ProvisioningProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.OUExecutor:
-      return <OUExecutorProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <OUExecutorProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.UserTypeResolver:
-      return <UserTypeResolverProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <UserTypeResolverProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.HTTPRequestExecutor:
-      return <HttpRequestProperties resource={resource} onChange={onChange} />;
+      executorSpecificProperties = <HttpRequestProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.CredentialSetter:
     case ExecutionTypes.AttributeUniquenessValidator:
     case ExecutionTypes.MagicLinkExecutor:
-      return <NoConfigProperties />;
+      executorSpecificProperties = <NoConfigProperties />;
+      break;
     default:
+      // Federated executors (Google, GitHub, OAuth, OIDC) - check if executor has an IDP type mapping
+      if (EXECUTOR_TO_IDP_TYPE_MAP[executorName]) {
+        executorSpecificProperties = <FederationProperties resource={resource} onChange={onChange} />;
+      }
       break;
   }
 
-  // Federated executors (Google, GitHub, OAuth, OIDC) - check if executor has an IDP type mapping
-  if (EXECUTOR_TO_IDP_TYPE_MAP[executorName]) {
-    return <FederationProperties resource={resource} onChange={onChange} />;
-  }
-
-  return null;
+  return (
+    <Stack gap={2}>
+      {executorSpecificProperties}
+      {showInputsEditor && <ExecutorInputsEditor inputs={currentInputs} onChange={handleInputsChange} />}
+    </Stack>
+  );
 }
 
 export default ExecutionExtendedProperties;

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -1755,7 +1755,7 @@ describe('ExecutionExtendedProperties', () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it('should return null when executor type is not mapped', () => {
+    it('should render only the inputs editor when executor type is not mapped', () => {
       const resourceWithUnmappedExecutor = {
         id: 'resource-1',
         data: {
@@ -1771,7 +1771,8 @@ describe('ExecutionExtendedProperties', () => {
         <ExecutionExtendedProperties resource={resourceWithUnmappedExecutor} onChange={mockOnChange} />,
       );
 
-      expect(container.firstChild).toBeNull();
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.getByText('flows:core.executions.inputs.title')).toBeInTheDocument();
     });
 
     it('should handle undefined resource gracefully', () => {

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/ExecutorInputsEditor.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/ExecutorInputsEditor.tsx
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormLabel,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+} from '@wso2/oxygen-ui';
+import {Trash} from '@wso2/oxygen-ui-icons-react';
+import {memo, useCallback, useMemo, useReducer, useState, type ReactNode} from 'react';
+import {useTranslation} from 'react-i18next';
+import {INPUT_TYPES} from './constants';
+import type {FlowNodeInput} from '@/features/flows/models/responses';
+import generateResourceId from '@/features/flows/utils/generateResourceId';
+
+/**
+ * Props interface of {@link ExecutorInputsEditor}
+ */
+export interface ExecutorInputsEditorProps {
+  inputs: FlowNodeInput[];
+  onChange: (inputs: FlowNodeInput[]) => void;
+}
+
+let nextId = 0;
+const generateId = (): string => {
+  nextId += 1;
+  return `ei-${nextId}`;
+};
+
+/**
+ * Reducer that maintains a stable list of IDs matched to entries length.
+ */
+const idsReducer = (prev: string[], requiredLength: number): string[] => {
+  if (prev.length === requiredLength) {
+    return prev;
+  }
+
+  if (requiredLength > prev.length) {
+    const newIds = Array.from({length: requiredLength - prev.length}, () => generateId());
+    return [...prev, ...newIds];
+  }
+
+  return prev.slice(0, requiredLength);
+};
+
+interface InputRowProps {
+  input: FlowNodeInput;
+  index: number;
+  onUpdate: (index: number, field: keyof FlowNodeInput, value: string | boolean) => void;
+  onRemove: (index: number) => void;
+}
+
+/**
+ * A single input card with type dropdown, identifier field, required checkbox, and remove action.
+ * Commits identifier to the parent only on blur to avoid input clobbering during fast typing.
+ */
+const InputRow = memo(function InputRow({input, index, onUpdate, onRemove}: InputRowProps): ReactNode {
+  const {t} = useTranslation();
+  const [localIdentifier, setLocalIdentifier] = useState(input.identifier);
+
+  // Reset local state when the prop changes from outside (e.g. parent replaces the list).
+  // useMemo runs synchronously during render, avoiding the cascading-render lint error
+  // that useEffect + setState would cause.
+  const [prevIdentifier, setPrevIdentifier] = useState(input.identifier);
+  if (input.identifier !== prevIdentifier) {
+    setPrevIdentifier(input.identifier);
+    setLocalIdentifier(input.identifier);
+  }
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 1.5,
+      }}
+    >
+      <Stack gap={1.5}>
+        <div>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <FormLabel>{t('flows:core.executions.inputs.typeLabel')}</FormLabel>
+            <Tooltip title={t('flows:core.executions.inputs.remove')}>
+              <IconButton
+                size="small"
+                onClick={() => onRemove(index)}
+                aria-label={t('flows:core.executions.inputs.remove')}
+              >
+                <Trash size={14} color="red" />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+          <Select
+            value={input.type}
+            onChange={(e) => onUpdate(index, 'type', e.target.value)}
+            size="small"
+            displayEmpty
+            fullWidth
+          >
+            <MenuItem value="" disabled>
+              {t('flows:core.executions.inputs.typePlaceholder')}
+            </MenuItem>
+            {INPUT_TYPES.map((inputType) => (
+              <MenuItem key={inputType.value} value={inputType.value}>
+                {t(inputType.translationKey)}
+              </MenuItem>
+            ))}
+          </Select>
+        </div>
+        <div>
+          <FormLabel>{t('flows:core.executions.inputs.identifierLabel')}</FormLabel>
+          <TextField
+            value={localIdentifier}
+            onChange={(e) => setLocalIdentifier(e.target.value)}
+            onBlur={() => {
+              if (localIdentifier !== input.identifier) {
+                onUpdate(index, 'identifier', localIdentifier);
+              }
+            }}
+            placeholder={t('flows:core.executions.inputs.identifierPlaceholder')}
+            size="small"
+            fullWidth
+          />
+        </div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={input.required}
+              onChange={(_, checked) => onUpdate(index, 'required', checked)}
+              size="small"
+            />
+          }
+          label={t('flows:core.executions.inputs.required')}
+        />
+      </Stack>
+    </Box>
+  );
+});
+
+/**
+ * Dynamic list editor for configuring executor inputs.
+ * Allows adding/removing input field definitions with type, identifier, and required flag.
+ *
+ * @param props - Props injected to the component.
+ * @returns The ExecutorInputsEditor component.
+ */
+function ExecutorInputsEditor({inputs: inputsProp, onChange}: ExecutorInputsEditorProps): ReactNode {
+  const inputs = useMemo(() => (Array.isArray(inputsProp) ? inputsProp : []), [inputsProp]);
+  const {t} = useTranslation();
+
+  // Stable IDs for each entry — used as React keys so rows survive re-renders.
+  const [ids, dispatchIds] = useReducer(idsReducer, inputs.length, (len) =>
+    Array.from({length: len}, () => generateId()),
+  );
+
+  const syncedIds = useMemo(() => {
+    if (ids.length !== inputs.length) {
+      dispatchIds(inputs.length);
+    }
+    return ids.length === inputs.length ? ids : idsReducer(ids, inputs.length);
+  }, [ids, inputs.length]);
+
+  const handleUpdate = useCallback(
+    (index: number, field: keyof FlowNodeInput, value: string | boolean) => {
+      const updated = [...inputs];
+      updated[index] = {...updated[index], [field]: value};
+      onChange(updated);
+    },
+    [inputs, onChange],
+  );
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      dispatchIds(inputs.length - 1);
+      const updated = inputs.filter((_, i) => i !== index);
+      onChange(updated);
+    },
+    [inputs, onChange],
+  );
+
+  const handleAdd = useCallback(() => {
+    const newInput: FlowNodeInput = {
+      ref: generateResourceId('input'),
+      type: 'TEXT_INPUT',
+      identifier: '',
+      required: true,
+    };
+    onChange([...inputs, newInput]);
+  }, [inputs, onChange]);
+
+  return (
+    <Stack gap={1.5}>
+      <FormLabel>{t('flows:core.executions.inputs.title')}</FormLabel>
+      {inputs.length === 0 && <Alert severity="info">{t('flows:core.executions.inputs.empty')}</Alert>}
+      {inputs.map((input, index) => (
+        <InputRow key={syncedIds[index]} input={input} index={index} onUpdate={handleUpdate} onRemove={handleRemove} />
+      ))}
+      <Button variant="outlined" size="small" onClick={handleAdd} fullWidth>
+        {t('flows:core.executions.inputs.add')}
+      </Button>
+    </Stack>
+  );
+}
+
+export default ExecutorInputsEditor;

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/ExecutorInputsEditor.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/ExecutorInputsEditor.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import ExecutorInputsEditor from '../ExecutorInputsEditor';
+import type {FlowNodeInput} from '@/features/flows/models/responses';
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock generateResourceId to return deterministic values in tests
+vi.mock('@/features/flows/utils/generateResourceId', () => ({
+  default: (prefix: string) => `${prefix}-test-id`,
+}));
+
+describe('ExecutorInputsEditor', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  describe('Empty State', () => {
+    it('should render the title and info alert when inputs are empty', () => {
+      render(<ExecutorInputsEditor inputs={[]} onChange={mockOnChange} />);
+
+      expect(screen.getByText('flows:core.executions.inputs.title')).toBeInTheDocument();
+      expect(screen.getByText('flows:core.executions.inputs.empty')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('should render the add button when inputs are empty', () => {
+      render(<ExecutorInputsEditor inputs={[]} onChange={mockOnChange} />);
+
+      expect(screen.getByText('flows:core.executions.inputs.add')).toBeInTheDocument();
+    });
+
+    it('should handle undefined inputs gracefully', () => {
+      render(<ExecutorInputsEditor inputs={undefined as unknown as FlowNodeInput[]} onChange={mockOnChange} />);
+
+      expect(screen.getByText('flows:core.executions.inputs.empty')).toBeInTheDocument();
+    });
+
+    it('should handle non-array inputs gracefully', () => {
+      render(<ExecutorInputsEditor inputs={'invalid' as unknown as FlowNodeInput[]} onChange={mockOnChange} />);
+
+      expect(screen.getByText('flows:core.executions.inputs.empty')).toBeInTheDocument();
+    });
+  });
+
+  describe('Rendering Inputs', () => {
+    const twoInputs: FlowNodeInput[] = [
+      {type: 'TEXT_INPUT', identifier: 'username', required: true},
+      {type: 'PASSWORD_INPUT', identifier: 'password', required: true},
+    ];
+
+    it('should render input rows for each input', () => {
+      render(<ExecutorInputsEditor inputs={twoInputs} onChange={mockOnChange} />);
+
+      const textboxes = screen.getAllByRole('textbox');
+      expect(textboxes).toHaveLength(2);
+      expect(textboxes[0]).toHaveValue('username');
+      expect(textboxes[1]).toHaveValue('password');
+    });
+
+    it('should not render the info alert when inputs exist', () => {
+      render(<ExecutorInputsEditor inputs={twoInputs} onChange={mockOnChange} />);
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('should render remove buttons for each input', () => {
+      render(<ExecutorInputsEditor inputs={twoInputs} onChange={mockOnChange} />);
+
+      expect(screen.getAllByLabelText('flows:core.executions.inputs.remove')).toHaveLength(2);
+    });
+
+    it('should render checkboxes for each input', () => {
+      render(<ExecutorInputsEditor inputs={twoInputs} onChange={mockOnChange} />);
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(2);
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).toBeChecked();
+    });
+
+    it('should render unchecked checkbox when required is false', () => {
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'optional', required: false}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+  });
+
+  describe('Add Input', () => {
+    it('should call onChange with a new TEXT_INPUT when add button is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(<ExecutorInputsEditor inputs={[]} onChange={mockOnChange} />);
+
+      await user.click(screen.getByText('flows:core.executions.inputs.add'));
+
+      expect(mockOnChange).toHaveBeenCalledWith([
+        {ref: 'input-test-id', type: 'TEXT_INPUT', identifier: '', required: true},
+      ]);
+    });
+
+    it('should append to existing inputs when add button is clicked', async () => {
+      const user = userEvent.setup();
+      const existingInputs: FlowNodeInput[] = [{type: 'EMAIL_INPUT', identifier: 'email', required: true}];
+
+      render(<ExecutorInputsEditor inputs={existingInputs} onChange={mockOnChange} />);
+
+      await user.click(screen.getByText('flows:core.executions.inputs.add'));
+
+      expect(mockOnChange).toHaveBeenCalledWith([
+        {type: 'EMAIL_INPUT', identifier: 'email', required: true},
+        {ref: 'input-test-id', type: 'TEXT_INPUT', identifier: '', required: true},
+      ]);
+    });
+  });
+
+  describe('Remove Input', () => {
+    it('should call onChange without the removed input', async () => {
+      const user = userEvent.setup();
+      const inputs: FlowNodeInput[] = [
+        {type: 'TEXT_INPUT', identifier: 'username', required: true},
+        {type: 'PASSWORD_INPUT', identifier: 'password', required: true},
+      ];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      const removeButtons = screen.getAllByLabelText('flows:core.executions.inputs.remove');
+      await user.click(removeButtons[0]);
+
+      expect(mockOnChange).toHaveBeenCalledWith([{type: 'PASSWORD_INPUT', identifier: 'password', required: true}]);
+    });
+
+    it('should call onChange with empty array when last input is removed', async () => {
+      const user = userEvent.setup();
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'username', required: true}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      await user.click(screen.getByLabelText('flows:core.executions.inputs.remove'));
+
+      expect(mockOnChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('Update Type', () => {
+    it('should call onChange with updated type when type is changed', async () => {
+      const user = userEvent.setup();
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'field', required: true}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      // Open the select dropdown and pick a new type
+      const selectButton = screen.getByRole('combobox');
+      await user.click(selectButton);
+
+      const passwordOption = screen.getByText('flows:core.executions.inputs.types.password');
+      await user.click(passwordOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith([{type: 'PASSWORD_INPUT', identifier: 'field', required: true}]);
+    });
+  });
+
+  describe('Update Identifier', () => {
+    it('should call onChange with updated identifier on blur', () => {
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'old_id', required: true}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      const textbox = screen.getByRole('textbox');
+      fireEvent.change(textbox, {target: {value: 'new_id'}});
+      fireEvent.blur(textbox);
+
+      expect(mockOnChange).toHaveBeenCalledWith([{type: 'TEXT_INPUT', identifier: 'new_id', required: true}]);
+    });
+
+    it('should not call onChange on blur when identifier is unchanged', () => {
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'same_id', required: true}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      const textbox = screen.getByRole('textbox');
+      fireEvent.blur(textbox);
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Update Required', () => {
+    it('should call onChange with toggled required when checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'field', required: true}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('checkbox'));
+
+      expect(mockOnChange).toHaveBeenCalledWith([{type: 'TEXT_INPUT', identifier: 'field', required: false}]);
+    });
+
+    it('should call onChange with required true when unchecked checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'field', required: false}];
+
+      render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('checkbox'));
+
+      expect(mockOnChange).toHaveBeenCalledWith([{type: 'TEXT_INPUT', identifier: 'field', required: true}]);
+    });
+  });
+
+  describe('Identifier Sync', () => {
+    it('should update local identifier when prop changes externally', () => {
+      const inputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'initial', required: true}];
+
+      const {rerender} = render(<ExecutorInputsEditor inputs={inputs} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('textbox')).toHaveValue('initial');
+
+      const updatedInputs: FlowNodeInput[] = [{type: 'TEXT_INPUT', identifier: 'updated', required: true}];
+      rerender(<ExecutorInputsEditor inputs={updatedInputs} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('textbox')).toHaveValue('updated');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/constants.ts
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/constants.ts
@@ -104,3 +104,29 @@ export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
  * Passkey modes that require relying party configuration.
  */
 export const PASSKEY_MODES_WITH_RELYING_PARTY = ['challenge', 'register_start'] as const;
+
+/**
+ * Available input types for executor input configuration.
+ * These correspond to the backend input type constants defined in common/constants.go.
+ */
+export const INPUT_TYPES = [
+  {value: 'TEXT_INPUT', translationKey: 'flows:core.executions.inputs.types.text'},
+  {value: 'EMAIL_INPUT', translationKey: 'flows:core.executions.inputs.types.email'},
+  {value: 'PASSWORD_INPUT', translationKey: 'flows:core.executions.inputs.types.password'},
+  {value: 'OTP_INPUT', translationKey: 'flows:core.executions.inputs.types.otp'},
+  {value: 'PHONE_INPUT', translationKey: 'flows:core.executions.inputs.types.phone'},
+  {value: 'CONSENT_INPUT', translationKey: 'flows:core.executions.inputs.types.consent'},
+  {value: 'SELECT', translationKey: 'flows:core.executions.inputs.types.select'},
+] as const;
+
+/**
+ * Executors that have fixed/programmatic inputs and should not show the input editor.
+ * OAuth executors get a fixed 'code' input; ConsentExecutor gets 'consent_decisions'.
+ */
+export const EXECUTORS_WITH_FIXED_INPUTS = new Set<string>([
+  ExecutionTypes.GoogleFederation,
+  ExecutionTypes.GithubFederation,
+  ExecutionTypes.OAuthExecutor,
+  ExecutionTypes.OIDCAuthExecutor,
+  ExecutionTypes.ConsentExecutor,
+]);

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2091,6 +2091,24 @@ const translations = {
     'core.executions.httpRequest.errorHandling.retryDelay.placeholder': '0',
     'core.executions.httpRequest.errorHandling.retryDelay.hint': 'Delay between retries in milliseconds (max 5000).',
 
+    // Executor input configuration
+    'core.executions.inputs.title': 'Executor Inputs',
+    'core.executions.inputs.typeLabel': 'Type',
+    'core.executions.inputs.typePlaceholder': 'Select type',
+    'core.executions.inputs.identifierLabel': 'Identifier',
+    'core.executions.inputs.identifierPlaceholder': 'e.g., username, email',
+    'core.executions.inputs.required': 'Required',
+    'core.executions.inputs.add': 'Add Input',
+    'core.executions.inputs.remove': 'Remove input',
+    'core.executions.inputs.empty': 'No custom inputs configured. The executor will use its default inputs.',
+    'core.executions.inputs.types.text': 'Text',
+    'core.executions.inputs.types.email': 'Email',
+    'core.executions.inputs.types.password': 'Password',
+    'core.executions.inputs.types.otp': 'OTP',
+    'core.executions.inputs.types.phone': 'Phone',
+    'core.executions.inputs.types.consent': 'Consent',
+    'core.executions.inputs.types.select': 'Select',
+
     // Execution steps - tooltips and messages
     // No-config executors
     'core.executions.noConfig.description': 'This executor has no configurable properties.',


### PR DESCRIPTION
## Summary

- Adds a dynamic list editor (`ExecutorInputsEditor`) in the flow builder property panel for configuring executor inputs per node
- Each input row supports type selection (Text, Email, Password, OTP, Phone, Consent, Select), identifier, and required flag
- Updates `reactFlowTransformer` to preserve user-configured inputs instead of auto-inferring from the preceding PROMPT node
- Hides the editor for executors with fixed inputs (OAuth/OIDC, Consent)

## Test plan

- [ ] Add a TASK_EXECUTION node (e.g., BasicAuthExecutor), open property panel, verify "Executor Inputs" section appears
- [ ] Add/remove input rows, configure type and identifier, verify changes persist
- [ ] Save the flow and verify `executor.inputs[]` in the flow JSON
- [ ] Re-open the flow and verify inputs load back into the editor
- [ ] Verify OAuth/Consent executors do not show the inputs editor
- [ ] Verify flows without custom inputs still work with executor defaults

Closes #2453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dynamic Executor Inputs editor allowing add/remove and per-input configuration (type, identifier, required) directly in the executor properties panel.
* **Improvements**
  * Preserve pre-configured executor inputs to avoid accidental overrides; unified rendering of executor-specific properties with inline inputs editor where applicable.
* **Tests**
  * Added comprehensive tests for the inputs editor and updated executor-property tests to reflect new behavior.
* **Localization**
  * Added translations for the executor inputs UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->