### PR TITLE
Validate user attributes with user types

### DIFF
--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -137,6 +137,11 @@ $customerUserTypeData = ([ordered]@{
             displayName = "Last Name"
             required = $false
         }
+        name = @{
+            type = "string"
+            displayName = "Full Name"
+            required = $false
+        }
         mobileNumber = @{
             type = "string"
             displayName = "Mobile Number"

--- a/backend/cmd/server/bootstrap/02-sample-resources.sh
+++ b/backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -123,6 +123,11 @@ read -r -d '' CUSTOMER_USER_TYPE_PAYLOAD <<JSON || true
       "displayName": "Last Name",
       "required": false
     },
+    "name": {
+      "type": "string",
+      "displayName": "Full Name",
+      "required": false
+    },
     "mobileNumber": {
       "type": "string",
       "displayName": "Mobile Number",

--- a/backend/internal/application/error_constants.go
+++ b/backend/internal/application/error_constants.go
@@ -474,4 +474,18 @@ var (
 			DefaultValue: "An application may have at most one inbound auth config per protocol",
 		},
 	}
+	// ErrorInvalidUserAttribute is the error returned when a user attribute is not valid for any
+	// of the application's allowed user types.
+	ErrorInvalidUserAttribute = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "APP-1035",
+		Error: core.I18nMessage{
+			Key:          "error.applicationservice.invalid_user_attribute",
+			DefaultValue: "Invalid user attribute",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.applicationservice.invalid_user_attribute_description",
+			DefaultValue: "One or more user attributes are not valid for the configured allowed user types",
+		},
+	}
 )

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -1228,6 +1228,8 @@ func translateInboundClientFKError(err error) *serviceerror.ServiceError {
 		return &ErrorInvalidUserType
 	case errors.Is(err, inboundclient.ErrUserSchemaLookupFailed):
 		return &serviceerror.InternalServerError
+	case errors.Is(err, inboundclient.ErrInvalidUserAttribute):
+		return &ErrorInvalidUserAttribute
 	default:
 		return nil
 	}

