### PR TITLE
Use `types` instead of `schemas` in user-types list API

### DIFF
--- a/api/agent.yaml
+++ b/api/agent.yaml
@@ -1309,7 +1309,7 @@ paths:
                 totalResults: 1
                 startIndex: 1
                 count: 1
-                schemas:
+                types:
                   - id: "550e8400-e29b-41d4-a716-446655440000"
                     name: "default"
                     ouId: "26eec421-f1bb-4deb-a5d3-9ab6554c2ae6"
@@ -2636,7 +2636,7 @@ components:
           type: integer
           description: "Number of elements in the returned page."
           example: 3
-        schemas:
+        types:
           type: array
           items:
             type: object

--- a/api/user.yaml
+++ b/api/user.yaml
@@ -1074,7 +1074,7 @@ paths:
                 totalResults: 3
                 startIndex: 1
                 count: 3
-                schemas:
+                types:
                   - id: "660e8400-e29b-41d4-a716-446655440001"
                     name: "employee"
                     ouId: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
@@ -1971,7 +1971,7 @@ components:
           type: integer
           description: "Number of elements in the returned page."
           example: 3
-        schemas:
+        types:
           type: array
           items:
             type: object

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -72,8 +72,8 @@ func (e *entityTypeExporter) GetAllResourceIDs(ctx context.Context) ([]string, *
 	if err != nil {
 		return nil, err
 	}
-	ids := make([]string, 0, len(response.Schemas))
-	for _, schema := range response.Schemas {
+	ids := make([]string, 0, len(response.Types))
+	for _, schema := range response.Types {
 		if !schema.IsReadOnly {
 			ids = append(ids, schema.ID)
 		}

--- a/backend/internal/entitytype/declarative_resource_internal_test.go
+++ b/backend/internal/entitytype/declarative_resource_internal_test.go
@@ -407,7 +407,7 @@ func TestGetAllResourceIDs_WithReadOnlyFilter(t *testing.T) {
 	exporter := newEntityTypeExporter(mockService)
 
 	response := &EntityTypeListResponse{
-		Schemas: []EntityTypeListItem{
+		Types: []EntityTypeListItem{
 			{ID: "schema1", Name: "Schema 1", IsReadOnly: false}, // Mutable - should be included
 			{ID: "schema2", Name: "Schema 2", IsReadOnly: true},  // Immutable - should be excluded
 			{ID: "schema3", Name: "Schema 3", IsReadOnly: false}, // Mutable - should be included

--- a/backend/internal/entitytype/declarative_resource_test.go
+++ b/backend/internal/entitytype/declarative_resource_test.go
@@ -67,7 +67,7 @@ func (s *EntityTypeExporterTestSuite) TestGetParameterizerType() {
 
 func (s *EntityTypeExporterTestSuite) TestGetAllResourceIDs_Success() {
 	expectedResponse := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{ID: "schema1", Name: "Schema 1"},
 			{ID: "schema2", Name: "Schema 2"},
 		},
@@ -106,7 +106,7 @@ func (s *EntityTypeExporterTestSuite) TestGetAllResourceIDs_Error() {
 
 func (s *EntityTypeExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 	expectedResponse := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{},
+		Types: []entitytype.EntityTypeListItem{},
 	}
 
 	s.mockService.EXPECT().

--- a/backend/internal/entitytype/model.go
+++ b/backend/internal/entitytype/model.go
@@ -87,7 +87,7 @@ type EntityTypeListResponse struct {
 	TotalResults int                  `json:"totalResults"`
 	StartIndex   int                  `json:"startIndex"`
 	Count        int                  `json:"count"`
-	Schemas      []EntityTypeListItem `json:"schemas"`
+	Types        []EntityTypeListItem `json:"types"`
 	Links        []Link               `json:"links"`
 }
 

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -164,7 +164,7 @@ func (us *entityTypeService) listAllEntityTypes(
 		TotalResults: totalCount,
 		StartIndex:   offset + 1,
 		Count:        len(entityTypes),
-		Schemas:      entityTypes,
+		Types:        entityTypes,
 		Links: buildPaginationLinks(category, limit, offset, totalCount,
 			utils.DisplayQueryParam(includeDisplay)),
 	}, nil
@@ -182,7 +182,7 @@ func (us *entityTypeService) listAccessibleEntityTypes(
 			TotalResults: 0,
 			StartIndex:   offset + 1,
 			Count:        0,
-			Schemas:      []EntityTypeListItem{},
+			Types:        []EntityTypeListItem{},
 			Links:        buildPaginationLinks(category, limit, offset, 0, displayQuery),
 		}, nil
 	}
@@ -205,7 +205,7 @@ func (us *entityTypeService) listAccessibleEntityTypes(
 		TotalResults: totalCount,
 		StartIndex:   offset + 1,
 		Count:        len(entityTypes),
-		Schemas:      entityTypes,
+		Types:        entityTypes,
 		Links:        buildPaginationLinks(category, limit, offset, totalCount, displayQuery),
 	}, nil
 }

--- a/backend/internal/entitytype/service_authz_test.go
+++ b/backend/internal/entitytype/service_authz_test.go
@@ -103,7 +103,7 @@ func (s *AuthzTestSuite) TestGetEntityTypeList_AllAllowed() {
 	s.Require().Nil(svcErr)
 	s.Require().NotNil(resp)
 	s.Equal(2, resp.TotalResults)
-	s.Len(resp.Schemas, 2)
+	s.Len(resp.Types, 2)
 }
 
 func (s *AuthzTestSuite) TestGetEntityTypeList_FilteredByOUIDs() {
@@ -129,8 +129,8 @@ func (s *AuthzTestSuite) TestGetEntityTypeList_FilteredByOUIDs() {
 	s.Require().Nil(svcErr)
 	s.Require().NotNil(resp)
 	s.Equal(1, resp.TotalResults)
-	s.Len(resp.Schemas, 1)
-	s.Equal("s1", resp.Schemas[0].ID)
+	s.Len(resp.Types, 1)
+	s.Equal("s1", resp.Types[0].ID)
 }
 
 func (s *AuthzTestSuite) TestGetEntityTypeList_EmptyAccessibleOUIDs() {
@@ -149,7 +149,7 @@ func (s *AuthzTestSuite) TestGetEntityTypeList_EmptyAccessibleOUIDs() {
 	s.Require().Nil(svcErr)
 	s.Require().NotNil(resp)
 	s.Equal(0, resp.TotalResults)
-	s.Empty(resp.Schemas)
+	s.Empty(resp.Types)
 }
 
 func (s *AuthzTestSuite) TestGetEntityTypeList_AuthzServiceError() {
@@ -628,9 +628,9 @@ func (s *AuthzTestSuite) TestGetEntityTypeList_WithIncludeDisplay() {
 		context.Background(), TypeCategoryUser, 10, 0, true)
 	s.Require().Nil(svcErr)
 	s.Require().NotNil(resp)
-	s.Require().Len(resp.Schemas, 2)
-	s.Equal("handle-1", resp.Schemas[0].OUHandle)
-	s.Equal("handle-2", resp.Schemas[1].OUHandle)
+	s.Require().Len(resp.Types, 2)
+	s.Equal("handle-1", resp.Types[0].OUHandle)
+	s.Equal("handle-2", resp.Types[1].OUHandle)
 	ouServiceMock.AssertExpectations(s.T())
 }
 

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -244,7 +244,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 		return execResp, nil
 	}
 
-	if len(schemas.Schemas) == 0 {
+	if len(schemas.Types) == 0 {
 		logger.Debug("No user types available")
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "No user types available"
@@ -252,7 +252,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	}
 
 	// Build the list of available schema names, filtering by allowedUserTypes if configured
-	availableSchemas := u.filterSchemasByAllowedTypes(schemas.Schemas, allowedUserTypes)
+	availableSchemas := u.filterSchemasByAllowedTypes(schemas.Types, allowedUserTypes)
 
 	// If an OU was already selected (OU-first onboarding flow), filter schemas to those valid for that OU.
 	// This only applies to USER_ONBOARDING flows where OUResolver with "promptAll" runs first.

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -1052,7 +1052,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 
 	// Mock GetEntityTypeList returning empty list
 	emptyList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{},
+		Types: []entitytype.EntityTypeListItem{},
 	}
 	suite.mockEntityTypeService.On("GetEntityTypeList", ctx.Context, mock.Anything, 100, 0, false).
 		Return(emptyList, nil)
@@ -1102,7 +1102,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 
 	// Mock GetEntityTypeList returning a single schema
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "ou-123"},
 		},
 	}
@@ -1130,7 +1130,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 
 	// Mock GetEntityTypeList returning schemas
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee"},
 			{Name: "customer"},
 		},
@@ -1166,7 +1166,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 
 	// Mock GetEntityTypeList returning multiple schemas
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "ou-123"},
 			{Name: "customer", OUID: "ou-456"},
 			{Name: "partner", OUID: "ou-789"},
@@ -1199,7 +1199,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 
 	// Mock GetEntityTypeList returning multiple schemas including non-allowed ones
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "ou-123"},
 			{Name: "customer", OUID: "ou-456"},
 			{Name: "partner", OUID: "ou-789"},
@@ -1234,7 +1234,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 
 	// Mock GetEntityTypeList returning schemas that don't match the allowed list
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "ou-123"},
 			{Name: "customer", OUID: "ou-456"},
 		},
