### PR TITLE
Add support for wildcards in the host component of registered redirect URIs

### DIFF
--- a/backend/internal/inboundclient/model/oauth_test.go
+++ b/backend/internal/inboundclient/model/oauth_test.go
@@ -593,3 +593,53 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_WildcardDisabl
 	)
 	suite.Error(err)
 }
+
+func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardEnabled_Matches() {
+	sysconfig.ResetServerRuntime()
+	cfg := &sysconfig.Config{}
+	cfg.OAuth.AllowWildcardRedirectURI = true
+	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
+
+	err := model.ValidateRedirectURI(
+		[]string{"https://tenant-app-*-*.gateway.example.com/cb"},
+		"https://tenant-app-019dfc78-f19ab4f2.gateway.example.com/cb",
+	)
+	suite.NoError(err)
+}
+
+func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardEnabled_NonMatchingDynamicPart() {
+	sysconfig.ResetServerRuntime()
+	cfg := &sysconfig.Config{}
+	cfg.OAuth.AllowWildcardRedirectURI = true
+	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
+
+	// Hyphen inside the dynamic part is not in [0-9a-zA-Z]+, so this must fail.
+	err := model.ValidateRedirectURI(
+		[]string{"https://app-*-prod.example.com/cb"},
+		"https://app-foo-bar-prod.example.com/cb",
+	)
+	suite.Error(err)
+}
+
+func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardDisabled_NoMatch() {
+	// Default: AllowWildcardRedirectURI = false. Note the pattern would never have made it
+	// past registration with the flag off, but we still verify the matcher returns no match.
+	err := model.ValidateRedirectURI(
+		[]string{"https://app-*.example.com/cb"},
+		"https://app-prod.example.com/cb",
+	)
+	suite.Error(err)
+}
+
+func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardDoesNotCrossDot() {
+	sysconfig.ResetServerRuntime()
+	cfg := &sysconfig.Config{}
+	cfg.OAuth.AllowWildcardRedirectURI = true
+	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
+
+	err := model.ValidateRedirectURI(
+		[]string{"https://app-*.example.com/cb"},
+		"https://app-foo.evil.example.com/cb",
+	)
+	suite.Error(err)
+}

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -739,8 +739,14 @@ func validateRedirectURIs(p *inboundmodel.OAuthProfile) error {
 		if parsedURI.Fragment != "" {
 			return ErrOAuthRedirectURIFragmentNotAllowed
 		}
+		wildcardEnabled := config.GetServerRuntime().Config.OAuth.AllowWildcardRedirectURI
 		if strings.ContainsRune(parsedURI.Host, '*') {
-			return ErrOAuthInvalidRedirectURI
+			if !wildcardEnabled {
+				return ErrOAuthInvalidRedirectURI
+			}
+			if err := validateHostWildcardPattern(parsedURI.Host); err != nil {
+				return err
+			}
 		}
 		if strings.ContainsRune(parsedURI.RawQuery, '*') {
 			return ErrOAuthInvalidRedirectURI
@@ -748,7 +754,6 @@ func validateRedirectURIs(p *inboundmodel.OAuthProfile) error {
 		if containsInvalidWildcardSegment(parsedURI.Path) {
 			return ErrOAuthInvalidRedirectURI
 		}
-		wildcardEnabled := config.GetServerRuntime().Config.OAuth.AllowWildcardRedirectURI
 		if strings.ContainsRune(parsedURI.Path, '*') && !wildcardEnabled {
 			return ErrOAuthInvalidRedirectURI
 		}
@@ -756,6 +761,24 @@ func validateRedirectURIs(p *inboundmodel.OAuthProfile) error {
 	if slices.Contains(p.GrantTypes, string(oauth2const.GrantTypeAuthorizationCode)) &&
 		len(p.RedirectURIs) == 0 {
 		return ErrOAuthAuthCodeRequiresRedirectURIs
+	}
+	return nil
+}
+
+// validateHostWildcardPattern enforces structural rules for wildcards in the host
+// component: no * in the port portion of host:port, and no whole-label *. * matches one
+// or more alphanumeric characters at match time, enforced by the matcher itself.
+func validateHostWildcardPattern(host string) error {
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		if strings.ContainsRune(host[i+1:], '*') {
+			return ErrOAuthInvalidRedirectURI
+		}
+		host = host[:i]
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "*" {
+			return ErrOAuthInvalidRedirectURI
+		}
 	}
 	return nil
 }

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -1149,6 +1149,82 @@ func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_QueryWildca
 	assert.ErrorIs(suite.T(), validateRedirectURIs(p), ErrOAuthInvalidRedirectURI)
 }
 
+// ----- Host wildcard registration with allow_wildcard_redirect_uri = true -----
+
+func (suite *InboundClientServiceTestSuite) enableWildcardConfig() {
+	sysconfig.ResetServerRuntime()
+	cfg := &sysconfig.Config{}
+	cfg.OAuth.AllowWildcardRedirectURI = true
+	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardLabelInternal_Accepted() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs:  []string{"https://tenant-app-*-*.gateway.example.com/cb"},
+		GrantTypes:    []string{"authorization_code"},
+		ResponseTypes: []string{"code"},
+	}
+	assert.NoError(suite.T(), validateRedirectURIs(p))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardSimplePattern_Accepted() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs:  []string{"https://app-*.example.com/cb"},
+		GrantTypes:    []string{"authorization_code"},
+		ResponseTypes: []string{"code"},
+	}
+	assert.NoError(suite.T(), validateRedirectURIs(p))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardWholeLabel_Rejected() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs: []string{"https://*.example.com/cb"},
+		GrantTypes:   []string{"authorization_code"},
+	}
+	assert.ErrorIs(suite.T(), validateRedirectURIs(p), ErrOAuthInvalidRedirectURI)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardInPort_Rejected() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs: []string{"https://app.example.com:80*0/cb"},
+		GrantTypes:   []string{"authorization_code"},
+	}
+	assert.ErrorIs(suite.T(), validateRedirectURIs(p), ErrOAuthInvalidRedirectURI)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardWithPort_Accepted() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs:  []string{"https://app-*.example.com:8443/cb"},
+		GrantTypes:    []string{"authorization_code"},
+		ResponseTypes: []string{"code"},
+	}
+	assert.NoError(suite.T(), validateRedirectURIs(p))
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardFlagOff_Rejected() {
+	// SetupTest already initializes with AllowWildcardRedirectURI = false.
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs: []string{"https://app-*.example.com/cb"},
+		GrantTypes:   []string{"authorization_code"},
+	}
+	assert.ErrorIs(suite.T(), validateRedirectURIs(p), ErrOAuthInvalidRedirectURI)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HostWildcardMixedWithPath_Accepted() {
+	suite.enableWildcardConfig()
+	p := &inboundmodel.OAuthProfile{
+		RedirectURIs:  []string{"https://app-*.example.com/cb/*"},
+		GrantTypes:    []string{"authorization_code"},
+		ResponseTypes: []string{"code"},
+	}
+	assert.NoError(suite.T(), validateRedirectURIs(p))
+}
+
 func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_MissingSchemeRejected() {
 	p := &inboundmodel.OAuthProfile{
 		RedirectURIs: []string{"//app/cb"},

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -69,11 +69,12 @@ func ParseURL(urlStr string) (*url.URL, error) {
 }
 
 // MatchURIPattern reports whether incoming matches pattern.
-// pattern may contain * (exactly one path segment) or ** (zero or more path segments)
-// only in the path component. Scheme, host, and query must match exactly (case-insensitive
-// scheme and host per RFC 3986). Both paths are cleaned (resolving . and .. segments)
-// before matching to prevent path traversal. Returns (false, error) for malformed inputs,
-// (false, nil) for no match, (true, nil) for a match.
+// In the path component, * matches exactly one segment and ** matches zero or more segments.
+// In the host component, * matches one or more alphanumeric characters within a single
+// DNS label and does not cross label boundaries. Scheme and host comparison is
+// case-insensitive; query must match exactly. Paths are cleaned (resolving . and ..
+// segments) before matching to prevent path traversal. Returns (false, error) for malformed
+// inputs, (false, nil) for no match, (true, nil) for a match.
 func MatchURIPattern(pattern, incoming string) (bool, error) {
 	patternURL, err := url.Parse(pattern)
 	if err != nil || patternURL.Scheme == "" || patternURL.Host == "" {
@@ -87,7 +88,7 @@ func MatchURIPattern(pattern, incoming string) (bool, error) {
 	if !strings.EqualFold(patternURL.Scheme, incomingURL.Scheme) {
 		return false, nil
 	}
-	if !strings.EqualFold(patternURL.Host, incomingURL.Host) {
+	if !matchHostPattern(patternURL.Host, incomingURL.Host) {
 		return false, nil
 	}
 	if patternURL.RawQuery != incomingURL.RawQuery {
@@ -97,6 +98,68 @@ func MatchURIPattern(pattern, incoming string) (bool, error) {
 		return false, nil
 	}
 	return matchPathPattern(path.Clean(patternURL.Path), path.Clean(incomingURL.Path)), nil
+}
+
+// matchHostPattern matches incoming host against pattern host. * in the pattern matches
+// one or more alphanumeric characters within a single DNS label. Comparison is
+// case-insensitive. When the pattern contains no *, this is equivalent to strings.EqualFold.
+func matchHostPattern(pattern, incoming string) bool {
+	if !strings.ContainsRune(pattern, '*') {
+		return strings.EqualFold(pattern, incoming)
+	}
+	pattern = strings.ToLower(pattern)
+	incoming = strings.ToLower(incoming)
+	pLabels := strings.Split(pattern, ".")
+	iLabels := strings.Split(incoming, ".")
+	if len(pLabels) != len(iLabels) {
+		return false
+	}
+	for k := range pLabels {
+		if !matchHostLabel(pLabels[k], iLabels[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchHostLabel matches a single host label. * in the pattern matches one or more
+// alphanumeric chars (a-z, 0-9). Both inputs must already be lowercased.
+func matchHostLabel(pat, inc string) bool {
+	return matchHostLabelImpl(pat, inc, 0, 0)
+}
+
+// matchHostLabelImpl is the recursive backtracking matcher for matchHostLabel.
+// pi and ii are the current positions in pat and inc respectively. * is greedy with
+// backtracking so adjacent literals like *foo can match correctly.
+func matchHostLabelImpl(pat, inc string, pi, ii int) bool {
+	for pi < len(pat) {
+		if pat[pi] == '*' {
+			j := ii
+			for j < len(inc) && isHostAlphaNum(inc[j]) {
+				j++
+			}
+			// * must consume at least one character; try the longest match first then backtrack.
+			for k := j; k > ii; k-- {
+				if matchHostLabelImpl(pat, inc, pi+1, k) {
+					return true
+				}
+			}
+			return false
+		}
+		if ii >= len(inc) || pat[pi] != inc[ii] {
+			return false
+		}
+		pi++
+		ii++
+	}
+	return ii == len(inc)
+}
+
+// isHostAlphaNum reports whether the byte is a lowercase letter or a digit.
+// The host matcher lowercases its inputs before comparing, so this is the full
+// character class consumed by * within a host label.
+func isHostAlphaNum(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z')
 }
 
 // matchPathPattern reports whether incomingPath matches patternPath.

--- a/backend/internal/system/utils/http_util_test.go
+++ b/backend/internal/system/utils/http_util_test.go
@@ -1034,6 +1034,79 @@ func (suite *HTTPUtilTestSuite) TestMatchURIPattern() {
 			incoming:  "https://example.com/app/%2e%2e/admin",
 			wantMatch: false,
 		},
+		// Host wildcard cases: * matches one or more alphanumeric chars within a single label.
+		{
+			name:      "HostWildcardLabelInternal",
+			pattern:   "https://tenant-app-*-*.gateway.example.com",
+			incoming:  "https://tenant-app-019dfc78-f19ab4f2.gateway.example.com",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardCaseInsensitive",
+			pattern:   "https://foo-*-bar.example.com",
+			incoming:  "https://FOO-AbCd-Bar.EXAMPLE.com",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardDoesNotCrossDot",
+			pattern:   "https://foo-*-bar.example.com",
+			incoming:  "https://foo-x.y-bar.example.com",
+			wantMatch: false,
+		},
+		{
+			name:      "HostWildcardDoesNotMatchHyphenInDynamic",
+			pattern:   "https://foo-*-bar.example.com",
+			incoming:  "https://foo-a-b-bar.example.com",
+			wantMatch: false,
+		},
+		{
+			name:      "HostWildcardLabelCountMismatch",
+			pattern:   "https://*-app.example.com",
+			incoming:  "https://x-app.dev.example.com",
+			wantMatch: false,
+		},
+		{
+			name:      "HostWildcardSingleStarRequiresAtLeastOneChar",
+			pattern:   "https://prefix-*.example.com",
+			incoming:  "https://prefix-.example.com",
+			wantMatch: false,
+		},
+		{
+			name:      "HostWildcardWithPath",
+			pattern:   "https://app-*.example.com/cb/*",
+			incoming:  "https://app-prod.example.com/cb/v1",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardAdjacentLiteralBacktrack",
+			pattern:   "https://*foo.example.com",
+			incoming:  "https://abcfoo.example.com",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardAdjacentLiteralNoMatch",
+			pattern:   "https://*foo.example.com",
+			incoming:  "https://abcbar.example.com",
+			wantMatch: false,
+		},
+		{
+			name:      "HostNoWildcardFastPath",
+			pattern:   "https://example.com/cb",
+			incoming:  "https://EXAMPLE.com/cb",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardWithMatchingPort",
+			pattern:   "https://app-*.example.com:8443/cb",
+			incoming:  "https://app-prod.example.com:8443/cb",
+			wantMatch: true,
+		},
+		{
+			name:      "HostWildcardWithMismatchedPort",
+			pattern:   "https://app-*.example.com:8443/cb",
+			incoming:  "https://app-prod.example.com:8080/cb",
+			wantMatch: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -327,7 +327,7 @@ OAuth 2.0 and OpenID Connect settings.
 | `oauth.refresh_token.validity_period` | `86400` | Refresh token validity period in seconds (24 hours) |
 | `oauth.authorization_code.validity_period` | `600` | Authorization code validity period in seconds (10 minutes) |
 | `oauth.dcr.insecure` | `false` | If `true`, allows insecure dynamic client registration (development only) |
-| `oauth.allow_wildcard_redirect_uri` | `false` | If `true`, allows wildcard patterns (`*`, `**`) in the path component of registered redirect URIs. When `false`, only exact redirect URI matching is performed and registering a wildcard URI returns a `400 Bad Request` error. |
+| `oauth.allow_wildcard_redirect_uri` | `false` | If `true`, allows wildcard patterns in registered redirect URIs: `*` and `**` in the path component, and `*` in the host component (label-internal, alphanumeric only). When `false`, only exact redirect URI matching is performed and registering a wildcard URI returns a `400 Bad Request` error. |
 
 :::note
 Enabling `oauth.allow_wildcard_redirect_uri` affects all applications in the deployment. See [Use Wildcard Redirect URIs](/docs/next/guides/guides/applications/application-settings#use-wildcard-redirect-uris) for pattern syntax and matching rules.

--- a/docs/content/guides/guides/applications/application-settings.mdx
+++ b/docs/content/guides/guides/applications/application-settings.mdx
@@ -28,45 +28,69 @@ Under **Access** on the General tab, you can restrict which users can authentica
 
 ## Use Wildcard Redirect URIs
 
-<ProductName /> supports wildcard patterns in the path component of registered redirect URIs. This lets you register a single pattern that covers a range of valid callback paths, rather than listing every exact URI.
+<ProductName /> supports wildcard patterns in the **path** and **host** components of registered redirect URIs. This lets you register a single pattern that covers a range of valid callbacks, rather than listing every exact URI. The path and host scopes use different wildcard semantics — see the syntax tables below.
 
 :::note
-Wildcard redirect URI support is disabled by default. A <ProductName /> administrator must set `oauth.allow_wildcard_redirect_uri: true` in `deployment.yaml` before you can register wildcard patterns. See [Configuration](/docs/next/guides/getting-started/configuration) for details.
+Wildcard redirect URI support is disabled by default. A <ProductName /> administrator must set `oauth.allow_wildcard_redirect_uri: true` in `deployment.yaml` before you can register wildcard patterns. The same flag enables both path and host wildcards. See [Configuration](/docs/next/guides/getting-started/configuration) for details.
 :::
 
-### Wildcard Syntax
+### Path Wildcard Syntax
+
+In the path, wildcards operate at the level of `/`-delimited segments.
 
 | Wildcard | Matches | Example pattern | Matches | Does not match |
 |----------|---------|-----------------|---------|----------------|
 | `*` | Exactly one path segment (no slashes) | `https://example.com/cb/*` | `https://example.com/cb/v1` | `https://example.com/cb/v1/extra` |
 | `**` | Zero or more path segments | `https://example.com/app/**/cb` | `https://example.com/app/cb`, `https://example.com/app/tenant/region/cb` | `https://example.com/app` (missing trailing `cb`) |
 
+`*` and `**` must appear as complete path segments. Mixed segments such as `/foo*` or `/*bar` are rejected at registration. Full regular expression syntax (e.g., `[a-z]+`) is also rejected.
+
+### Host Wildcard Syntax
+
+In the host, wildcards operate at the level of characters within a single DNS label (between `.` separators).
+
+| Wildcard | Matches | Example pattern | Matches | Does not match |
+|----------|---------|-----------------|---------|----------------|
+| `*` | One or more alphanumeric characters (`[0-9a-zA-Z]+`) within a single label | `https://app-*.example.com/cb` | `https://app-prod.example.com/cb`, `https://app-staging.example.com/cb` | `https://app-foo-bar.example.com/cb` (hyphen inside dynamic part), `https://app-foo.dev.example.com/cb` (dot inside dynamic part) |
+
+You can use multiple `*` wildcards in the same label as long as they are separated by literal characters:
+
+```
+Pattern:  https://tenant-app-*-*.gateway.example.com/cb
+Matches:  https://tenant-app-019dfc78-f19ab4f2.gateway.example.com/cb
+```
+
+`*` in the host matches **only** alphanumeric characters — hyphens, underscores, and dots are not matched by `*`. Register them as literal characters where needed.
+
 ### Wildcard Placement Rules
 
-Wildcards are only permitted in the **path** component of a URI.
+| URI Component | Path Wildcards (`*`, `**`) | Host Wildcards (`*`) |
+|---------------|---------------------------|----------------------|
+| Scheme (e.g., `https`) | No | No |
+| Host / domain | — | Yes — label-internal only (whole-label `*` such as `*.example.com` is rejected) |
+| Port (e.g., `:8443`) | — | No (registering `:80*0` is rejected) |
+| Path (e.g., `/callback`) | Yes | — |
+| Query string (e.g., `?foo=bar`) | No | No |
+| Fragment | Not allowed in redirect URIs | Not allowed in redirect URIs |
 
-| URI Component | Wildcards Allowed |
-|---------------|-------------------|
-| Scheme (e.g., `https`) | No |
-| Host / domain (e.g., `example.com`) | No |
-| Path (e.g., `/callback/*`) | Yes |
-| Query string (e.g., `?foo=bar`) | No |
-| Fragment | Not allowed in redirect URIs |
-
-Only `*` and `**` are supported. Full regular expression syntax (e.g., `[a-z]+`) is rejected.
+A whole-label wildcard such as `https://*.example.com/cb` is rejected at registration; `*` must be flanked by literal characters within the same label.
 
 ### Matching Rules at Authorization Time
 
 When <ProductName /> receives an authorization request, it evaluates the incoming `redirect_uri` against each registered URI in registration order. The first match wins.
 
-- **Scheme and host** must match exactly (case-insensitive per RFC 3986).
+- **Scheme** must match exactly (case-insensitive).
+- **Host** must match the registered host. When the registered host contains `*`, comparison is per-label and case-insensitive; `*` matches one or more alphanumeric characters within a label and never crosses a `.`.
+- **Port** must match exactly.
 - **Query string** must match exactly. A mismatch in query parameters causes the request to be rejected.
 - **Path wildcards** are expanded as described above.
 - If `redirect_uri` is omitted from the request and the single registered URI contains a wildcard, the request is rejected — a wildcard pattern cannot serve as a concrete redirect target.
 
+If a registered redirect URI fails any of these rules at registration time, the request returns `400 Bad Request` with error `APP-1012` (`Invalid redirect URI`).
+
 ### Token Request Behavior
 
-The `redirect_uri` in a token request is always validated with exact matching per [RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3). Wildcard expansion does not apply. The value must exactly match the `redirect_uri` sent in the original authorization request.
+The `redirect_uri` in a token request is always validated with exact matching per [RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3). Wildcard expansion does not apply — neither in the path nor in the host. The value must exactly match the `redirect_uri` sent in the original authorization request.
 
 ### Deep Link Support
 

--- a/tests/integration/oauth/wildcard/host_wildcard_redirect_uri_test.go
+++ b/tests/integration/oauth/wildcard/host_wildcard_redirect_uri_test.go
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package wildcard
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	hostLabelInternalClientID     = "hw_label_internal_client"
+	hostLabelInternalClientSecret = "hw_label_internal_secret"
+	hostMultiStarClientID         = "hw_multi_star_client"
+	hostMultiStarClientSecret     = "hw_multi_star_secret"
+	hostMixedPathClientID         = "hw_mixed_path_client"
+	hostMixedPathClientSecret     = "hw_mixed_path_secret"
+)
+
+// HostWildcardRedirectURITestSuite covers wildcards in the host component of redirect URIs.
+// It requires the server to be started with oauth.allow_wildcard_redirect_uri: true.
+type HostWildcardRedirectURITestSuite struct {
+	suite.Suite
+	client *http.Client
+	ouID   string
+	appIDs []string
+}
+
+func TestHostWildcardRedirectURITestSuite(t *testing.T) {
+	suite.Run(t, new(HostWildcardRedirectURITestSuite))
+}
+
+func (ts *HostWildcardRedirectURITestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "host-wildcard-redirect-uri-test-ou",
+		Name:        "Host Wildcard Redirect URI Test OU",
+		Description: "Organization unit for host wildcard redirect URI integration tests",
+	})
+	ts.Require().NoError(err, "Failed to create organization unit")
+	ts.ouID = ouID
+
+	authzApps := []struct {
+		name         string
+		clientID     string
+		clientSecret string
+		redirectURIs []string
+	}{
+		{
+			name:         "hw-label-internal-app",
+			clientID:     hostLabelInternalClientID,
+			clientSecret: hostLabelInternalClientSecret,
+			redirectURIs: []string{"https://app-*.gateway.example.com/cb"},
+		},
+		{
+			name:         "hw-multi-star-app",
+			clientID:     hostMultiStarClientID,
+			clientSecret: hostMultiStarClientSecret,
+			redirectURIs: []string{"https://tenant-app-*-*.gateway.example.com/cb"},
+		},
+		{
+			name:         "hw-mixed-path-app",
+			clientID:     hostMixedPathClientID,
+			clientSecret: hostMixedPathClientSecret,
+			redirectURIs: []string{"https://app-*.example.com/cb/*"},
+		},
+	}
+
+	for _, app := range authzApps {
+		appID, createErr := ts.createApp(app.name, app.clientID, app.clientSecret, app.redirectURIs)
+		ts.Require().NoError(createErr, "Failed to create app %s", app.name)
+		ts.appIDs = append(ts.appIDs, appID)
+	}
+}
+
+func (ts *HostWildcardRedirectURITestSuite) TearDownSuite() {
+	for _, id := range ts.appIDs {
+		_ = testutils.DeleteApplication(id)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApp posts an application with the given redirect URIs and returns its ID.
+func (ts *HostWildcardRedirectURITestSuite) createApp(name, clientID, clientSecret string, redirectURIs []string) (string, error) {
+	payload := map[string]interface{}{
+		"name": name,
+		"ouId": ts.ouID,
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            redirectURIs,
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"pkceRequired":            false,
+					"publicClient":            false,
+				},
+			},
+		},
+	}
+	return ts.postAppExpectCreated(payload)
+}
+
+// postApplication sends a POST /applications request and returns the raw response.
+// The caller is responsible for closing the response body.
+func (ts *HostWildcardRedirectURITestSuite) postApplication(name string, redirectURIs []string) (*http.Response, error) {
+	payload := map[string]interface{}{
+		"name": name,
+		"ouId": ts.ouID,
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"redirectUris":            redirectURIs,
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payload: %w", err)
+	}
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return ts.client.Do(req)
+}
+
+func (ts *HostWildcardRedirectURITestSuite) postAppExpectCreated(payload map[string]interface{}) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected 201, got %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+	id, ok := result["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("response missing string id field")
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// Registration validation tests
+// ---------------------------------------------------------------------------
+
+// TestHWAC01_HostWildcardLabelInternal_Accepted verifies that a host wildcard placed
+// inside a label between literal characters is accepted at registration.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC01_HostWildcardLabelInternal_Accepted() {
+	resp, err := ts.postApplication("hw-ac01", []string{"https://app-*.example.com/cb"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	ts.Equal(http.StatusCreated, resp.StatusCode, "body=%s", string(respBody))
+
+	var result map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(respBody, &result))
+	if id, _ := result["id"].(string); id != "" {
+		ts.appIDs = append(ts.appIDs, id)
+	}
+}
+
+// TestHWAC02_HostWholeLabelWildcard_Rejected verifies that a whole-label host wildcard
+// (a label that is exactly "*") is rejected at registration.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC02_HostWholeLabelWildcard_Rejected() {
+	resp, err := ts.postApplication("hw-ac02", []string{"https://*.example.com/cb"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHWAC03_HostWildcardInPort_Rejected verifies that a wildcard in the port portion
+// of host:port is rejected at registration.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC03_HostWildcardInPort_Rejected() {
+	resp, err := ts.postApplication("hw-ac03", []string{"https://app.example.com:80*0/cb"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHWAC04_HostWildcardWithExplicitPort_Accepted verifies that a host wildcard pattern
+// with an explicit literal port is accepted at registration.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC04_HostWildcardWithExplicitPort_Accepted() {
+	resp, err := ts.postApplication("hw-ac04", []string{"https://app-*.example.com:8443/cb"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	ts.Equal(http.StatusCreated, resp.StatusCode, "body=%s", string(respBody))
+
+	var result map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(respBody, &result))
+	if id, _ := result["id"].(string); id != "" {
+		ts.appIDs = append(ts.appIDs, id)
+	}
+}
+
+// TestHWAC05_HostWildcardMultipleStars_Accepted verifies that multiple wildcards within
+// a single label, separated by literal characters, are accepted.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC05_HostWildcardMultipleStars_Accepted() {
+	resp, err := ts.postApplication("hw-ac05",
+		[]string{"https://tenant-app-*-*.gateway.example.com/cb"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	ts.Equal(http.StatusCreated, resp.StatusCode, "body=%s", string(respBody))
+
+	var result map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(respBody, &result))
+	if id, _ := result["id"].(string); id != "" {
+		ts.appIDs = append(ts.appIDs, id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Authorization request matching tests
+// ---------------------------------------------------------------------------
+
+// TestHWAC06_LabelInternalWildcard_Matches verifies that a label-internal '*' matches
+// an alphanumeric run within the corresponding incoming label.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC06_LabelInternalWildcard_Matches() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://app-prod.gateway.example.com/cb",
+		"code", "openid", "state_hwac06",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isLoginPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC07_LabelInternalWildcard_RejectsHyphen verifies that hyphens inside the dynamic
+// portion are not matched by '*' (since '*' matches [0-9a-zA-Z]+, no hyphen).
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC07_LabelInternalWildcard_RejectsHyphen() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://app-foo-bar.gateway.example.com/cb",
+		"code", "openid", "state_hwac07",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isErrorPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC08_LabelInternalWildcard_RejectsDotInsideLabel verifies that '*' does not cross
+// label boundaries — a dot inside the dynamic portion forces the match to fail.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC08_LabelInternalWildcard_RejectsDotInsideLabel() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://app-foo.bar.gateway.example.com/cb",
+		"code", "openid", "state_hwac08",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isErrorPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC09_MultipleStarsInLabel_Matches verifies that two wildcards in the same label
+// match alphanumeric runs separated by the literal hyphen.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC09_MultipleStarsInLabel_Matches() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostMultiStarClientID,
+		"https://tenant-app-019dfc78-f19ab4f2.gateway.example.com/cb",
+		"code", "openid", "state_hwac09",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isLoginPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC10_HostWildcardCaseInsensitive_Matches verifies that host comparison remains
+// case-insensitive when wildcards are involved.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC10_HostWildcardCaseInsensitive_Matches() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://APP-PROD.GATEWAY.EXAMPLE.com/cb",
+		"code", "openid", "state_hwac10",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isLoginPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC11_HostAndPathWildcards_Matches verifies that host and path wildcards
+// compose correctly within a single registered URI.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC11_HostAndPathWildcards_Matches() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostMixedPathClientID,
+		"https://app-staging.example.com/cb/v3",
+		"code", "openid", "state_hwac11",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isLoginPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC12_LabelCountMismatch_RedirectsToErrorPage verifies that an incoming host with
+// a different number of labels than the pattern is rejected.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC12_LabelCountMismatch_RedirectsToErrorPage() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://app-prod.dev.gateway.example.com/cb",
+		"code", "openid", "state_hwac12",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	ts.True(isErrorPageRedirect(resp.Header.Get("Location")))
+}
+
+// TestHWAC13_EmptyDynamicPart_RedirectsToErrorPage verifies that '*' requires at least one
+// alphanumeric character — an empty dynamic portion does not match.
+func (ts *HostWildcardRedirectURITestSuite) TestHWAC13_EmptyDynamicPart_RedirectsToErrorPage() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		hostLabelInternalClientID,
+		"https://app-.gateway.example.com/cb",
+		"code", "openid", "state_hwac13",
+	)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	// url.Parse may reject hostnames with consecutive dots; if the request is locally
+	// rejected the server still responds with an error page redirect.
+	ts.Equal(http.StatusFound, resp.StatusCode)
+	loc := resp.Header.Get("Location")
+	ts.True(isErrorPageRedirect(loc) || strings.Contains(loc, "error"))
+}


### PR DESCRIPTION
### Purpose

Adds support for `*` wildcards in the **host** component of registered redirect URIs, complementing the existing path-wildcard support. Gated by the existing `oauth.allow_wildcard_redirect_uri` flag — no new configuration introduced.

This unblocks ephemeral-environment use cases such as Choreo gateway URLs, where the hostname carries dynamic alphanumeric IDs that change per environment:

```
https://tenant-app-019dfc78-f19ab4f2.gateway.example.com/cb
                  └────┬───┘ └────┬───┘
                       *          *
```

A single registered pattern `https://tenant-app-*-*.gateway.example.com/cb` now matches every concrete URL in that family.

### Approach

**Wildcard semantics in the host (different from path):**
- `*` matches `[0-9a-zA-Z]+` — one or more alphanumeric characters
- `*` does not cross DNS label boundaries (a `.` in the input always forces a label-level mismatch)
- `*` does not match `-`, `_`, `.`, or any other delimiter — users must register hyphens explicitly between wildcards
- Comparison is case-insensitive

**Path-wildcard semantics are unchanged:** `*` matches a whole path segment, `**` matches zero or more segments. The two scopes are documented separately.

**Registration guardrails (enforced when the flag is on):**
- Whole-label `*` (e.g. `*.foo.com`) is rejected — a whole-label wildcard meaningfully widens attack surface and is left out of v1
- `*` in the port portion of `host:port` is rejected
- `*` in scheme/query continues to be rejected (unchanged)

**Token endpoint matching unchanged:** strict equality is preserved — the `redirect_uri` in a token request must exactly equal the `redirect_uri` from the original authorization request. Wildcards never apply at the token endpoint.

**Files changed (2 production, 3 unit-test, 1 new integration test):**

| File | Change |
|---|---|
| `backend/internal/system/utils/http_util.go` | Added `matchHostPattern` + `matchHostLabel` + `isHostAlphaNum`. `MatchURIPattern` now delegates host comparison to `matchHostPattern`. Fast path preserved: when pattern has no `*`, falls back to `strings.EqualFold` (no measurable cost). |
| `backend/internal/inboundclient/service.go` | Flag-gated host-`*` rejection in `validateRedirectURIs`. New `validateHostWildcardPattern` enforces structural rules. |
| `backend/internal/system/utils/http_util_test.go` | 12 new test cases for `matchHostPattern` |
| `backend/internal/inboundclient/service_test.go` | 7 new registration validation cases |
| `backend/internal/inboundclient/model/oauth_test.go` | 4 new end-to-end match cases |
| `tests/integration/oauth/wildcard/host_wildcard_redirect_uri_test.go` | New integration suite — 13 acceptance criteria (HWAC01–HWAC13) |

**Backward compatibility:**
- Flag default (`false`) — registration and matching behave exactly as before
- Flag on, no `*` in pattern — `EqualFold` fast path preserved
- Flag on, path-wildcard pattern — unchanged
- Flag on, host-wildcard pattern — new behavior
- Token endpoint — unchanged
- No data migration needed (no host-wildcard URIs could previously exist in storage)

<html><head></head><body><h3>Tested Scenarios</h3>
<h4>Unit tests — <code>matchHostPattern</code> matcher</h4>

Case | Pattern | Incoming | Expected
-- | -- | -- | --
Label-internal multi-* | https://development-thunder-wc-*-*.gateway.dp.dev.cloud.wso2.com | https://development-thunder-wc-019dfc78-f19ab4f2.gateway.dp.dev.cloud.wso2.com | match
Case-insensitive | https://foo-*-bar.example.com | https://FOO-AbCd-Bar.EXAMPLE.com | match
Dot inside dynamic part | https://foo-*-bar.example.com | https://foo-x.y-bar.example.com | no match
Hyphen inside dynamic part | https://foo-*-bar.example.com | https://foo-a-b-bar.example.com | no match
Label count mismatch | https://*-app.example.com | https://x-app.dev.example.com | no match
Empty dynamic part | https://prefix-*.example.com | https://prefix-.example.com | no match (* requires ≥ 1 char)
Host wildcard + path wildcard | https://app-*.example.com/cb/* | https://app-prod.example.com/cb/v1 | match
Adjacent literal (backtrack) | https://*foo.example.com | https://abcfoo.example.com | match
Adjacent literal mismatch | https://*foo.example.com | https://abcbar.example.com | no match
No-wildcard fast path | https://example.com/cb | https://EXAMPLE.com/cb | match (regression)
Matching port | https://app-*.example.com:8443/cb | https://app-prod.example.com:8443/cb | match
Mismatched port | https://app-*.example.com:8443/cb | https://app-prod.example.com:8080/cb | no match


<p>Frontend client-side validator (<code>new URL(uri)</code> in <code>AccessSection.tsx</code>) verified to accept wildcard hostnames without throwing — wildcard URIs pass through to the backend.</p>
<h3>Related Issues</h3>
<ul>
<li>N/A</li>
</ul>
<h3>Related PRs</h3>
<ul>
<li>N/A</li>
</ul>
<h3>Checklist</h3>
<ul>
<li>[x] Followed the contribution guidelines.</li>
<li>[x] Manual test round performed and verified.</li>
<li>[ ] Documentation provided.
<ul>
<li>[ ] Ran Vale and fixed all errors and warnings</li>
</ul>
</li>
<li>[x] Tests provided.
<ul>
<li>[x] Unit Tests</li>
<li>[x] Integration Tests</li>
</ul>
</li>
<li>[ ] Breaking changes.</li>
</ul>
<h3>Security checks</h3>
<ul>
<li>[x] Followed secure coding standards.</li>
<li>[x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.</li>
</ul>
&lt;!-- This is an auto-generated comment: release notes by [coderabbit.ai](http://coderabbit.ai) --&gt;
<h2>Summary by CodeRabbit</h2>
<ul>
<li>
<p><strong>New Features</strong></p>
<ul>
<li>Host-level wildcard support for OAuth redirect URIs, gated by a configuration flag.</li>
<li>Wildcards match dynamic content within a single DNS label (case-insensitive) and must consume at least one character.</li>
</ul>
</li>
<li>
<p><strong>Behavior Changes</strong></p>
<ul>
<li>Wildcards do not span dot boundaries, cannot be a whole-label <code>*</code>, and are disallowed in the port portion.</li>
</ul>
</li>
<li>
<p><strong>Tests</strong></p>
<ul>
<li>Expanded unit and integration tests covering allowlist, matching, and rejection scenarios for host wildcards.</li>
</ul>
</li>
</ul>
&lt;!-- end of auto-generated comment: release notes by [coderabbit.ai](http://coderabbit.ai) --&gt;
<p>This is the tests part you added to the PR description. There are tests listed as regression. Why??</p></body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional wildcard redirect URI support for OAuth applications. When enabled via configuration, applications can use `*` wildcard patterns in the host component to match multiple redirect URIs with restrictions on wildcard placement and content.

* **Documentation**
  * Updated configuration and application settings guides to document host-level wildcard redirect URI behavior, including matching rules and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->