### PR TITLE
Update codecov informational config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -68,7 +68,7 @@ coverage:
         enabled: true
         target: auto
         threshold: 1%
-        informational: true
+        informational: false
       backend-unit:
         flags:
           - backend-unit
@@ -105,7 +105,7 @@ coverage:
       default:
         target: 80%
         threshold: 1%
-        informational: true
+        informational: false
 
 ignore:
   - "backend/tests/**"


### PR DESCRIPTION
### Purpose
This pull request updates the Codecov configuration to change how coverage thresholds are reported. The main change is that coverage results are no longer marked as informational, which means coverage failures can now affect pull request status checks.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Codecov configuration so coverage status checks are non-informational (now enforced) for both project and patch coverage, ensuring these coverage checks are treated as required rather than informational during verification processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->