@@ -1491,7 +1491,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_Filte
 	}
 
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "parent-ou-123"},
 			{Name: "customer", OUID: "other-ou-789"},
 			{Name: "partner", OUID: "parent-ou-123"},
@@ -1531,7 +1531,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_Filte
 	}
 
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "parent-ou-123"},
 			{Name: "customer", OUID: "other-ou-789"},
 		},
@@ -1567,7 +1567,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_AllSc
 	}
 
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "ou-123"},
 			{Name: "customer", OUID: "ou-456"},
 		},
@@ -1602,7 +1602,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_IsPar
 	}
 
 	schemaList := &entitytype.EntityTypeListResponse{
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{Name: "employee", OUID: "parent-ou-123"},
 			{Name: "customer", OUID: "error-ou"},
 		},

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -993,11 +993,11 @@ func (s *inboundClientService) validateAllowedUserTypes(
 				log.String("error", svcErr.Error.DefaultValue), log.String("code", svcErr.Code))
 			return ErrUserSchemaLookupFailed
 		}
-		for _, schema := range entityTypeList.Schemas {
+		for _, schema := range entityTypeList.Types {
 			existingUserTypes[schema.Name] = true
 		}
-		if len(entityTypeList.Schemas) == 0 ||
-			offset+len(entityTypeList.Schemas) >= entityTypeList.TotalResults {
+		if len(entityTypeList.Types) == 0 ||
+			offset+len(entityTypeList.Types) >= entityTypeList.TotalResults {
 			break
 		}
 		offset += limit

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -1346,7 +1346,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateAllowedUserTypes_AllExis
 	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
 		&entitytypepkg.EntityTypeListResponse{
 			TotalResults: 1,
-			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "person"}},
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "person"}},
 		}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 	assert.NoError(suite.T(), svc.validateAllowedUserTypes(context.Background(), []string{"person"}))
