### PR TITLE
Make the encrypt function accept AlgorithmParams pointer

### DIFF
--- a/backend/internal/system/cryptolab/encrypt.go
+++ b/backend/internal/system/cryptolab/encrypt.go
@@ -39,7 +39,10 @@ import (
 //     Returns nil, CryptoDetails{EPK, CEK}, nil. params.ECDHES.ContentEncryptionAlgorithm must be set.
 //   - AlgorithmECDHESA128KW / AlgorithmECDHESA256KW: key must be *ecdsa.PublicKey. content is ignored.
 //     Returns wrappedCEK, CryptoDetails{EPK, CEK}, nil. params.ECDHES.ContentEncryptionAlgorithm must be set.
-func Encrypt(key any, params AlgorithmParams, content []byte) ([]byte, *CryptoDetails, error) {
+func Encrypt(key any, params *AlgorithmParams, content []byte) ([]byte, *CryptoDetails, error) {
+	if params == nil {
+		return nil, nil, errors.New("algorithm params required")
+	}
 	switch params.Algorithm {
 	case AlgorithmAESGCM:
 		aesKey, ok := key.([]byte)
@@ -53,19 +56,19 @@ func Encrypt(key any, params AlgorithmParams, content []byte) ([]byte, *CryptoDe
 		if !ok {
 			return nil, nil, errors.New("RSA-OAEP-256 requires a *rsa.PublicKey")
 		}
-		return encryptRSAOAEP256(rsaPub, params)
+		return encryptRSAOAEP256(rsaPub, *params)
 	case AlgorithmECDHES:
 		ecPub, ok := key.(*ecdsa.PublicKey)
 		if !ok {
 			return nil, nil, errors.New("ECDH-ES requires a *ecdsa.PublicKey")
 		}
-		return encryptECDHES(ecPub, params)
+		return encryptECDHES(ecPub, *params)
 	case AlgorithmECDHESA128KW, AlgorithmECDHESA256KW:
 		ecPub, ok := key.(*ecdsa.PublicKey)
 		if !ok {
 			return nil, nil, fmt.Errorf("%s requires a *ecdsa.PublicKey", params.Algorithm)
 		}
-		return encryptECDHESKW(ecPub, params)
+		return encryptECDHESKW(ecPub, *params)
 	default:
 		return nil, nil, fmt.Errorf("unsupported algorithm: %s", params.Algorithm)
 	}

--- a/backend/internal/system/cryptolab/encryptdecrypt_test.go
+++ b/backend/internal/system/cryptolab/encryptdecrypt_test.go
@@ -53,7 +53,7 @@ func TestAESGCMEncryptDecryptRoundTrip(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ciphertext, details, err := Encrypt(key, params, tc.plaintext)
+			ciphertext, details, err := Encrypt(key, &params, tc.plaintext)
 			require.NoError(t, err)
 			assert.Nil(t, details)
 			assert.NotEmpty(t, ciphertext)
@@ -77,10 +77,10 @@ func TestAESGCMProducesUniqueCiphertexts(t *testing.T) {
 	plaintext := []byte("same plaintext")
 	params := AlgorithmParams{Algorithm: AlgorithmAESGCM}
 
-	ct1, _, err := Encrypt(key, params, plaintext)
+	ct1, _, err := Encrypt(key, &params, plaintext)
 	require.NoError(t, err)
 
-	ct2, _, err := Encrypt(key, params, plaintext)
+	ct2, _, err := Encrypt(key, &params, plaintext)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, ct1, ct2, "Each encryption should produce a unique ciphertext due to random nonce")
@@ -94,7 +94,7 @@ func TestAESGCMTamperDetection(t *testing.T) {
 	plaintext := []byte("tamper test")
 	params := AlgorithmParams{Algorithm: AlgorithmAESGCM}
 
-	ciphertext, _, err := Encrypt(key, params, plaintext)
+	ciphertext, _, err := Encrypt(key, &params, plaintext)
 	require.NoError(t, err)
 
 	// Flip a byte in the ciphertext portion (after nonce)
@@ -129,7 +129,7 @@ func TestAESGCMWrongKeyFails(t *testing.T) {
 
 	params := AlgorithmParams{Algorithm: AlgorithmAESGCM}
 
-	ciphertext, _, err := Encrypt(key1, params, []byte("secret"))
+	ciphertext, _, err := Encrypt(key1, &params, []byte("secret"))
 	require.NoError(t, err)
 
 	_, err = Decrypt(key2, params, ciphertext)
@@ -139,7 +139,7 @@ func TestAESGCMWrongKeyFails(t *testing.T) {
 func TestAESGCMWrongKeyTypeFails(t *testing.T) {
 	params := AlgorithmParams{Algorithm: AlgorithmAESGCM}
 
-	_, _, err := Encrypt("not-a-byte-slice", params, []byte("secret"))
+	_, _, err := Encrypt("not-a-byte-slice", &params, []byte("secret"))
 	assert.Error(t, err, "Encrypt with wrong key type should fail")
 
 	_, err = Decrypt("not-a-byte-slice", params, []byte("some ciphertext"))
@@ -161,7 +161,7 @@ func TestRSAOAEP256EncryptDecryptRoundTrip(t *testing.T) {
 		},
 	}
 
-	wrappedCEK, details, err := Encrypt(&privKey.PublicKey, params, nil)
+	wrappedCEK, details, err := Encrypt(&privKey.PublicKey, &params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, details)
 	assert.NotEmpty(t, wrappedCEK, "Wrapped CEK should not be empty")
@@ -184,14 +184,14 @@ func TestRSAOAEP256MissingContentEncryptionAlgorithmFails(t *testing.T) {
 		RSAOAEP256: RSAOAEP256Params{},
 	}
 
-	_, _, err = Encrypt(&privKey.PublicKey, params, nil)
+	_, _, err = Encrypt(&privKey.PublicKey, &params, nil)
 	assert.Error(t, err, "Encrypt without ContentEncryptionAlgorithm should fail")
 }
 
 func TestRSAOAEP256WrongKeyTypeFails(t *testing.T) {
 	params := AlgorithmParams{Algorithm: AlgorithmRSAOAEP256}
 
-	_, _, err := Encrypt("not-an-rsa-key", params, nil)
+	_, _, err := Encrypt("not-an-rsa-key", &params, nil)
 	assert.Error(t, err, "Encrypt with wrong key type should fail")
 
 	_, err = Decrypt("not-an-rsa-key", params, []byte("wrapped"))
@@ -213,7 +213,7 @@ func TestECDHESEncryptDecryptRoundTrip(t *testing.T) {
 		},
 	}
 
-	ciphertext, details, err := Encrypt(&receiverKey.PublicKey, encParams, nil)
+	ciphertext, details, err := Encrypt(&receiverKey.PublicKey, &encParams, nil)
 	require.NoError(t, err)
 	require.NotNil(t, details)
 	assert.Nil(t, ciphertext, "ECDH-ES direct agreement returns nil ciphertext")
@@ -255,7 +255,7 @@ func TestECDHESWrongKeyTypeFails(t *testing.T) {
 		ECDHES:    ECDHESParams{ContentEncryptionAlgorithm: "A128GCM"},
 	}
 
-	_, _, err := Encrypt("not-an-ec-key", params, nil)
+	_, _, err := Encrypt("not-an-ec-key", &params, nil)
 	assert.Error(t, err, "Encrypt with wrong key type should fail")
 
 	_, err = Decrypt("not-an-ec-key", params, nil)
@@ -277,7 +277,7 @@ func TestECDHESA128KWEncryptDecryptRoundTrip(t *testing.T) {
 		},
 	}
 
-	wrappedCEK, details, err := Encrypt(&receiverKey.PublicKey, encParams, nil)
+	wrappedCEK, details, err := Encrypt(&receiverKey.PublicKey, &encParams, nil)
 	require.NoError(t, err)
 	require.NotNil(t, details)
 	assert.NotEmpty(t, wrappedCEK, "ECDH-ES+A128KW should return a wrapped CEK")
@@ -308,7 +308,7 @@ func TestECDHESA256KWEncryptDecryptRoundTrip(t *testing.T) {
 		},
 	}
 
-	wrappedCEK, details, err := Encrypt(&receiverKey.PublicKey, encParams, nil)
+	wrappedCEK, details, err := Encrypt(&receiverKey.PublicKey, &encParams, nil)
 	require.NoError(t, err)
 	require.NotNil(t, details)
 	assert.NotEmpty(t, wrappedCEK, "ECDH-ES+A256KW should return a wrapped CEK")
@@ -329,13 +329,41 @@ func TestECDHESA256KWEncryptDecryptRoundTrip(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
+// Nil params tests
+// ----------------------------------------------------------------------------
+
+func TestEncryptNilParamsFails(t *testing.T) {
+	_, _, err := Encrypt([]byte("key"), nil, []byte("content"))
+	assert.Error(t, err, "Encrypt with nil params should fail")
+	assert.Contains(t, err.Error(), "algorithm params required")
+}
+
+// ----------------------------------------------------------------------------
+// ECDH-ES+KW wrong key type tests
+// ----------------------------------------------------------------------------
+
+func TestECDHESKWWrongKeyTypeFails(t *testing.T) {
+	for _, alg := range []Algorithm{AlgorithmECDHESA128KW, AlgorithmECDHESA256KW} {
+		t.Run(string(alg), func(t *testing.T) {
+			params := AlgorithmParams{
+				Algorithm: alg,
+				ECDHES:    ECDHESParams{ContentEncryptionAlgorithm: "A128GCM"},
+			}
+			_, _, err := Encrypt("not-an-ec-key", &params, nil)
+			assert.Error(t, err, "Encrypt with wrong key type should fail")
+			assert.Contains(t, err.Error(), "*ecdsa.PublicKey")
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
 // Unsupported algorithm tests
 // ----------------------------------------------------------------------------
 
 func TestEncryptUnsupportedAlgorithmFails(t *testing.T) {
 	params := AlgorithmParams{Algorithm: "UNSUPPORTED"}
 
-	_, _, err := Encrypt([]byte("key"), params, []byte("content"))
+	_, _, err := Encrypt([]byte("key"), &params, []byte("content"))
 	assert.Error(t, err)
 }
 

--- a/backend/internal/system/kmprovider/defaultkm/config.go
+++ b/backend/internal/system/kmprovider/defaultkm/config.go
@@ -49,7 +49,7 @@ func (es *encryptionService) Encrypt(_ context.Context, plaintext []byte) ([]byt
 		return nil, errors.New("default encryption key not found")
 	}
 	ciphertext, _, err := cryptolab.Encrypt(
-		key, cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}, plaintext,
+		key, &cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}, plaintext,
 	)
 	if err != nil {
 		return nil, err

--- a/backend/internal/system/kmprovider/defaultkm/config_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/config_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package defaultkm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncryptionService_Encrypt_NoDefaultKey covers lines 48-50: when the
+// encryptionService has no default key, Encrypt should return an error.
+func TestEncryptionService_Encrypt_NoDefaultKey(t *testing.T) {
+	es := &encryptionService{
+		defaultKeyID: "",
+		keys:         map[string][]byte{},
+	}
+	_, err := es.Encrypt(context.Background(), []byte("plaintext"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "default encryption key not found")
+}
+
+// TestEncryptionService_Encrypt_InvalidKeySize covers lines 54-56: when the
+// stored key has an invalid AES size, the underlying Encrypt call returns an
+// error that the service propagates.
+func TestEncryptionService_Encrypt_InvalidKeySize(t *testing.T) {
+	es := &encryptionService{
+		defaultKeyID: "bad-key",
+		keys:         map[string][]byte{"bad-key": {0x01}}, // 1 byte — invalid AES key length
+	}
+	_, err := es.Encrypt(context.Background(), []byte("plaintext"))
+	require.Error(t, err)
+}

--- a/backend/internal/system/kmprovider/defaultkm/runtime.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime.go
@@ -65,13 +65,13 @@ func (s *runtimeCryptoService) Encrypt(
 		if err != nil {
 			return nil, nil, err
 		}
-		return cryptolab.Encrypt(rsaPub, params, content)
+		return cryptolab.Encrypt(rsaPub, &params, content)
 	case cryptolab.AlgorithmECDHES, cryptolab.AlgorithmECDHESA128KW, cryptolab.AlgorithmECDHESA256KW:
 		ecPub, err := s.getECPublicKey(keyRef)
 		if err != nil {
 			return nil, nil, err
 		}
-		return cryptolab.Encrypt(ecPub, params, content)
+		return cryptolab.Encrypt(ecPub, &params, content)
 	default:
 		return nil, nil, fmt.Errorf("unsupported algorithm: %s", params.Algorithm)
 	}

--- a/backend/internal/system/kmprovider/defaultkm/runtime_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_test.go
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package defaultkm
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asgardeo/thunder/internal/system/cryptolab"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/i18n/core"
+	"github.com/asgardeo/thunder/internal/system/kmprovider"
+	"github.com/asgardeo/thunder/tests/mocks/crypto/pki/pkimock"
+)
+
+const testKeyID = "test-key-id"
+
+func newTestSvcErr() *serviceerror.ServiceError {
+	return &serviceerror.ServiceError{
+		Code:  "TEST-001",
+		Error: core.I18nMessage{DefaultValue: "key not found"},
+	}
+}
+
+// TestEncrypt_RSAOAEP256_Success covers line 68: the success path for RSA-OAEP-256
+// when the PKI service returns a valid RSA certificate.
+func TestEncrypt_RSAOAEP256_Success(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	cert := &x509.Certificate{PublicKey: &rsaKey.PublicKey}
+
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().
+		GetX509Certificate(testKeyID).
+		Return(cert, nil)
+
+	svc := NewRuntimeCryptoService(pkiMock, nil)
+
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{
+			ContentEncryptionAlgorithm: "A256GCM",
+		},
+	}
+	wrappedCEK, details, err := svc.Encrypt(
+		context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil,
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, wrappedCEK)
+	assert.NotNil(t, details)
+}
+
+// TestEncrypt_RSAOAEP256_GetPublicKeyError covers the error return path inside the
+// RSA-OAEP-256 case (lines 65-66) when the PKI service cannot find the key.
+func TestEncrypt_RSAOAEP256_GetPublicKeyError(t *testing.T) {
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().
+		GetX509Certificate(testKeyID).
+		Return(nil, newTestSvcErr())
+
+	svc := NewRuntimeCryptoService(pkiMock, nil)
+
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{
+			ContentEncryptionAlgorithm: "A256GCM",
+		},
+	}
+	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), testKeyID)
+}
+
+// TestEncrypt_ECDHES_Success covers the ECDH-ES algorithm case (lines 69-70, 74) on the
+// happy path where the PKI service returns a valid EC certificate.
+func TestEncrypt_ECDHES_Success(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	cert := &x509.Certificate{PublicKey: &ecKey.PublicKey}
+
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().
+		GetX509Certificate(testKeyID).
+		Return(cert, nil)
+
+	svc := NewRuntimeCryptoService(pkiMock, nil)
+
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmECDHES,
+		ECDHES: cryptolab.ECDHESParams{
+			ContentEncryptionAlgorithm: "A128GCM",
+		},
+	}
+	_, details, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, details)
+}
+
+// TestEncrypt_ECDHES_GetPublicKeyError covers the error return path inside the
+// ECDH-ES case (lines 71-72) when the PKI service cannot find the key.
+func TestEncrypt_ECDHES_GetPublicKeyError(t *testing.T) {
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().
+		GetX509Certificate(testKeyID).
+		Return(nil, newTestSvcErr())
+
+	svc := NewRuntimeCryptoService(pkiMock, nil)
+
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmECDHES,
+		ECDHES: cryptolab.ECDHESParams{
+			ContentEncryptionAlgorithm: "A128GCM",
+		},
+	}
+	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), testKeyID)
+}
+
+// TestEncrypt_UnsupportedAlgorithm covers the default branch (lines 75-76) for an
+// algorithm that is not handled by the switch.
+func TestEncrypt_UnsupportedAlgorithm(t *testing.T) {
+	svc := NewRuntimeCryptoService(nil, nil)
+
+	params := cryptolab.AlgorithmParams{Algorithm: "UNSUPPORTED"}
+	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported algorithm")
+}


### PR DESCRIPTION
### Purpose

Previously required callers to always construct a full AlgorithmParams value, even in cases where passing nil is the more natural expression (e.g. when the caller delegates algorithm selection entirely to a lower layer). The value receiver made it impossible to distinguish "no params provided" from "zero-value params". This change updates the signature to accept *AlgorithmParams, enabling nil to be passed explicitly and making the API more flexible for future callers.


### Related Issues
- https://github.com/asgardeo/thunder/pull/2474/changes#r3199068477

### Related PRs
- https://github.com/asgardeo/thunder/pull/2474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to encryption parameter handling for better code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->