### PR TITLE
Stick pnpm version to 10.33.4 in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,6 +152,9 @@ DOCS_DEFAULT_PORT=3000
 TEST_RUN="${4:-}"
 TEST_PACKAGE="${5:-}"
 
+# PNPM version to use for frontend builds and docs build
+PNPM_VERSION="10.33.4"
+
 # ============================================================================
 # Read Configuration from deployment.yaml
 # ============================================================================
@@ -377,7 +380,7 @@ function build_frontend() {
     # Check if pnpm is installed, if not install it
     if ! command -v pnpm >/dev/null 2>&1; then
         echo "pnpm not found, installing..."
-        npm install -g pnpm
+        npm install -g pnpm@$PNPM_VERSION
     fi
     
     # Navigate to frontend directory and install dependencies
@@ -400,7 +403,7 @@ function build_docs() {
     # Check if pnpm is installed, if not install it
     if ! command -v pnpm >/dev/null 2>&1; then
         echo "pnpm not found, installing..."
-        npm install -g pnpm
+        npm install -g pnpm@$PNPM_VERSION
     fi
     
     # Navigate to frontend directory first to ensure build:docs script can run
@@ -1151,7 +1154,7 @@ function run_frontend() {
     # Check if pnpm is installed, if not install it
     if ! command -v pnpm >/dev/null 2>&1; then
         echo "pnpm not found, installing..."
-        npm install -g pnpm
+        npm install -g pnpm@$PNPM_VERSION
     fi
     
     # Navigate to frontend directory and install dependencies
@@ -1179,7 +1182,7 @@ function run_docs() {
     # Check if pnpm is installed, if not install it
     if ! command -v pnpm >/dev/null 2>&1; then
         echo "pnpm not found, installing..."
-        npm install -g pnpm
+        npm install -g pnpm@$PNPM_VERSION
     fi
     
     # Navigate to frontend directory first to install all dependencies


### PR DESCRIPTION
### Purpose
Stick pnpm version to 10.33.4 in build.sh


### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned package manager version to ensure consistent and reproducible builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->