@@ -1357,7 +1357,7 @@ func (suite *InboundClientServiceTestSuite) TestValidateAllowedUserTypes_Missing
 	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
 		&entitytypepkg.EntityTypeListResponse{
 			TotalResults: 1,
-			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "person"}},
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "person"}},
 		}, nil)
 	svc := &inboundClientService{entityType: us, logger: log.GetLogger()}
 	err := svc.validateAllowedUserTypes(context.Background(), []string{"ghost"})
@@ -1959,7 +1959,7 @@ func (suite *InboundClientServiceTestSuite) TestCreateInboundClient_RejectsInval
 	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
 		&entitytypepkg.EntityTypeListResponse{
 			TotalResults: 1,
-			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
 	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
@@ -1983,7 +1983,7 @@ func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_RejectsInval
 	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
 		&entitytypepkg.EntityTypeListResponse{
 			TotalResults: 1,
-			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
 	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
@@ -2007,7 +2007,7 @@ func (suite *InboundClientServiceTestSuite) TestValidate_RejectsInvalidUserAttri
 	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
 		&entitytypepkg.EntityTypeListResponse{
 			TotalResults: 1,
-			Schemas:      []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
 		}, nil)
 	us.EXPECT().GetNonCredentialAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false).
 		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1618,7 +1618,7 @@ func (suite *ExportServiceTestSuite) TestExportEntityTypes_Wildcard() {
 	mockSchemaList := &entitytype.EntityTypeListResponse{
 		TotalResults: 2,
 		Count:        2,
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{ID: "schema1", Name: "Customer Schema", OUID: "ou1"},
 			{ID: "schema2", Name: "Employee Schema", OUID: "ou1"},
 		},
@@ -1756,7 +1756,7 @@ func (suite *ExportServiceTestSuite) TestExportEntityTypes_WildcardPartialFailur
 	mockSchemaList := &entitytype.EntityTypeListResponse{
 		TotalResults: 3,
 		Count:        3,
-		Schemas: []entitytype.EntityTypeListItem{
+		Types: []entitytype.EntityTypeListItem{
 			{ID: "schema1", Name: "Customer Schema"},
 			{ID: "schema2", Name: "Employee Schema"},
 			{ID: "schema3", Name: "Partner Schema"},

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -1443,7 +1443,7 @@ paths:
                 totalResults: 2
                 startIndex: 1
                 count: 2
-                schemas:
+                types:
                   - id: 660e8400-e29b-41d4-a716-446655440001
                     name: service-agent
                     ouId: a839f4bd-39dc-4eaa-b5cc-210d8ecaee87
@@ -11905,7 +11905,7 @@ paths:
                 totalResults: 3
                 startIndex: 1
                 count: 3
-                schemas:
+                types:
                   - id: 660e8400-e29b-41d4-a716-446655440001
                     name: employee
                     ouId: a839f4bd-39dc-4eaa-b5cc-210d8ecaee87
@@ -13402,7 +13402,7 @@ components:
           type: integer
           description: Number of elements in the returned page.
           example: 3
-        schemas:
+        types:
           type: array
           items:
             type: object
@@ -18314,7 +18314,7 @@ components:
           type: integer
           description: Number of elements in the returned page.
           example: 3
-        schemas:
+        types:
           type: array
           items:
             type: object

--- a/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
@@ -40,7 +40,7 @@ export default function EditAgentAttributes({agent, onSaved = undefined}: EditAg
   const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
 
   const {data: agentTypesData} = useGetAgentTypes();
-  const matchedSchema = agentTypesData?.schemas?.find((s) => s.name === agent.type);
+  const matchedSchema = agentTypesData?.types?.find((s) => s.name === agent.type);
   const {data: schemaDetails, isLoading} = useGetAgentType(matchedSchema?.id);
 
   const updateAgent = useUpdateAgent();

--- a/frontend/apps/console/src/features/agents/components/edit-agent/attributes/__tests__/EditAgentAttributes.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/attributes/__tests__/EditAgentAttributes.test.tsx
@@ -63,7 +63,7 @@ describe('EditAgentAttributes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseGetAgentTypes.mockReturnValue({
-      data: {schemas: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
+      data: {types: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
     });
     mockUseGetAgentType.mockReturnValue({
       data: {

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/AllowedUserTypesSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/AllowedUserTypesSection.tsx
@@ -37,7 +37,7 @@ export default function AllowedUserTypesSection({
   const {t} = useTranslation();
   const {data: userTypesData, isLoading} = useGetUserTypes();
 
-  const userTypeOptions = userTypesData?.schemas?.map((schema) => schema.name) ?? [];
+  const userTypeOptions = userTypesData?.types?.map((schema) => schema.name) ?? [];
   const value = editedAgent.allowedUserTypes ?? agent.allowedUserTypes ?? [];
 
   return (

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/__tests__/AllowedUserTypesSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/__tests__/AllowedUserTypesSection.test.tsx
@@ -51,7 +51,7 @@ describe('AllowedUserTypesSection', () => {
     vi.clearAllMocks();
     mockUseGetUserTypes.mockReturnValue({
       data: {
-        schemas: [
+        types: [
           {id: 'ut-1', name: 'employee'},
           {id: 'ut-2', name: 'customer'},
         ],
@@ -137,7 +137,7 @@ describe('AllowedUserTypesSection', () => {
   });
 
   it('handles missing user-type schemas gracefully', () => {
-    mockUseGetUserTypes.mockReturnValueOnce({data: {schemas: undefined}, isLoading: false});
+    mockUseGetUserTypes.mockReturnValueOnce({data: {types: undefined}, isLoading: false});
     render(<AllowedUserTypesSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
 
     expect(screen.getByText('employee')).toBeInTheDocument();

--- a/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
@@ -71,7 +71,7 @@ export default function AgentCreatePage(): JSX.Element {
   const isChildOuForbidden = (childOuError as {response?: {status?: number}} | null)?.response?.status === 403;
   const hasChildOUs = !isChildOuLoading && !childOuError && (childOuData?.totalResults ?? 0) > 0;
 
-  const agentTypes = useMemo(() => agentTypesData?.schemas ?? [], [agentTypesData]);
+  const agentTypes = useMemo(() => agentTypesData?.types ?? [], [agentTypesData]);
   const [createdAgent, setCreatedAgent] = useState<Agent | null>(null);
 
   // Agent types are restricted to a single bootstrap-provisioned `default` schema. Auto-pick it

--- a/frontend/apps/console/src/features/agents/pages/AgentsListPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentsListPage.tsx
@@ -34,7 +34,7 @@ export default function AgentsListPage(): JSX.Element {
   // Agent types are restricted to a single bootstrap-provisioned `default` schema; the Schema
   // button jumps to its edit page so operators can manage attribute definitions in place.
   const {data: agentTypesData, isLoading: isAgentTypesLoading} = useGetAgentTypes();
-  const defaultAgentType = agentTypesData?.schemas?.find((s) => s.name === DEFAULT_AGENT_TYPE_NAME);
+  const defaultAgentType = agentTypesData?.types?.find((s) => s.name === DEFAULT_AGENT_TYPE_NAME);
 
   const handleSchemaClick = (): void => {
     if (!defaultAgentType) return;

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
@@ -181,7 +181,7 @@ describe('AgentCreatePage', () => {
     }));
 
     mockUseGetAgentTypes.mockReturnValue({
-      data: {schemas: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
+      data: {types: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
     });
 
     mockUseGetAgentType.mockReturnValue({

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentsListPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentsListPage.test.tsx
@@ -62,7 +62,7 @@ describe('AgentsListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseGetAgentTypes.mockReturnValue({
-      data: {schemas: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
+      data: {types: [{id: 'schema-1', name: 'default', ouId: 'ou-1'}]},
       isLoading: false,
     });
   });
@@ -120,7 +120,7 @@ describe('AgentsListPage', () => {
   });
 
   it('disables the Schema button when no default agent type exists', () => {
-    mockUseGetAgentTypes.mockReturnValue({data: {schemas: []}, isLoading: false});
+    mockUseGetAgentTypes.mockReturnValue({data: {types: []}, isLoading: false});
     render(<AgentsListPage />);
 
     expect(screen.getByTestId('agent-schema-button')).toBeDisabled();
@@ -149,7 +149,7 @@ describe('AgentsListPage', () => {
   });
 
   it('does not navigate when Schema is clicked but no default type exists', async () => {
-    mockUseGetAgentTypes.mockReturnValue({data: {schemas: []}, isLoading: false});
+    mockUseGetAgentTypes.mockReturnValue({data: {types: []}, isLoading: false});
     const user = userEvent.setup();
 
     render(<AgentsListPage />);

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
@@ -90,7 +90,7 @@ export default function AccessSection({
   const [redirectUris, setRedirectUris] = useState<string[]>(() => oauth2Config?.redirectUris ?? []);
   const [uriErrors, setUriErrors] = useState<Record<number, string>>({});
 
-  const userTypeOptions = userTypesData?.schemas.map((schema) => schema.name) ?? [];
+  const userTypeOptions = userTypesData?.types.map((schema) => schema.name) ?? [];
 
   const generalSettingsSchema = z.object({
     url: z.string().url('Please enter a valid URL').or(z.literal('')).optional(),

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
@@ -64,7 +64,7 @@ describe('AccessSection', () => {
   } as OAuth2Config;
 
   const mockUserTypes = {
-    schemas: [
+    types: [
       {name: 'admin', id: '1'},
       {name: 'user', id: '2'},
       {name: 'guest', id: '3'},

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -146,11 +146,11 @@ export default function EditTokenSettings({
 
   // Get schema IDs for allowed user types
   const schemaIds = useMemo(() => {
-    if (!userTypesData?.schemas || allowedUserTypes.length === 0) {
+    if (!userTypesData?.types || allowedUserTypes.length === 0) {
       return [];
     }
 
-    return userTypesData.schemas.filter((schema) => allowedUserTypes.includes(schema.name)).map((schema) => schema.id);
+    return userTypesData.types.filter((schema) => allowedUserTypes.includes(schema.name)).map((schema) => schema.id);
   }, [userTypesData, allowedUserTypes]);
 
   // Determine if this is OAuth/OIDC mode (has separate token configs) or Native mode

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettings.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettings.test.tsx
@@ -33,7 +33,7 @@ const {mockHttp, mockGetServerUrl, mockLogger} = vi.hoisted(() => {
         totalResults: 1,
         startIndex: 0,
         count: 1,
-        schemas: [
+        types: [
           {
             id: 'schema-1',
             name: 'default',
@@ -405,7 +405,7 @@ describe('EditTokenSettings', () => {
         }
 
         return Promise.resolve({
-          data: {totalResults: 1, startIndex: 0, count: 1, schemas: [{id: 'schema-1', name: 'default'}]},
+          data: {totalResults: 1, startIndex: 0, count: 1, types: [{id: 'schema-1', name: 'default'}]},
         });
       });
     };

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -171,7 +171,7 @@ export default function ApplicationCreatePage(): JSX.Element {
       return;
     }
 
-    const userTypes = userTypesData?.schemas ?? [];
+    const userTypes = userTypesData?.types ?? [];
     const allowedUserTypes = (() => {
       // If there's exactly 1 user type, automatically include it
       if (userTypes.length === 1) {
@@ -493,7 +493,7 @@ export default function ApplicationCreatePage(): JSX.Element {
             selectedApproach={signInApproach}
             onApproachChange={setSignInApproach}
             onReadyChange={handleApproachStepReadyChange}
-            userTypes={userTypesData?.schemas ?? []}
+            userTypes={userTypesData?.types ?? []}
             selectedUserTypes={selectedUserTypes}
             onUserTypesChange={setSelectedUserTypes}
           />

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -72,7 +72,7 @@ vi.mock('../../api/useCreateApplication', () => ({
 vi.mock('../../../user-types/api/useGetUserTypes', () => ({
   default: () => ({
     data: {
-      schemas: [
+      types: [
         {name: 'customer', displayName: 'Customer'},
         {name: 'employee', displayName: 'Employee'},
       ],

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
@@ -46,7 +46,7 @@ describe('useGetUserTypes', () => {
     totalResults: 2,
     startIndex: 1,
     count: 2,
-    schemas: [
+    types: [
       {id: '123', name: 'UserType1', ouId: 'root-ou', allowSelfRegistration: false},
       {id: '456', name: 'UserType2', ouId: 'child-ou', allowSelfRegistration: true},
     ],
@@ -94,7 +94,7 @@ describe('useGetUserTypes', () => {
     });
 
     expect(result.current.data).toEqual(mockUserTypeListResponse);
-    expect(result.current.data?.schemas).toHaveLength(2);
+    expect(result.current.data?.types).toHaveLength(2);
     expect(result.current.data?.totalResults).toBe(2);
     expect(result.current.data?.count).toBe(2);
   });
@@ -290,7 +290,7 @@ describe('useGetUserTypes', () => {
       totalResults: 0,
       startIndex: 0,
       count: 0,
-      schemas: [],
+      types: [],
     };
 
     mockHttpRequest.mockResolvedValueOnce({
@@ -304,7 +304,7 @@ describe('useGetUserTypes', () => {
     });
 
     expect(result.current.data).toEqual(emptyResponse);
-    expect(result.current.data?.schemas).toHaveLength(0);
+    expect(result.current.data?.types).toHaveLength(0);
     expect(result.current.data?.totalResults).toBe(0);
   });
 });

--- a/frontend/apps/console/src/features/user-types/components/UserTypesList.tsx
+++ b/frontend/apps/console/src/features/user-types/components/UserTypesList.tsx
@@ -195,7 +195,7 @@ export default function UserTypesList() {
       <ListingTable.Provider variant="data-grid-card" loading={isLoading}>
         <ListingTable.Container disablePaper>
           <ListingTable.DataGrid
-            rows={userTypesData?.schemas ?? []}
+            rows={userTypesData?.types ?? []}
             columns={columns}
             getRowId={(row) => (row as UserTypeListItem).id}
             onRowClick={(params) => {

--- a/frontend/apps/console/src/features/user-types/components/__tests__/UserTypesList.test.tsx
+++ b/frontend/apps/console/src/features/user-types/components/__tests__/UserTypesList.test.tsx
@@ -177,7 +177,7 @@ describe('UserTypesList', () => {
     totalResults: 2,
     startIndex: 1,
     count: 2,
-    schemas: [
+    types: [
       {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou', ouHandle: 'root', allowSelfRegistration: false},
       {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou', ouHandle: 'child', allowSelfRegistration: true},
     ],
@@ -232,7 +232,7 @@ describe('UserTypesList', () => {
     mockUseGetUserTypes.mockReturnValueOnce({
       data: {
         ...mockUserTypesData,
-        schemas: [{...mockUserTypesData.schemas[0], ouHandle: undefined}],
+        types: [{...mockUserTypesData.types[0], ouHandle: undefined}],
       },
       isLoading: false,
       error: null,
@@ -247,7 +247,7 @@ describe('UserTypesList', () => {
     mockUseGetUserTypes.mockReturnValueOnce({
       data: {
         ...mockUserTypesData,
-        schemas: [{...mockUserTypesData.schemas[0], ouId: undefined, ouHandle: undefined}],
+        types: [{...mockUserTypesData.types[0], ouId: undefined, ouHandle: undefined}],
       },
       isLoading: false,
       error: null,
@@ -442,7 +442,7 @@ describe('UserTypesList', () => {
         totalResults: 0,
         startIndex: 1,
         count: 0,
-        schemas: [],
+        types: [],
       },
       isLoading: false,
       error: null,

--- a/frontend/apps/console/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/console/src/features/user-types/types/user-types.ts
@@ -140,7 +140,7 @@ export interface UserTypeListResponse {
   totalResults: number;
   startIndex: number;
   count: number;
-  schemas: UserTypeListItem[];
+  types: UserTypeListItem[];
   links?: ApiPaginationLink[];
 }
 

--- a/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentTypes.test.tsx
+++ b/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentTypes.test.tsx
@@ -43,7 +43,7 @@ describe('useGetAgentTypes', () => {
     totalResults: 1,
     startIndex: 1,
     count: 1,
-    schemas: [
+    types: [
       {
         id: 'aaa-bbb-ccc',
         name: 'default',

--- a/frontend/packages/configure-agent-types/src/models/__tests__/responses.test.ts
+++ b/frontend/packages/configure-agent-types/src/models/__tests__/responses.test.ts
@@ -25,9 +25,9 @@ describe('agent-types response types', () => {
       totalResults: 1,
       startIndex: 0,
       count: 1,
-      schemas: [{id: 'a1', name: 'default', ouId: 'ou1'}],
+      types: [{id: 'a1', name: 'default', ouId: 'ou1'}],
     };
-    expect(list.schemas).toHaveLength(1);
+    expect(list.types).toHaveLength(1);
   });
 
   it('accepts AgentTypeListResponse with optional pagination links', () => {
@@ -35,7 +35,7 @@ describe('agent-types response types', () => {
       totalResults: 0,
       startIndex: 0,
       count: 0,
-      schemas: [],
+      types: [],
       links: [{href: 'https://example.com/agent-types?offset=10', rel: 'next'}],
     };
     expect(list.links).toHaveLength(1);

--- a/frontend/packages/configure-agent-types/src/models/responses.ts
+++ b/frontend/packages/configure-agent-types/src/models/responses.ts
@@ -26,6 +26,6 @@ export interface AgentTypeListResponse {
   totalResults: number;
   startIndex: number;
   count: number;
-  schemas: AgentTypeListItem[];
+  types: AgentTypeListItem[];
   links?: ApiPaginationLink[];
 }

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUserTypes.test.ts
@@ -49,7 +49,7 @@ describe('useGetUserTypes', () => {
     totalResults: 2,
     startIndex: 0,
     count: 2,
-    schemas: [
+    types: [
       {id: 'schema-1', name: 'Employee', ouId: 'ou-1'},
       {id: 'schema-2', name: 'Contractor', ouId: 'ou-2'},
     ],
@@ -86,7 +86,7 @@ describe('useGetUserTypes', () => {
     });
 
     expect(result.current.data).toEqual(mockSchemasResponse);
-    expect(result.current.data?.schemas).toHaveLength(2);
+    expect(result.current.data?.types).toHaveLength(2);
     expect(result.current.data?.totalResults).toBe(2);
     expect(result.current.data?.count).toBe(2);
   });
@@ -299,7 +299,7 @@ describe('useGetUserTypes', () => {
       totalResults: 0,
       startIndex: 0,
       count: 0,
-      schemas: [],
+      types: [],
     };
 
     mockHttpRequest.mockResolvedValueOnce({
@@ -313,7 +313,7 @@ describe('useGetUserTypes', () => {
     });
 
     expect(result.current.data).toEqual(emptyResponse);
-    expect(result.current.data?.schemas).toHaveLength(0);
+    expect(result.current.data?.types).toHaveLength(0);
     expect(result.current.data?.totalResults).toBe(0);
   });
 

--- a/frontend/packages/configure-users/src/models/users.ts
+++ b/frontend/packages/configure-users/src/models/users.ts
@@ -193,7 +193,7 @@ export interface UserTypeListResponse {
   totalResults: number;
   startIndex: number;
   count: number;
-  schemas: SchemaInterface[];
+  types: SchemaInterface[];
 }
 
 export interface SchemaInterface {

--- a/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
@@ -77,7 +77,7 @@ export default function UserCreatePage(): JSX.Element {
   const tokenOuId = user?.ouId ?? null;
   const isChildOuForbidden = (childOuError as {response?: {status?: number}} | null)?.response?.status === 403;
   const isChildOuProbeFailed = !!childOuError && !isChildOuForbidden;
-  const userTypes = useMemo(() => userTypesData?.schemas ?? [], [userTypesData]);
+  const userTypes = useMemo(() => userTypesData?.types ?? [], [userTypesData]);
   const hasChildOUs = !isChildOuLoading && !childOuError && (childOuData?.totalResults ?? 0) > 0;
 
   const activeSteps = useMemo((): UserCreateFlowStep[] => {

--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -95,12 +95,12 @@ export default function UserEditPage() {
 
   // Find the schema ID based on the user's type (which is the schema name)
   const matchedSchema = useMemo(() => {
-    if (!user?.type || !userTypeList?.schemas) {
+    if (!user?.type || !userTypeList?.types) {
       return undefined;
     }
 
-    return userTypeList.schemas.find((s) => s.name === user.type);
-  }, [user?.type, userTypeList?.schemas]);
+    return userTypeList.types.find((s) => s.name === user.type);
+  }, [user?.type, userTypeList?.types]);
 
   const schemaId = matchedSchema?.id;
   const trimmedOuId = matchedSchema?.ouId?.trim();

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -251,7 +251,7 @@ const mockSchemasData: UserTypeListResponse = {
   totalResults: 2,
   startIndex: 1,
   count: 2,
-  schemas: [
+  types: [
     {id: 'schema1', name: 'Employee', ouId: 'root-ou'},
     {id: 'schema2', name: 'Contractor', ouId: 'child-ou'},
   ],
@@ -607,7 +607,7 @@ describe('UserCreatePage', () => {
     mockUseGetUserTypes.mockReturnValue({
       data: {
         ...mockSchemasData,
-        schemas: [{id: 'schema1', name: 'Employee', ouId: ''}],
+        types: [{id: 'schema1', name: 'Employee', ouId: ''}],
       },
       isLoading: false,
       error: null,
@@ -665,7 +665,7 @@ describe('UserCreatePage', () => {
     mockUseGetUserTypes.mockReturnValue({
       data: {
         ...mockSchemasData,
-        schemas: [{id: 'schema1', name: 'Employee', ouId: ''}],
+        types: [{id: 'schema1', name: 'Employee', ouId: ''}],
       },
       isLoading: false,
       error: null,

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -159,7 +159,7 @@ describe('UserEditPage', () => {
     totalResults: 1,
     startIndex: 1,
     count: 1,
-    schemas: [{id: 'employee', name: 'Employee', ouId: 'test-ou'}],
+    types: [{id: 'employee', name: 'Employee', ouId: 'test-ou'}],
   };
 
   const mockSchemaData: ApiUserType = {
@@ -513,7 +513,7 @@ describe('UserEditPage', () => {
       mockUseGetUserTypes.mockReturnValue({
         data: {
           ...mockSchemasData,
-          schemas: [{...mockSchemasData.schemas[0], ouId: ''}],
+          types: [{...mockSchemasData.types[0], ouId: ''}],
         },
         isLoading: false,
         error: null,
@@ -809,7 +809,7 @@ describe('UserEditPage', () => {
       mockUseGetUserTypes.mockReturnValue({
         data: {
           ...mockSchemasData,
-          schemas: [{...mockSchemasData.schemas[0], ouId: 'schema-ou'}],
+          types: [{...mockSchemasData.types[0], ouId: 'schema-ou'}],
         },
         isLoading: false,
         error: null,
@@ -832,7 +832,7 @@ describe('UserEditPage', () => {
       mockUseGetUserTypes.mockReturnValue({
         data: {
           ...mockSchemasData,
-          schemas: [{...mockSchemasData.schemas[0], ouId: ''}],
+          types: [{...mockSchemasData.types[0], ouId: ''}],
         },
         isLoading: false,
         error: null,

--- a/tests/e2e/utils/server-setup/mfa-setup.ts
+++ b/tests/e2e/utils/server-setup/mfa-setup.ts
@@ -424,7 +424,7 @@ export class MFASetup {
     }
 
     const schemasData = await schemasResponse.json();
-    const personSchema = schemasData.schemas?.find((s: any) => s.name === "Person");
+    const personSchema = schemasData.types?.find((s: any) => s.name === "Person");
 
     if (!personSchema || !personSchema.ouId) {
       throw new Error("Person user type not found or missing organization unit");

--- a/tests/integration/composite/composite_mode_api_test.go
+++ b/tests/integration/composite/composite_mode_api_test.go
@@ -263,7 +263,7 @@ func (suite *CompositeModeSuite) TestEntityTypeDeclarativeVisibility() {
 	suite.Equal(http.StatusOK, resp.StatusCode, "declarative user type should be visible")
 	resp.Body.Close()
 
-	suite.assertMergedCollectionContainsIDs("/user-types", "schemas", "decl-schema-1", "user_type")
+	suite.assertMergedCollectionContainsIDs("/user-types", "types", "decl-schema-1", "user_type")
 }
 
 func (suite *CompositeModeSuite) TestThemeDeclarativeVisibility() {

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -215,15 +215,15 @@ func findDefaultAgentTypeID() (string, error) {
 	}
 
 	var list struct {
-		Schemas []struct {
+		Types []struct {
 			ID   string `json:"id"`
 			Name string `json:"name"`
-		} `json:"schemas"`
+		} `json:"types"`
 	}
 	if err := json.Unmarshal(body, &list); err != nil {
 		return "", fmt.Errorf("failed to parse list response: %w. Response: %s", err, string(body))
 	}
-	for _, s := range list.Schemas {
+	for _, s := range list.Types {
 		if s.Name == "default" {
 			return s.ID, nil
 		}

--- a/tests/integration/usertype/model.go
+++ b/tests/integration/usertype/model.go
@@ -75,7 +75,7 @@ type UserTypeListResponse struct {
 	TotalResults int                  `json:"totalResults"`
 	StartIndex   int                  `json:"startIndex"`
 	Count        int                  `json:"count"`
-	Schemas      []UserTypeListItem `json:"schemas"`
+	Types        []UserTypeListItem `json:"types"`
 	Links        []testutils.Link     `json:"links"`
 }
 

--- a/tests/integration/usertype/usertype_api_list_test.go
+++ b/tests/integration/usertype/usertype_api_list_test.go
@@ -71,12 +71,12 @@ func (ts *ListUserTypesTestSuite) TestListUserTypes() {
 
 	// Verify response structure according to API spec
 	ts.Assert().GreaterOrEqual(listResponse.TotalResults, 0, "TotalResults should be non-negative")
-	ts.Assert().Equal(listResponse.Count, len(listResponse.Schemas), "Count should match actual schemas")
+	ts.Assert().Equal(listResponse.Count, len(listResponse.Types), "Count should match actual types")
 	ts.Assert().Equal(1, listResponse.StartIndex, "StartIndex should be 1 (1-based)")
 	ts.Assert().NotNil(listResponse.Links, "Should have links array")
 
 	// Verify each schema has required fields for list view
-	for _, schema := range listResponse.Schemas {
+	for _, schema := range listResponse.Types {
 		ts.Assert().NotEmpty(schema.ID, "Schema should have ID")
 		ts.Assert().NotEmpty(schema.Name, "Schema should have name")
 	}

--- a/tests/integration/usertype/usertype_authz_test.go
+++ b/tests/integration/usertype/usertype_authz_test.go
@@ -307,8 +307,8 @@ func (ts *UserTypeAuthzTestSuite) TestListUserTypes() {
 	var listResp UserTypeListResponse
 	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
 
-	ids := make([]string, 0, len(listResp.Schemas))
-	for _, s := range listResp.Schemas {
+	ids := make([]string, 0, len(listResp.Types))
+	for _, s := range listResp.Types {
 		ids = append(ids, s.ID)
 	}
 


### PR DESCRIPTION
---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The list response payload for `GET /user-types` and `GET /agent-types` renames the array field `schemas` to `types`.

#### 💥 Impact
Any client reading `response.schemas` from these endpoints will receive `undefined`. Affects: in-tree console + `@thunderid/configure-users` package (updated in this PR), Postman/OpenAPI consumers, and any external integration parsing the list response.

#### 🔄 Migration Guide
Replace `schemas` with `types` on the list response.

```diff
- const userTypes = data.schemas;
+ const userTypes = data.types;
```

```diff
  {
    "totalResults": 3,
    "startIndex": 1,
    "count": 3,
-   "schemas": [ ... ]
+   "types": [ ... ]
  }
```

No changes to individual `GET /user-types/{id}` or `GET /agent-types/{id}` payloads, request bodies, or query parameters.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API response structure for type list endpoints: agent types, user types, and entity type listings now return items under a `types` field instead of `schemas`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->