### PR TITLE
Make Encrypt, Decrypt and GetTLSMaterial accept KeyRef pointer in RuntimeCryptoProvider

### DIFF
--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -478,7 +478,7 @@ func (s *flowExecService) encryptEngineContext(ctx context.Context, engineCtx *E
 		return nil, fmt.Errorf("failed to serialize engine context: %w", err)
 	}
 	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}
-	ciphertext, _, err := s.cryptoSvc.Encrypt(ctx, kmprovider.KeyRef{}, params, []byte(serialized.Context))
+	ciphertext, _, err := s.cryptoSvc.Encrypt(ctx, nil, params, []byte(serialized.Context))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt context: %w", err)
 	}
@@ -660,7 +660,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 
 	if isContextEncrypted(dbModel.Context) {
 		decryptParams := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM}
-		decrypted, decryptErr := s.cryptoSvc.Decrypt(ctx, kmprovider.KeyRef{}, decryptParams, []byte(dbModel.Context))
+		decrypted, decryptErr := s.cryptoSvc.Decrypt(ctx, nil, decryptParams, []byte(dbModel.Context))
 		if decryptErr != nil {
 			logger.Error("Failed to decrypt flow context",
 				log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -601,7 +601,7 @@ func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 		RunAndReturn(
 			func(
 				ctx context.Context,
-				_ kmprovider.KeyRef,
+				_ *kmprovider.KeyRef,
 				_ cryptolab.AlgorithmParams,
 				content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
 				encrypted, encErr := cfgSvc.Encrypt(ctx, content)
@@ -670,7 +670,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		RunAndReturn(func(
 			ctx context.Context,
-			_ kmprovider.KeyRef,
+			_ *kmprovider.KeyRef,
 			_ cryptolab.AlgorithmParams,
 			content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
 			encrypted, encErr := cfgSvc.Encrypt(ctx, content)
@@ -679,7 +679,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 	mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		RunAndReturn(func(
 			ctx context.Context,
-			_ kmprovider.KeyRef,
+			_ *kmprovider.KeyRef,
 			_ cryptolab.AlgorithmParams, content []byte) ([]byte, error) {
 			return cfgSvc.Decrypt(ctx, content)
 		})
@@ -716,7 +716,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 
 	// Step 2: Simulate getFlowContext decrypt path — call through the mock so RunAndReturn fires
 	decryptedBytes, err := mockCrypto.Decrypt(
-		context.Background(), kmprovider.KeyRef{},
+		context.Background(), nil,
 		cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmAESGCM},
 		[]byte(encryptedEngineCtx.Context))
 	assert.NoError(t, err)
@@ -1266,4 +1266,58 @@ func TestReadEntitySystemAttributes_InvalidJSON(t *testing.T) {
 func TestReadEntitySystemAttributes_Valid(t *testing.T) {
 	e := &entityprovider.Entity{SystemAttributes: []byte(`{"name":"X"}`)}
 	assert.Equal(t, map[string]interface{}{"name": "X"}, readEntitySystemAttributes(e))
+}
+
+func TestEncryptEngineContext_SerializeError(t *testing.T) {
+	// Triggers line 478: FromEngineContext fails because Attributes contains an
+	// unjsonifiable value (channel), wrapping the error with "failed to serialize engine context".
+	engineCtx := &EngineContext{
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"bad": make(chan int), // channels cannot be marshaled to JSON
+			},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+
+	svc := &flowExecService{}
+	_, err := svc.encryptEngineContext(context.Background(), engineCtx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to serialize engine context")
+}
+
+func TestEncryptEngineContext_EncryptError(t *testing.T) {
+	// Triggers line 483: serialization succeeds but cryptoSvc.Encrypt returns an error,
+	// wrapping it with "failed to encrypt context".
+	testConfig := &config.Config{}
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize())
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	engineCtx := &EngineContext{
+		ExecutionID: "exec-id",
+		AppID:       "app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+
+	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil, errors.New("encryption backend unavailable"))
+
+	svc := &flowExecService{cryptoSvc: mockCrypto}
+	_, err := svc.encryptEngineContext(context.Background(), engineCtx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to encrypt context")
 }

--- a/backend/internal/system/kmprovider/defaultkm/runtime.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime.go
@@ -51,7 +51,7 @@ func NewRuntimeCryptoService(
 }
 
 func (s *runtimeCryptoService) Encrypt(
-	ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte,
+	ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte,
 ) ([]byte, *cryptolab.CryptoDetails, error) {
 	switch params.Algorithm {
 	case cryptolab.AlgorithmAESGCM:
@@ -61,13 +61,19 @@ func (s *runtimeCryptoService) Encrypt(
 		encrypted, err := s.cfgService.Encrypt(ctx, content)
 		return encrypted, nil, err
 	case cryptolab.AlgorithmRSAOAEP256:
-		rsaPub, err := s.getRSAPublicKey(keyRef)
+		if keyRef == nil {
+			return nil, nil, errors.New("keyRef required for RSA-OAEP-256")
+		}
+		rsaPub, err := s.getRSAPublicKey(*keyRef)
 		if err != nil {
 			return nil, nil, err
 		}
 		return cryptolab.Encrypt(rsaPub, &params, content)
 	case cryptolab.AlgorithmECDHES, cryptolab.AlgorithmECDHESA128KW, cryptolab.AlgorithmECDHESA256KW:
-		ecPub, err := s.getECPublicKey(keyRef)
+		if keyRef == nil {
+			return nil, nil, errors.New("keyRef required for ECDH-ES")
+		}
+		ecPub, err := s.getECPublicKey(*keyRef)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -78,7 +84,7 @@ func (s *runtimeCryptoService) Encrypt(
 }
 
 func (s *runtimeCryptoService) Decrypt(
-	ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte,
+	ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte,
 ) ([]byte, error) {
 	switch params.Algorithm {
 	case cryptolab.AlgorithmAESGCM:
@@ -87,13 +93,19 @@ func (s *runtimeCryptoService) Decrypt(
 		}
 		return s.cfgService.Decrypt(ctx, content)
 	case cryptolab.AlgorithmRSAOAEP256:
-		rsaPriv, err := s.getRSAPrivateKey(keyRef)
+		if keyRef == nil {
+			return nil, errors.New("keyRef required for RSA-OAEP-256")
+		}
+		rsaPriv, err := s.getRSAPrivateKey(*keyRef)
 		if err != nil {
 			return nil, err
 		}
 		return cryptolab.Decrypt(rsaPriv, params, content)
 	case cryptolab.AlgorithmECDHES, cryptolab.AlgorithmECDHESA128KW, cryptolab.AlgorithmECDHESA256KW:
-		ecPriv, err := s.getECPrivateKey(keyRef)
+		if keyRef == nil {
+			return nil, errors.New("keyRef required for ECDH-ES")
+		}
+		ecPriv, err := s.getECPrivateKey(*keyRef)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +136,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 }
 
 func (s *runtimeCryptoService) GetTLSMaterial(
-	_ context.Context, _ kmprovider.KeyRef,
+	_ context.Context, _ *kmprovider.KeyRef,
 ) (*kmprovider.TLSMaterial, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/system/kmprovider/defaultkm/runtime_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_test.go
@@ -46,9 +46,7 @@ func newTestSvcErr() *serviceerror.ServiceError {
 	}
 }
 
-// TestEncrypt_RSAOAEP256_Success covers line 68: the success path for RSA-OAEP-256
-// when the PKI service returns a valid RSA certificate.
-func TestEncrypt_RSAOAEP256_Success(t *testing.T) {
+func TestEncrypt_RSAOAEP256_SuccessViaConstructor(t *testing.T) {
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
@@ -68,15 +66,13 @@ func TestEncrypt_RSAOAEP256_Success(t *testing.T) {
 		},
 	}
 	wrappedCEK, details, err := svc.Encrypt(
-		context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil,
+		context.Background(), &kmprovider.KeyRef{KeyID: testKeyID}, params, nil,
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, wrappedCEK)
 	assert.NotNil(t, details)
 }
 
-// TestEncrypt_RSAOAEP256_GetPublicKeyError covers the error return path inside the
-// RSA-OAEP-256 case (lines 65-66) when the PKI service cannot find the key.
 func TestEncrypt_RSAOAEP256_GetPublicKeyError(t *testing.T) {
 	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
 	pkiMock.EXPECT().
@@ -91,13 +87,11 @@ func TestEncrypt_RSAOAEP256_GetPublicKeyError(t *testing.T) {
 			ContentEncryptionAlgorithm: "A256GCM",
 		},
 	}
-	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
+	_, _, err := svc.Encrypt(context.Background(), &kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), testKeyID)
 }
 
-// TestEncrypt_ECDHES_Success covers the ECDH-ES algorithm case (lines 69-70, 74) on the
-// happy path where the PKI service returns a valid EC certificate.
 func TestEncrypt_ECDHES_Success(t *testing.T) {
 	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
@@ -117,13 +111,11 @@ func TestEncrypt_ECDHES_Success(t *testing.T) {
 			ContentEncryptionAlgorithm: "A128GCM",
 		},
 	}
-	_, details, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
+	_, details, err := svc.Encrypt(context.Background(), &kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, details)
 }
 
-// TestEncrypt_ECDHES_GetPublicKeyError covers the error return path inside the
-// ECDH-ES case (lines 71-72) when the PKI service cannot find the key.
 func TestEncrypt_ECDHES_GetPublicKeyError(t *testing.T) {
 	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
 	pkiMock.EXPECT().
@@ -138,18 +130,305 @@ func TestEncrypt_ECDHES_GetPublicKeyError(t *testing.T) {
 			ContentEncryptionAlgorithm: "A128GCM",
 		},
 	}
-	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
+	_, _, err := svc.Encrypt(context.Background(), &kmprovider.KeyRef{KeyID: testKeyID}, params, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), testKeyID)
 }
 
-// TestEncrypt_UnsupportedAlgorithm covers the default branch (lines 75-76) for an
-// algorithm that is not handled by the switch.
 func TestEncrypt_UnsupportedAlgorithm(t *testing.T) {
 	svc := NewRuntimeCryptoService(nil, nil)
 
 	params := cryptolab.AlgorithmParams{Algorithm: "UNSUPPORTED"}
-	_, _, err := svc.Encrypt(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
+	_, _, err := svc.Encrypt(context.Background(), &kmprovider.KeyRef{KeyID: testKeyID}, params, []byte("data"))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported algorithm")
+}
+
+// Encrypt – RSA-OAEP-256
+func TestEncrypt_RSAOAEP256_NilKeyRef(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: pkimock.NewPKIServiceInterfaceMock(t)}
+	params := cryptolab.AlgorithmParams{
+		Algorithm:  cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err := svc.Encrypt(context.Background(), nil, params, []byte("data"))
+	assert.EqualError(t, err, "keyRef required for RSA-OAEP-256")
+}
+
+func TestEncrypt_RSAOAEP256_PKIError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{
+		Algorithm:  cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err := svc.Encrypt(context.Background(), keyRef, params, []byte("data"))
+	assert.Error(t, err)
+}
+
+func TestEncrypt_RSAOAEP256_NonRSAPublicKey(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(
+		&x509.Certificate{PublicKey: &ecKey.PublicKey}, nil,
+	)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{
+		Algorithm:  cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err = svc.Encrypt(context.Background(), keyRef, params, []byte("data"))
+	assert.EqualError(t, err, "key is not an RSA public key")
+}
+
+func TestEncrypt_RSAOAEP256_Success(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(
+		&x509.Certificate{PublicKey: &rsaKey.PublicKey}, nil,
+	)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{
+		Algorithm:  cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	ciphertext, details, err := svc.Encrypt(context.Background(), keyRef, params, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ciphertext)
+	require.NotNil(t, details)
+	assert.NotEmpty(t, details.CEK)
+}
+
+// Encrypt – ECDH-ES variants
+func TestEncrypt_ECDHES_NilKeyRef(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: pkimock.NewPKIServiceInterfaceMock(t)}
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmECDHES,
+		ECDHES:    cryptolab.ECDHESParams{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err := svc.Encrypt(context.Background(), nil, params, []byte("data"))
+	assert.EqualError(t, err, "keyRef required for ECDH-ES")
+}
+
+func TestEncrypt_ECDHES_PKIError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmECDHES,
+		ECDHES:    cryptolab.ECDHESParams{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err := svc.Encrypt(context.Background(), keyRef, params, []byte("data"))
+	assert.Error(t, err)
+}
+
+func TestEncrypt_ECDHES_NonECPublicKey(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(
+		&x509.Certificate{PublicKey: &rsaKey.PublicKey}, nil,
+	)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{
+		Algorithm: cryptolab.AlgorithmECDHES,
+		ECDHES:    cryptolab.ECDHESParams{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	_, _, err = svc.Encrypt(context.Background(), keyRef, params, nil)
+	assert.EqualError(t, err, "key is not an EC public key")
+}
+
+func TestEncrypt_ECDHESVariants_Success(t *testing.T) {
+	algorithms := []cryptolab.Algorithm{
+		cryptolab.AlgorithmECDHES,
+		cryptolab.AlgorithmECDHESA128KW,
+		cryptolab.AlgorithmECDHESA256KW,
+	}
+
+	for _, alg := range algorithms {
+		t.Run(string(alg), func(t *testing.T) {
+			ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+
+			pki := pkimock.NewPKIServiceInterfaceMock(t)
+			pki.EXPECT().GetX509Certificate("key1").Return(
+				&x509.Certificate{PublicKey: &ecKey.PublicKey}, nil,
+			)
+
+			svc := &runtimeCryptoService{pkiService: pki}
+			keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+			params := cryptolab.AlgorithmParams{
+				Algorithm: alg,
+				ECDHES:    cryptolab.ECDHESParams{ContentEncryptionAlgorithm: "A256GCM"},
+			}
+
+			_, details, err := svc.Encrypt(context.Background(), keyRef, params, nil)
+			require.NoError(t, err)
+			require.NotNil(t, details)
+			assert.NotNil(t, details.EPK)
+			assert.NotEmpty(t, details.CEK)
+		})
+	}
+}
+
+// Decrypt – RSA-OAEP-256
+func TestDecrypt_RSAOAEP256_NilKeyRef(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: pkimock.NewPKIServiceInterfaceMock(t)}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmRSAOAEP256}
+
+	_, err := svc.Decrypt(context.Background(), nil, params, []byte("ciphertext"))
+	assert.EqualError(t, err, "keyRef required for RSA-OAEP-256")
+}
+
+func TestDecrypt_RSAOAEP256_PKIError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey("key1").Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmRSAOAEP256}
+
+	_, err := svc.Decrypt(context.Background(), keyRef, params, []byte("ciphertext"))
+	assert.Error(t, err)
+}
+
+func TestDecrypt_RSAOAEP256_NonRSAPrivateKey(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey("key1").Return(ecKey, nil)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmRSAOAEP256}
+
+	_, err = svc.Decrypt(context.Background(), keyRef, params, []byte("ciphertext"))
+	assert.EqualError(t, err, "key is not an RSA private key")
+}
+
+func TestDecrypt_RSAOAEP256_RoundTrip(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetX509Certificate("key1").Return(
+		&x509.Certificate{PublicKey: &rsaKey.PublicKey}, nil,
+	)
+	pki.EXPECT().GetPrivateKey("key1").Return(rsaKey, nil)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	encParams := cryptolab.AlgorithmParams{
+		Algorithm:  cryptolab.AlgorithmRSAOAEP256,
+		RSAOAEP256: cryptolab.RSAOAEP256Params{ContentEncryptionAlgorithm: "A256GCM"},
+	}
+
+	wrappedCEK, details, err := svc.Encrypt(context.Background(), keyRef, encParams, nil)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	decParams := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmRSAOAEP256}
+	unwrappedCEK, err := svc.Decrypt(context.Background(), keyRef, decParams, wrappedCEK)
+	require.NoError(t, err)
+	assert.Equal(t, details.CEK, unwrappedCEK)
+}
+
+// Decrypt – ECDH-ES variants
+func TestDecrypt_ECDHES_NilKeyRef(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: pkimock.NewPKIServiceInterfaceMock(t)}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmECDHES}
+
+	_, err := svc.Decrypt(context.Background(), nil, params, nil)
+	assert.EqualError(t, err, "keyRef required for ECDH-ES")
+}
+
+func TestDecrypt_ECDHES_PKIError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey("key1").Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmECDHES}
+
+	_, err := svc.Decrypt(context.Background(), keyRef, params, nil)
+	assert.Error(t, err)
+}
+
+func TestDecrypt_ECDHES_NonECPrivateKey(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey("key1").Return(rsaKey, nil)
+
+	svc := &runtimeCryptoService{pkiService: pki}
+	keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+	params := cryptolab.AlgorithmParams{Algorithm: cryptolab.AlgorithmECDHES}
+
+	_, err = svc.Decrypt(context.Background(), keyRef, params, nil)
+	assert.EqualError(t, err, "key is not an EC private key")
+}
+
+func TestDecrypt_ECDHESVariants_RoundTrip(t *testing.T) {
+	algorithms := []cryptolab.Algorithm{
+		cryptolab.AlgorithmECDHES,
+		cryptolab.AlgorithmECDHESA128KW,
+		cryptolab.AlgorithmECDHESA256KW,
+	}
+
+	for _, alg := range algorithms {
+		t.Run(string(alg), func(t *testing.T) {
+			ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+
+			pki := pkimock.NewPKIServiceInterfaceMock(t)
+			pki.EXPECT().GetX509Certificate("key1").Return(
+				&x509.Certificate{PublicKey: &ecKey.PublicKey}, nil,
+			)
+			pki.EXPECT().GetPrivateKey("key1").Return(ecKey, nil)
+
+			svc := &runtimeCryptoService{pkiService: pki}
+			keyRef := &kmprovider.KeyRef{KeyID: "key1"}
+
+			encParams := cryptolab.AlgorithmParams{
+				Algorithm: alg,
+				ECDHES:    cryptolab.ECDHESParams{ContentEncryptionAlgorithm: "A256GCM"},
+			}
+			ciphertext, encDetails, err := svc.Encrypt(context.Background(), keyRef, encParams, nil)
+			require.NoError(t, err)
+			require.NotNil(t, encDetails)
+
+			decParams := cryptolab.AlgorithmParams{
+				Algorithm: alg,
+				ECDHES:    cryptolab.ECDHESParams{EPK: encDetails.EPK, ContentEncryptionAlgorithm: "A256GCM"},
+			}
+			derivedCEK, err := svc.Decrypt(context.Background(), keyRef, decParams, ciphertext)
+			require.NoError(t, err)
+			assert.Equal(t, encDetails.CEK, derivedCEK)
+		})
+	}
 }

--- a/backend/internal/system/kmprovider/providers.go
+++ b/backend/internal/system/kmprovider/providers.go
@@ -36,10 +36,10 @@ type ConfigCryptoProvider interface {
 // encryption, decryption, signing, and key discovery.
 type RuntimeCryptoProvider interface {
 	Encrypt(
-		ctx context.Context, keyRef KeyRef, params cryptolab.AlgorithmParams, content []byte,
+		ctx context.Context, keyRef *KeyRef, params cryptolab.AlgorithmParams, content []byte,
 	) ([]byte, *cryptolab.CryptoDetails, error)
-	Decrypt(ctx context.Context, keyRef KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error)
+	Decrypt(ctx context.Context, keyRef *KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error)
 	Sign(ctx context.Context, keyRef KeyRef, algorithm cryptolab.SignAlgorithm, content []byte) ([]byte, error)
 	GetPublicKeys(ctx context.Context, filter PublicKeyFilter) ([]PublicKeyInfo, error)
-	GetTLSMaterial(ctx context.Context, keyRef KeyRef) (*TLSMaterial, error)
+	GetTLSMaterial(ctx context.Context, keyRef *KeyRef) (*TLSMaterial, error)
 }

--- a/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
+++ b/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
@@ -40,7 +40,7 @@ func (_m *RuntimeCryptoProviderMock) EXPECT() *RuntimeCryptoProviderMock_Expecte
 }
 
 // Decrypt provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error) {
+func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error) {
 	ret := _mock.Called(ctx, keyRef, params, content)
 
 	if len(ret) == 0 {
@@ -49,17 +49,17 @@ func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef kmpr
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) ([]byte, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) ([]byte, error)); ok {
 		return returnFunc(ctx, keyRef, params, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) []byte); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) []byte); ok {
 		r0 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) error); ok {
 		r1 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		r1 = ret.Error(1)
@@ -74,22 +74,22 @@ type RuntimeCryptoProviderMock_Decrypt_Call struct {
 
 // Decrypt is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef kmprovider.KeyRef
+//   - keyRef *kmprovider.KeyRef
 //   - params cryptolab.AlgorithmParams
 //   - content []byte
 func (_e *RuntimeCryptoProviderMock_Expecter) Decrypt(ctx interface{}, keyRef interface{}, params interface{}, content interface{}) *RuntimeCryptoProviderMock_Decrypt_Call {
 	return &RuntimeCryptoProviderMock_Decrypt_Call{Call: _e.mock.On("Decrypt", ctx, keyRef, params, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Run(run func(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Decrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Decrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 kmprovider.KeyRef
+		var arg1 *kmprovider.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(kmprovider.KeyRef)
+			arg1 = args[1].(*kmprovider.KeyRef)
 		}
 		var arg2 cryptolab.AlgorithmParams
 		if args[2] != nil {
@@ -114,13 +114,13 @@ func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Return(bytes []byte, err error
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Decrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Decrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Decrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Decrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Encrypt provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
+func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, *cryptolab.CryptoDetails, error) {
 	ret := _mock.Called(ctx, keyRef, params, content)
 
 	if len(ret) == 0 {
@@ -130,24 +130,24 @@ func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef kmpr
 	var r0 []byte
 	var r1 *cryptolab.CryptoDetails
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) ([]byte, *cryptolab.CryptoDetails, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) ([]byte, *cryptolab.CryptoDetails, error)); ok {
 		return returnFunc(ctx, keyRef, params, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) []byte); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) []byte); ok {
 		r0 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) *cryptolab.CryptoDetails); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) *cryptolab.CryptoDetails); ok {
 		r1 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*cryptolab.CryptoDetails)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) error); ok {
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *kmprovider.KeyRef, cryptolab.AlgorithmParams, []byte) error); ok {
 		r2 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		r2 = ret.Error(2)
@@ -162,22 +162,22 @@ type RuntimeCryptoProviderMock_Encrypt_Call struct {
 
 // Encrypt is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef kmprovider.KeyRef
+//   - keyRef *kmprovider.KeyRef
 //   - params cryptolab.AlgorithmParams
 //   - content []byte
 func (_e *RuntimeCryptoProviderMock_Expecter) Encrypt(ctx interface{}, keyRef interface{}, params interface{}, content interface{}) *RuntimeCryptoProviderMock_Encrypt_Call {
 	return &RuntimeCryptoProviderMock_Encrypt_Call{Call: _e.mock.On("Encrypt", ctx, keyRef, params, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Run(run func(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Encrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Encrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 kmprovider.KeyRef
+		var arg1 *kmprovider.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(kmprovider.KeyRef)
+			arg1 = args[1].(*kmprovider.KeyRef)
 		}
 		var arg2 cryptolab.AlgorithmParams
 		if args[2] != nil {
@@ -202,7 +202,7 @@ func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Return(bytes []byte, cryptoDet
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Encrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, *cryptolab.CryptoDetails, error)) *RuntimeCryptoProviderMock_Encrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Encrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolab.AlgorithmParams, content []byte) ([]byte, *cryptolab.CryptoDetails, error)) *RuntimeCryptoProviderMock_Encrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -276,7 +276,7 @@ func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) RunAndReturn(run func(ct
 }
 
 // GetTLSMaterial provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) GetTLSMaterial(ctx context.Context, keyRef kmprovider.KeyRef) (*kmprovider.TLSMaterial, error) {
+func (_mock *RuntimeCryptoProviderMock) GetTLSMaterial(ctx context.Context, keyRef *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error) {
 	ret := _mock.Called(ctx, keyRef)
 
 	if len(ret) == 0 {
@@ -285,17 +285,17 @@ func (_mock *RuntimeCryptoProviderMock) GetTLSMaterial(ctx context.Context, keyR
 
 	var r0 *kmprovider.TLSMaterial
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)); ok {
 		return returnFunc(ctx, keyRef)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef) *kmprovider.TLSMaterial); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef) *kmprovider.TLSMaterial); ok {
 		r0 = returnFunc(ctx, keyRef)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*kmprovider.TLSMaterial)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, kmprovider.KeyRef) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef) error); ok {
 		r1 = returnFunc(ctx, keyRef)
 	} else {
 		r1 = ret.Error(1)
@@ -310,20 +310,20 @@ type RuntimeCryptoProviderMock_GetTLSMaterial_Call struct {
 
 // GetTLSMaterial is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef kmprovider.KeyRef
+//   - keyRef *kmprovider.KeyRef
 func (_e *RuntimeCryptoProviderMock_Expecter) GetTLSMaterial(ctx interface{}, keyRef interface{}) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	return &RuntimeCryptoProviderMock_GetTLSMaterial_Call{Call: _e.mock.On("GetTLSMaterial", ctx, keyRef)}
 }
 
-func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Run(run func(ctx context.Context, keyRef kmprovider.KeyRef)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 kmprovider.KeyRef
+		var arg1 *kmprovider.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(kmprovider.KeyRef)
+			arg1 = args[1].(*kmprovider.KeyRef)
 		}
 		run(
 			arg0,
@@ -338,7 +338,7 @@ func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Return(tLSMaterial *kmp
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) RunAndReturn(run func(ctx context.Context, keyRef kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
In RuntimeCryptoProvider, Encrypt, Decrypt, and GetTLSMaterial now accept *KeyRef instead of KeyRef. Callers that don't need a key reference (e.g. AES-GCM via the config provider) can pass nil cleanly, replacing the previous kmprovider.KeyRef{} pattern which implied a valid but empty key. Sign is intentionally kept as a value since a key reference is always required there.

### Related Issues
- https://github.com/asgardeo/thunder/pull/2474/changes#r3199068477

### Related PRs
- https://github.com/asgardeo/thunder/pull/2474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation for context encryption/decryption, returning clear errors when required cryptographic references are missing.

* **Tests**
  * Added and expanded unit tests for encryption/decryption paths, including nil-reference, serialization, PKI/key-type failures, and successful encrypt→decrypt round-trips.

* **Refactor**
  * Updated cryptographic API parameter types to use nullable references for key parameters for consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->