--- a/backend/internal/inboundclient/error_constants.go
+++ b/backend/internal/inboundclient/error_constants.go
@@ -62,6 +62,8 @@ var (
 	// while validating allowed user types. Distinct from ErrFKInvalidUserType so the handler
 	// can map it to a server error instead of a client validation error.
 	ErrUserSchemaLookupFailed = errors.New("user schema lookup failed")
+	// ErrInvalidUserAttribute is returned when a user attribute is not valid for any of the allowed user types.
+	ErrInvalidUserAttribute = errors.New("invalid user attribute")
 
 	// ErrOAuthInvalidRedirectURI is returned when the redirect URI is invalid.
 	ErrOAuthInvalidRedirectURI = errors.New("invalid redirect URI")

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -133,6 +133,10 @@ func (s *inboundClientService) CreateInboundClient(ctx context.Context, client *
 	if fkErr := s.validateFKs(ctx, client); fkErr != nil {
 		return fkErr
 	}
+	if err := s.validateUserAttributesAgainstAllowedTypes(
+		ctx, client.AllowedUserTypes, client.Assertion, oauthProfile); err != nil {
+		return err
+	}
 	if oauthProfile != nil {
 		if vErr := validateOAuthProfile(oauthProfile, hasClientSecret); vErr != nil {
 			return vErr
@@ -202,6 +206,10 @@ func (s *inboundClientService) UpdateInboundClient(ctx context.Context, client *
 	if fkErr := s.validateFKs(ctx, client); fkErr != nil {
 		return fkErr
 	}
+	if err := s.validateUserAttributesAgainstAllowedTypes(
+		ctx, client.AllowedUserTypes, client.Assertion, oauthProfile); err != nil {
+		return err
+	}
 	if oauthProfile != nil {
 		if vErr := validateOAuthProfile(oauthProfile, hasClientSecret); vErr != nil {
 			return vErr
@@ -264,6 +272,10 @@ func (s *inboundClientService) Validate(ctx context.Context, client *inboundmode
 	}
 	if fkErr := s.validateFKs(ctx, client); fkErr != nil {
 		return fkErr
+	}
+	if err := s.validateUserAttributesAgainstAllowedTypes(
+		ctx, client.AllowedUserTypes, client.Assertion, oauthProfile); err != nil {
+		return err
 	}
 	if oauthProfile != nil {
 		if vErr := validateOAuthProfile(oauthProfile, hasClientSecret); vErr != nil {
@@ -996,6 +1008,100 @@ func (s *inboundClientService) validateAllowedUserTypes(
 		}
 	}
 	return nil
+}
+
+// validateUserAttributesAgainstAllowedTypes validates that every user attribute specified in the
+// assertion, token, and userinfo configs is a non-credential attribute defined in at least one
+// of the application's allowed entity types. Returns ErrInvalidUserAttribute when any attribute
+// fails the check.
+func (s *inboundClientService) validateUserAttributesAgainstAllowedTypes(
+	ctx context.Context,
+	allowedEntityTypes []string,
+	assertion *inboundmodel.AssertionConfig,
+	oauthProfile *inboundmodel.OAuthProfile,
+) error {
+	if len(allowedEntityTypes) == 0 || s.entityType == nil {
+		return nil
+	}
+
+	attrs := collectConfiguredUserAttributes(assertion, oauthProfile)
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	validAttrs := make(map[string]bool)
+	for _, entityTypeName := range allowedEntityTypes {
+		attrInfos, svcErr := s.entityType.GetNonCredentialAttributes(
+			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, entityTypeName, false)
+		if svcErr != nil {
+			if svcErr.Type == serviceerror.ServerErrorType {
+				return ErrUserSchemaLookupFailed
+			}
+			return ErrFKInvalidUserType
+		}
+		for _, info := range attrInfos {
+			validAttrs[info.Attribute] = true
+		}
+	}
+
+	for attr := range attrs {
+		if isComputedAttribute(attr) {
+			continue
+		}
+		if !validAttrs[attr] {
+			return ErrInvalidUserAttribute
+		}
+	}
+	return nil
+}
+
+// isComputedAttribute returns true for attributes that are derived at runtime (e.g. from group
+// memberships or OU associations) and are not defined in the entity type schema.
+func isComputedAttribute(attr string) bool {
+	switch attr {
+	case oauth2const.UserAttributeGroups,
+		oauth2const.UserAttributeRoles,
+		oauth2const.ClaimOUID,
+		oauth2const.ClaimOUName,
+		oauth2const.ClaimOUHandle,
+		oauth2const.ClaimUserType:
+		return true
+	}
+	return false
+}
+
+// collectConfiguredUserAttributes returns the distinct set of user attribute names explicitly
+// configured across assertion, access token, ID token, and userinfo configs.
+func collectConfiguredUserAttributes(
+	assertion *inboundmodel.AssertionConfig,
+	oauthProfile *inboundmodel.OAuthProfile,
+) map[string]bool {
+	attrs := make(map[string]bool)
+	if assertion != nil {
+		for _, a := range assertion.UserAttributes {
+			attrs[a] = true
+		}
+	}
+	if oauthProfile != nil {
+		if oauthProfile.Token != nil {
+			if oauthProfile.Token.AccessToken != nil {
+				for _, a := range oauthProfile.Token.AccessToken.UserAttributes {
+					attrs[a] = true
+				}
+			}
+			if oauthProfile.Token.IDToken != nil {
+				for _, a := range oauthProfile.Token.IDToken.UserAttributes {
+					attrs[a] = true
+				}
+			}
+		}
+		if oauthProfile.UserInfo != nil {
+			for _, a := range oauthProfile.UserInfo.UserAttributes {
+				attrs[a] = true
+			}
+		}
+	}
+	return attrs
 }
 
 // applyInboundDefaults fills default values for assertion, OAuth tokens, user info, and scope claims.

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -70,9 +70,9 @@ func newServiceWithCert(certService cert.CertificateServiceInterface) *inboundCl
 	return svc.(*inboundClientService)
 }
 
-func validInboundClient(id string) inboundmodel.InboundClient {
+func validInboundClient() inboundmodel.InboundClient {
 	return inboundmodel.InboundClient{
-		ID:                        id,
+		ID:                        "p1",
 		AuthFlowID:                "flow-1",
 		RegistrationFlowID:        "reg-1",
 		IsRegistrationFlowEnabled: true,
@@ -80,11 +80,20 @@ func validInboundClient(id string) inboundmodel.InboundClient {
 }
 
 func ptrInboundClient() *inboundmodel.InboundClient {
-	c := validInboundClient("p1")
+	c := validInboundClient()
 	return &c
 }
 
 func validOAuthProfile() *inboundmodel.OAuthProfile {
+	return &inboundmodel.OAuthProfile{
+		RedirectURIs:            []string{"https://app.example.com/cb"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+	}
+}
+
+func validOAuthProfileData() *inboundmodel.OAuthProfile {
 	return &inboundmodel.OAuthProfile{
 		RedirectURIs:            []string{"https://app.example.com/cb"},
 		GrantTypes:              []string{"authorization_code"},
@@ -165,7 +174,7 @@ func (suite *InboundClientServiceTestSuite) TestDeleteInboundClient_RefusesDecla
 func (suite *InboundClientServiceTestSuite) TestDelegatesPlainReads() {
 	store := newInboundClientStoreInterfaceMock(suite.T())
 	store.EXPECT().GetInboundClientList(mock.Anything, mock.Anything).
-		Return([]inboundmodel.InboundClient{validInboundClient("p1")}, nil)
+		Return([]inboundmodel.InboundClient{validInboundClient()}, nil)
 	store.EXPECT().IsDeclarative(mock.Anything, "p1").Return(true)
 
 	svc := newServiceForTest(store)
@@ -1703,4 +1712,315 @@ func (suite *InboundClientServiceTestSuite) TestGetOAuthClientByClientID_StoreEr
 	got, err := svc.GetOAuthClientByClientID(context.Background(), "x")
 	assert.ErrorIs(suite.T(), err, storeErr)
 	assert.Nil(suite.T(), got)
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_AllNil() {
+	out := collectConfiguredUserAttributes(nil, nil)
+	assert.Empty(suite.T(), out)
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_AssertionOnly() {
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "name"}}
+	out := collectConfiguredUserAttributes(assertion, nil)
+	assert.Len(suite.T(), out, 2)
+	assert.True(suite.T(), out["email"])
+	assert.True(suite.T(), out["name"])
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_AccessTokenOnly() {
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			AccessToken: &inboundmodel.AccessTokenConfig{UserAttributes: []string{"email"}},
+		},
+	}
+	out := collectConfiguredUserAttributes(nil, p)
+	assert.Len(suite.T(), out, 1)
+	assert.True(suite.T(), out["email"])
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_IDTokenOnly() {
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			IDToken: &inboundmodel.IDTokenConfig{UserAttributes: []string{"sub"}},
+		},
+	}
+	out := collectConfiguredUserAttributes(nil, p)
+	assert.Len(suite.T(), out, 1)
+	assert.True(suite.T(), out["sub"])
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_UserInfoOnly() {
+	p := &inboundmodel.OAuthProfile{
+		UserInfo: &inboundmodel.UserInfoConfig{UserAttributes: []string{"phone"}},
+	}
+	out := collectConfiguredUserAttributes(nil, p)
+	assert.Len(suite.T(), out, 1)
+	assert.True(suite.T(), out["phone"])
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_DedupsAcrossAllSources() {
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			AccessToken: &inboundmodel.AccessTokenConfig{UserAttributes: []string{"email", "name"}},
+			IDToken:     &inboundmodel.IDTokenConfig{UserAttributes: []string{"name", "phone"}},
+		},
+		UserInfo: &inboundmodel.UserInfoConfig{UserAttributes: []string{"email", "picture"}},
+	}
+	out := collectConfiguredUserAttributes(assertion, p)
+	assert.Len(suite.T(), out, 4)
+	assert.True(suite.T(), out["email"])
+	assert.True(suite.T(), out["name"])
+	assert.True(suite.T(), out["phone"])
+	assert.True(suite.T(), out["picture"])
+}
+
+func (suite *InboundClientServiceTestSuite) TestCollectConfiguredUserAttributes_NilSubFields() {
+	p := &inboundmodel.OAuthProfile{
+		Token:    &inboundmodel.OAuthTokenConfig{},
+		UserInfo: nil,
+	}
+	out := collectConfiguredUserAttributes(nil, p)
+	assert.Empty(suite.T(), out)
+}
+
+// ----- validateUserAttributesAgainstAllowedTypes -----
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_NoOpWhenNoAllowedTypes() {
+	svc := &inboundClientService{}
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), nil, assertion, nil))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_NoOpWhenNoEntityTypeService() {
+	svc := &inboundClientService{}
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, assertion, nil))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_NoOpWhenNoAttributesConfigured() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, nil))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAssertionAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}, {Attribute: "name"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, assertion, nil))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAssertionAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"banana"}}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, assertion, nil), ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ValidAccessTokenAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			AccessToken: &inboundmodel.AccessTokenConfig{UserAttributes: []string{"email"}},
+		},
+	}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, p))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidAccessTokenAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			AccessToken: &inboundmodel.AccessTokenConfig{UserAttributes: []string{"unknown_attr"}},
+		},
+	}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, p), ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidIDTokenAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			IDToken: &inboundmodel.IDTokenConfig{UserAttributes: []string{"ghost"}},
+		},
+	}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, p), ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_InvalidUserInfoAttribute() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	p := &inboundmodel.OAuthProfile{
+		UserInfo: &inboundmodel.UserInfoConfig{UserAttributes: []string{"ghost"}},
+	}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, p), ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ClientErrorMapsToFKError() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return(nil, &serviceerror.ServiceError{Type: serviceerror.ClientErrorType, Code: "ERR"})
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, assertion, nil), ErrFKInvalidUserType)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ServerErrorMapsToLookupFailed() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return(nil, &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "SRV"})
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email"}}
+	assert.ErrorIs(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, assertion, nil), ErrUserSchemaLookupFailed)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_UnionAcrossMultipleTypes() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "contractor", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "agency_name"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	// "agency_name" only exists in contractor — still valid because union semantics are used.
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "agency_name"}}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee", "contractor"}, assertion, nil))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_ComputedAttributesSkipSchemaCheck() {
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
+
+	// Computed attributes (groups, roles, ouId, ouName, ouHandle, userType) are derived at runtime
+	// and are not in the entity schema — they must be accepted without failing validation.
+	p := &inboundmodel.OAuthProfile{
+		Token: &inboundmodel.OAuthTokenConfig{
+			AccessToken: &inboundmodel.AccessTokenConfig{
+				UserAttributes: []string{"email", "groups", "ouId", "ouName", "ouHandle", "roles", "userType"},
+			},
+			IDToken: &inboundmodel.IDTokenConfig{
+				UserAttributes: []string{"groups", "ouId"},
+			},
+		},
+		UserInfo: &inboundmodel.UserInfoConfig{
+			UserAttributes: []string{"groups", "roles"},
+		},
+	}
+	assert.NoError(suite.T(), svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"employee"}, nil, p))
+}
+
+// ----- CreateInboundClient / UpdateInboundClient / Validate — user attribute validation wired in -----
+
+func (suite *InboundClientServiceTestSuite) TestCreateInboundClient_RejectsInvalidUserAttribute() {
+	store := newInboundClientStoreInterfaceMock(suite.T())
+	store.EXPECT().IsDeclarative(mock.Anything, "p1").Return(false)
+
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	// validateAllowedUserTypes (called by validateFKs) checks entity type existence via GetEntityTypeList.
+	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
+		&entitytypepkg.EntityTypeListResponse{
+			TotalResults: 1,
+			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+		}, nil)
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+
+	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)
+
+	c := validInboundClient()
+	c.AllowedUserTypes = []string{"employee"}
+	c.Assertion = &inboundmodel.AssertionConfig{UserAttributes: []string{"not_a_real_attr"}}
+
+	err := svc.CreateInboundClient(context.Background(), &c, nil, nil, false, "")
+	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_RejectsInvalidUserAttribute() {
+	store := newInboundClientStoreInterfaceMock(suite.T())
+	store.EXPECT().IsDeclarative(mock.Anything, "p1").Return(false)
+
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	// validateAllowedUserTypes (called by validateFKs) checks entity type existence via GetEntityTypeList.
+	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
+		&entitytypepkg.EntityTypeListResponse{
+			TotalResults: 1,
+			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+		}, nil)
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+
+	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)
+
+	c := validInboundClient()
+	c.AllowedUserTypes = []string{"employee"}
+	p := validOAuthProfileData()
+	p.UserInfo = &inboundmodel.UserInfoConfig{UserAttributes: []string{"ghost"}}
+
+	err := svc.UpdateInboundClient(context.Background(), &c, nil, p, true, "", "")
+	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidate_RejectsInvalidUserAttribute() {
+	store := newInboundClientStoreInterfaceMock(suite.T())
+
+	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	// validateAllowedUserTypes (called by validateFKs) checks entity type existence via GetEntityTypeList.
+	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
+		&entitytypepkg.EntityTypeListResponse{
+			TotalResults: 1,
+			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+		}, nil)
+	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+
+	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us, nil)
+
+	c := validInboundClient()
+	c.AllowedUserTypes = []string{"employee"}
+	p := validOAuthProfileData()
+	p.Token = &inboundmodel.OAuthTokenConfig{
+		AccessToken: &inboundmodel.AccessTokenConfig{UserAttributes: []string{"bad_attr"}},
+	}
+
+	err := svc.Validate(context.Background(), &c, p, true)
+	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -174,6 +174,8 @@ var defaultMessages = map[string]string{
 	"error.applicationservice.invalid_response_type_description": "One or more provided response types are invalid",
 	"error.applicationservice.invalid_token_endpoint_auth_method": "Invalid token endpoint authentication method",
 	"error.applicationservice.invalid_token_endpoint_auth_method_description": "The provided token endpoint authentication method is invalid",
+	"error.applicationservice.invalid_user_attribute": "Invalid user attribute",
+	"error.applicationservice.invalid_user_attribute_description": "One or more user attributes are not valid for the configured allowed user types",
 	"error.applicationservice.invalid_user_type": "Invalid user type",
 	"error.applicationservice.invalid_user_type_description": "One or more user types in allowed_user_types do not exist in the system",
 	"error.applicationservice.layout_not_found": "Layout not found",

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -276,7 +276,7 @@ func (ts *UserInfoTestSuite) createTestApplication(authFlowID string) string {
 					"scopes":                  []string{"openid", "profile", "email"},
 					"token": map[string]interface{}{
 						"idToken": map[string]interface{}{
-							"userAttributes": []string{"email", "given_name", "family_name", "name"},
+							"userAttributes": []string{"email", "given_name", "family_name"},
 						},
 					},
 					"scopeClaims": map[string][]string{


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request validate the user attributes contains in the application creation/update in the assertion, accessToken, idToken, userInfo user attributes with the application allowed user types.

- Now the application creation/update requests with the invalid user attributes will return 400 with below response.

```
{
    "code": "APP-1033",
    "message": {
        "key": "error.applicationservice.invalid_user_attribute",
        "defaultValue": "Invalid user attribute"
    },
    "description": {
        "key": "error.applicationservice.invalid_user_attribute_description",
        "defaultValue": "One or more user attributes are not valid for the configured allowed user types"
    }
}
```

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
- Validation has been introduced in the inbound client to validate the user attributes contained in the request with the allowed user types.
- To perform the validation unque user attribute list will be created combining all assertion, accessToken, idToken and userInfor user attributes.

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2583

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validate that inbound client user attributes are permitted by configured allowed user types.
  * Sample data now includes a non-required "Full Name" user attribute for Customer.

* **Bug Fixes**
  * Return a distinct error when user attributes are invalid and surface clearer error text.

* **Tests**
  * Added unit and integration tests covering user-attribute validation and error mapping.

* **Localization**
  * Added i18n messages for the new invalid-user-attribute error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->