### PR TITLE
Remove Type/Task from PR mandatory labels

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -27,7 +27,6 @@ jobs:
                 'Type/New Feature',
                 'Type/Improvement',
                 'Type/Bug',
-                'Type/Task',
                 'skip-changelog'
             ];
 


### PR DESCRIPTION
### Purpose
$subject as PR mandatory labels are only intended for change-list categorizations. A changelog PR has to be categorized as feature, improvement or bug fixing. There's no list for tasks. Otherwise such PRs will not appear in changelog.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request label validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->