### PR TITLE
Update `asgardeo/thunder` references in `docs` & `frontend`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ThunderID – Architecture Reference
 
-Go IAM server (`github.com/asgardeo/thunder`). Single binary serving a REST API + two React SPAs (`/gate`, `/console`).
+Go IAM server (`github.com/thunder-id/thunder-id`). Single binary serving a REST API + two React SPAs (`/gate`, `/console`).
 
 ## Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Contributing Guide](https://asgardeo.github.io/thunder/docs/next/community/contributing/overview) for guidelines on how to contribute to this project.
+Please refer to the [Contributing Guide](https://thunder-id.github.io/thunder-id/docs/next/community/contributing/overview) for guidelines on how to contribute to this project.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ### Identity Management Suite
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub last commit](https://img.shields.io/github/last-commit/asgardeo/thunder.svg)](https://github.com/asgardeo/thunder/commits/main)
-[![GitHub issues](https://img.shields.io/github/issues/asgardeo/thunder.svg)](https://github.com/asgardeo/thunder/issues)
-[![codecov.io](https://codecov.io/github/asgardeo/thunder/coverage.svg?branch=main)](https://codecov.io/github/asgardeo/thunder?branch=main)
-[![GitHub Release](https://img.shields.io/github/v/release/asgardeo/thunder?color=blue)](https://github.com/asgardeo/thunder/releases/latest)
+[![GitHub last commit](https://img.shields.io/github/last-commit/thunder-id/thunder-id.svg)](https://github.com/thunder-id/thunder-id/commits/main)
+[![GitHub issues](https://img.shields.io/github/issues/thunder-id/thunder-id.svg)](https://github.com/thunder-id/thunder-id/issues)
+[![codecov.io](https://codecov.io/github/thunder-id/coverage.svg?branch=main)](https://codecov.io/github/thunder-id?branch=main)
+[![GitHub Release](https://img.shields.io/github/v/release/thunder-id?color=blue)](https://github.com/thunder-id/releases/latest)
 
 ThunderID is a lightweight, open-source Identity and Access Management (IAM) engine built to secure access for humans, AI agents, and machines.
 
@@ -55,7 +55,7 @@ Follow these steps to download the latest release of ThunderID and run it locall
 
 1. **Download the distribution from the latest release**
 
-    Download `thunderid-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/asgardeo/thunder/releases/latest) for your operating system and architecture.
+    Download `thunderid-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/thunder-id/thunder-id/releases/latest) for your operating system and architecture.
 
     For example, if you are using a MacOS machine with a Apple Silicon (ARM64) processor, you would download `thunderid-<version>-macos-arm64.zip`.
 
@@ -116,7 +116,7 @@ Follow these steps to run ThunderID using Docker Compose.
     Download the `docker-compose.yml` file using the following command:
 
     ```bash
-    curl -o docker-compose.yml https://raw.githubusercontent.com/asgardeo/thunder/v0.37.0/install/quick-start/docker-compose.yml
+    curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunder-id/v0.37.0/install/quick-start/docker-compose.yml
     ```
 
 2. **Start ThunderID**
@@ -157,7 +157,7 @@ ThunderID provides two sample applications to help you get started quickly:
 
 1. **Download the sample**
 
-    Download `sample-app-react-vanilla-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/asgardeo/thunder/releases/latest).
+    Download `sample-app-react-vanilla-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/thunder-id/thunder-id/releases/latest).
 
 2. **Unzip and navigate to the sample app directory**
 
@@ -190,7 +190,7 @@ ThunderID provides two sample applications to help you get started quickly:
 
 1. **Download the sample**
 
-    Download `sample-app-react-sdk-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/asgardeo/thunder/releases/latest).
+    Download `sample-app-react-sdk-<version>-<os>-<arch>.zip` from the [latest release](https://github.com/thunder-id/thunder-id/releases/latest).
 
 2. **Unzip and navigate to the sample app directory**
 
@@ -308,19 +308,19 @@ To try out the Client Credentials flow, follow these steps:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=asgardeo/thunder&type=date&legend=top-left)](https://www.star-history.com/#asgardeo/thunder&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=thunder-id/thunder-id&type=date&legend=top-left)](https://www.star-history.com/#thunder-id/thunder-id&type=date&legend=top-left)
 
 ---
 
 ## Contributing
 
-Please refer to the [Contributing Guide](https://asgardeo.github.io/thunder/docs/next/community/contributing/overview) for the different ways to contribute to this project and the relevant guidelines.
+Please refer to the [Contributing Guide](https://thunder-id.github.io/thunder-id/docs/next/community/contributing/overview) for the different ways to contribute to this project and the relevant guidelines.
 
-For code contributions, refer to the [Contributing Code](https://asgardeo.github.io/thunder/docs/next/community/contributing/contributing-code/prerequisites) section for details on the prerequisites and instructions for running ThunderID in development mode.
+For code contributions, refer to the [Contributing Code](https://thunder-id.github.io/thunder-id/docs/next/community/contributing/contributing-code/prerequisites) section for details on the prerequisites and instructions for running ThunderID in development mode.
 
 ## Documentation
 
-Please refer to the [Documentation](https://asgardeo.github.io/thunder/docs/next/guides/getting-started/what-is-thunder) for additional guidance on getting started with ThunderID and exploring its features, concepts, and usage.
+Please refer to the [Documentation](https://thunder-id.github.io/thunder-id/docs/next/guides/getting-started/what-is-thunder) for additional guidance on getting started with ThunderID and exploring its features, concepts, and usage.
 
 <details>
 <summary><h2>Advanced Setup & Configuration</h2></summary>

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -1,6 +1,6 @@
 thunderid-team:
   name: ThunderID Team
   title: ThunderID Maintainers @ WSO2
-  url: https://github.com/asgardeo/thunder
-  image_url: https://github.com/asgardeo.png
+  url: https://github.com/thunder-id/thunder-id
+  image_url: https://github.com/thunder-id.png
   page: true

--- a/docs/content/community/contributing/contributing-code/backend-development/observability.mdx
+++ b/docs/content/community/contributing/contributing-code/backend-development/observability.mdx
@@ -26,7 +26,7 @@ This guide explains how to instrument your code with observability events and pr
 Your component should accept `ObservabilityServiceInterface` in its constructor or initialization method.
 
 ```go
-import "github.com/asgardeo/thunder/internal/observability"
+import "github.com/thunder-id/thunder-id/internal/observability"
 
 type MyComponent struct {
     obsSvc observability.ObservabilityServiceInterface
@@ -44,7 +44,7 @@ func NewMyComponent(obsSvc observability.ObservabilityServiceInterface) *MyCompo
 Use the injected service to publish events. Always check if the service is enabled (though the service handles no-ops, checking avoids unnecessary object creation).
 
 ```go
-import "github.com/asgardeo/thunder/internal/observability/event"
+import "github.com/thunder-id/thunder-id/internal/observability/event"
 
 func (c *MyComponent) DoSomething(ctx context.Context) {
     // 1. Check if enabled

--- a/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
+++ b/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
@@ -197,7 +197,7 @@ const config: Config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/asgardeo/thunder/tree/main/docs/',
+          editUrl: 'https://github.com/thunder-id/thunder-id/tree/main/docs/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -229,7 +229,7 @@ themeConfig: {
         label: 'Guides',
       },
       {
-        href: 'https://github.com/asgardeo/thunder',
+        href: 'https://github.com/thunder-id/thunder-id',
         label: 'GitHub',
         position: 'right',
       },

--- a/docs/content/community/release-operations.mdx
+++ b/docs/content/community/release-operations.mdx
@@ -89,7 +89,7 @@ The weekly release process uses these GitHub Actions workflows:
 
 | Workflow | Trigger | What It Does |
 | --- | --- | --- |
-| [Pre-Release Sync](https://github.com/asgardeo/thunder/blob/main/.github/workflows/pre-release-sync.yml) | Thursday 9:30 PM UTC and manual dispatch | Merges main into release branch; commits directly if no conflicts, opens a PR otherwise |
-| [Release Milestone Reminder](https://github.com/asgardeo/thunder/blob/main/.github/workflows/release-milestone-reminder.yaml) | Thursday 6:00 AM IST and manual dispatch | Sends release-readiness reminder based on open milestone items |
-| [Release Builder](https://github.com/asgardeo/thunder/blob/main/.github/workflows/release-builder.yml) | Scheduled on Friday and manual dispatch | Builds, tags, packages, and publishes the release |
-| [Post-Release Sync](https://github.com/asgardeo/thunder/blob/main/.github/workflows/post-release-sync.yml) | After successful release workflow run and manual dispatch | Merges release into main directly if no conflicts; opens a conflict-resolution PR otherwise |
+| [Pre-Release Sync](https://github.com/thunder-id/thunder-id/blob/main/.github/workflows/pre-release-sync.yml) | Thursday 9:30 PM UTC and manual dispatch | Merges main into release branch; commits directly if no conflicts, opens a PR otherwise |
+| [Release Milestone Reminder](https://github.com/thunder-id/thunder-id/blob/main/.github/workflows/release-milestone-reminder.yaml) | Thursday 6:00 AM IST and manual dispatch | Sends release-readiness reminder based on open milestone items |
+| [Release Builder](https://github.com/thunder-id/thunder-id/blob/main/.github/workflows/release-builder.yml) | Scheduled on Friday and manual dispatch | Builds, tags, packages, and publishes the release |
+| [Post-Release Sync](https://github.com/thunder-id/thunder-id/blob/main/.github/workflows/post-release-sync.yml) | After successful release workflow run and manual dispatch | Merges release into main directly if no conflicts; opens a conflict-resolution PR otherwise |

--- a/docs/content/guides/deployment-patterns/docker.mdx
+++ b/docs/content/guides/deployment-patterns/docker.mdx
@@ -33,7 +33,7 @@ docker run hello-world
 ### Step 1: Pull the Image
 
 ```bash
-docker pull ghcr.io/asgardeo/thunder:latest
+docker pull ghcr.io/thunder-id/thunder-id:latest
 ```
 
 ### Step 2: Set Up the Server
@@ -42,7 +42,7 @@ Run the one-time setup script before starting <ProductName /> for the first time
 
 ```bash
 docker run -it --rm \
-  ghcr.io/asgardeo/thunder:latest \
+  ghcr.io/thunder-id/thunder-id:latest \
   ./setup.sh
 ```
 
@@ -53,7 +53,7 @@ The container exits after setup completes. If you are using SQLite as the databa
 ```bash
 docker run --rm \
   -p 8090:8090 \
-  ghcr.io/asgardeo/thunder:latest
+  ghcr.io/thunder-id/thunder-id:latest
 ```
 
 <ProductName /> is now running at `https://localhost:8090`.
@@ -66,7 +66,7 @@ To override the default server configuration, mount a custom `deployment.yaml` f
 docker run --rm \
   -p 8090:8090 \
   -v $(pwd)/deployment.yaml:/opt/thunder/repository/conf/deployment.yaml \
-  ghcr.io/asgardeo/thunder:latest
+  ghcr.io/thunder-id/thunder-id:latest
 ```
 
 To also use custom TLS certificates, mount them alongside the configuration:
@@ -77,7 +77,7 @@ docker run --rm \
   -v $(pwd)/deployment.yaml:/opt/thunder/repository/conf/deployment.yaml \
   -v $(pwd)/certs/server.cert:/opt/thunder/repository/resources/security/server.cert \
   -v $(pwd)/certs/server.key:/opt/thunder/repository/resources/security/server.key \
-  ghcr.io/asgardeo/thunder:latest
+  ghcr.io/thunder-id/thunder-id:latest
 ```
 
 ## Access <ProductName />

--- a/docs/content/guides/deployment-patterns/openchoreo.mdx
+++ b/docs/content/guides/deployment-patterns/openchoreo.mdx
@@ -109,7 +109,7 @@ For a repeatable deployment, use a values file:
 
     # Container image configuration
     image:
-      repository: ghcr.io/asgardeo/thunder
+      repository: ghcr.io/thunder-id/thunder-id
       tag: "0.11.0"
 
     # Database configuration

--- a/docs/content/guides/deployment-patterns/production-guidelines.mdx
+++ b/docs/content/guides/deployment-patterns/production-guidelines.mdx
@@ -122,7 +122,7 @@ docker run --rm \
   -v $(pwd)/deployment.yaml:/opt/thunder/repository/conf/deployment.yaml \
   -v $(pwd)/certs/server.cert:/opt/thunder/repository/resources/security/server.cert \
   -v $(pwd)/certs/server.key:/opt/thunder/repository/resources/security/server.key \
-  ghcr.io/asgardeo/thunder:latest
+  ghcr.io/thunder-id/thunder-id:latest
 ```
 
 ## Generate a Unique Encryption Key

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -114,7 +114,7 @@ Download the `docker-compose.yml` file from the <ProductName /> repository:
 
 {/* TODO: Fix the version in the URL below */}
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/asgardeo/thunder/v0.16.0/install/quick-start/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunder-id/v0.16.0/install/quick-start/docker-compose.yml
 ```
 
 ### Step 2: Start <ProductName />

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -7,7 +7,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.36.0 {#v0-36-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 30, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.36.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.36.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -123,7 +123,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.35.0 {#v0-35-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 24, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.35.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.35.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -238,7 +238,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.34.0 {#v0-34-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 17, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.34.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.34.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -328,7 +328,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.33.0 {#v0-33-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 10, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.33.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.33.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -415,7 +415,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.32.0 {#v0-32-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 8, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.32.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.32.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -495,7 +495,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.31.0 {#v0-31-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>April 3, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.31.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.31.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -570,7 +570,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.30.0 {#v0-30-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 27, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.30.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.30.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -667,7 +667,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.29.0 {#v0-29-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 20, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.29.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.29.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -760,7 +760,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.28.0 {#v0-28-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 17, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.28.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.28.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -816,7 +816,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.27.0 {#v0-27-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 13, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.27.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.27.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -910,7 +910,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.26.0 {#v0-26-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 11, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.26.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.26.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -982,7 +982,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.25.0 {#v0-25-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>March 6, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.25.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.25.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1129,7 +1129,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.24.0 {#v0-24-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>February 27, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.24.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.24.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1247,7 +1247,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.23.0 {#v0-23-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>February 20, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.23.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.23.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1359,7 +1359,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.22.0 {#v0-22-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>February 13, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.22.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.22.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1458,7 +1458,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.21.0 {#v0-21-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>February 6, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.21.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.21.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1536,7 +1536,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.20.0 {#v0-20-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>January 30, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.20.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.20.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1613,7 +1613,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.19.0 {#v0-19-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>January 23, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.19.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.19.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1660,7 +1660,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 <div style={{ borderLeft: '3px solid #ff8c00', paddingLeft: '5px', marginLeft: '8px', marginBottom: '24px' }}>
 - Add react-api-based-sample app to the release artifacts
 - Allow defining meta for TASK_EXECUTION nodes
-- Bump golang.org/x/crypto from 0.44.0 to 0.45.0 in /backend by @dependabot[bot] in https://github.com/asgardeo/thunder/pull/1108
+- Bump golang.org/x/crypto from 0.44.0 to 0.45.0 in /backend by @dependabot[bot] in https://github.com/thunder-id/thunder-id/pull/1108
 - Remove i18n keys from default flows
 - Add i18n resolution support for the flow builder UI
 - Add React SDK integration MCP tool
@@ -1687,7 +1687,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.18.0 {#v0-18-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>January 16, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.18.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.18.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1754,7 +1754,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.17.0 {#v0-17-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>January 9, 2026</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.17.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.17.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1810,8 +1810,8 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 - Improve logic in flow-builder UI and remove SCSS styling
 - Introduce unit tests to the flow-builder
 - Improve test coverage in develop app
-- Bump golang.org/x/net from 0.19.0 to 0.38.0 in /backend by @dependabot[bot] in https://github.com/asgardeo/thunder/pull/1050
-- Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in /backend by @dependabot[bot] in https://github.com/asgardeo/thunder/pull/1051
+- Bump golang.org/x/net from 0.19.0 to 0.38.0 in /backend by @dependabot[bot] in https://github.com/thunder-id/thunder-id/pull/1050
+- Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in /backend by @dependabot[bot] in https://github.com/thunder-id/thunder-id/pull/1051
 - Update dockerfile UID&GID to 10001
 </div>
 
@@ -1829,7 +1829,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.16.0 {#v0-16-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>December 24, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.16.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.16.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1936,7 +1936,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.15.0 {#v0-15-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>December 13, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.15.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.15.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -1987,7 +1987,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.14.0 {#v0-14-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>December 6, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.14.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.14.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2079,7 +2079,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.13.0 {#v0-13-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>November 28, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.13.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.13.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2185,7 +2185,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.12.0 {#v0-12-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>November 17, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.12.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.12.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2318,7 +2318,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.11.0 {#v0-11-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>November 4, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.11.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.11.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2429,7 +2429,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.10.0 {#v0-10-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>October 18, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.10.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.10.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2481,7 +2481,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.9.0 {#v0-9-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>October 7, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.9.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.9.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2504,7 +2504,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.8.0 {#v0-8-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>September 23, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.8.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.8.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>
@@ -2533,7 +2533,7 @@ Explore the latest updates, features, and improvements to **ThunderID**.
 ## v0.7.0 {#v0-7-0}
 <p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>
   <span>📅 Published on <strong>September 10, 2025</strong></span> • 
-  <a href="https://github.com/asgardeo/thunder/releases/tag/v0.7.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
+  <a href="https://github.com/thunder-id/thunder-id/releases/tag/v0.7.0" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>
 </p>
 
 <div style={{ padding: '15px', marginBottom: '10px',}}>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -59,7 +59,7 @@ const config: Config = {
 
   // Prevent search engine indexing
   // TODO: Remove this flag when the docs are ready for public access
-  // Tracker: https://github.com/asgardeo/thunder/issues/1209
+  // Tracker: https://github.com/thunder-id/thunder-id/issues/1209
   noIndex: true,
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -245,7 +245,7 @@ const config: Config = {
               value: '<hr style="margin: 0.3rem 0;">',
             },
             {
-              href: 'https://github.com/asgardeo/thunder/issues/1912',
+              href: 'https://github.com/thunder-id/thunder-id/issues/1912',
               label: '🌍 Help translate',
             },
           ],

--- a/docs/docusaurus.product.config.ts
+++ b/docs/docusaurus.product.config.ts
@@ -65,18 +65,18 @@ const DocusaurusProductConfig = {
       'ThunderID is a modern, open-source identity management service designed for teams building secure, customizable authentication experiences across applications, services, and AI agents.',
     source: {
       github: {
-        name: 'thunder',
-        fullName: 'asgardeo/thunder',
-        url: 'https://github.com/asgardeo/thunder',
-        discussionsUrl: 'https://github.com/asgardeo/thunder/discussions',
-        issuesUrl: 'https://github.com/asgardeo/thunder/issues',
-        releasesUrl: 'https://github.com/asgardeo/thunder/releases',
+        name: 'thunder-id',
+        fullName: 'thunder-id/thunder-id',
+        url: 'https://github.com/thunder-id/thunder-id',
+        discussionsUrl: 'https://github.com/thunder-id/thunder-id/discussions',
+        issuesUrl: 'https://github.com/thunder-id/thunder-id/issues',
+        releasesUrl: 'https://github.com/thunder-id/thunder-id/releases',
         editUrls: {
-          blog: 'https://github.com/asgardeo/thunder/tree/main/blog/',
-          content: 'https://github.com/asgardeo/thunder/tree/main/docs/',
+          blog: 'https://github.com/thunder-id/thunder-id/tree/main/blog/',
+          content: 'https://github.com/thunder-id/thunder-id/tree/main/docs/',
         },
         owner: {
-          name: 'asgardeo',
+          name: 'thunder-id',
         },
       },
     },
@@ -92,10 +92,10 @@ const DocusaurusProductConfig = {
     },
     deployment: {
       production: {
-        baseUrl: 'thunder',
+        baseUrl: 'thunder-id',
         // TODO: Docusaurus doesn't seem to allow subpaths in the URL yet.
         // Can't use the GitHub pages URL until then.
-        url: 'https://thunder.dev',
+        url: 'https://thunderid.dev',
       },
     },
   },

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -106,4 +106,4 @@ Common locale codes:
 
 ## Questions?
 
-If you have questions about translations, please open a [discussion](https://github.com/asgardeo/thunder/discussions) or [issue](https://github.com/asgardeo/thunder/issues).
+If you have questions about translations, please open a [discussion](https://github.com/thunder-id/thunder-id/discussions) or [issue](https://github.com/thunder-id/thunder-id/issues).

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,16 +5,16 @@
   "description": "Documentation for ⚡️ ThunderID",
   "author": "WSO2",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/docs#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/docs#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder"
+    "url": "https://github.com/thunder-id/thunder-id"
   },
   "keywords": [
-    "asgardeo",
+    "thunder-id",
     "thunderid",
     "docs",
     "documentation",

--- a/docs/src/components/HomePage/CommunitySection.tsx
+++ b/docs/src/components/HomePage/CommunitySection.tsx
@@ -220,7 +220,7 @@ export default function CommunitySection(): JSX.Element {
               title="Contribute"
               description={`Help shape ${productName} by submitting features, fixes, or improvements.`}
               linkLabel="Start Contributing"
-              href="https://github.com/asgardeo/thunder/blob/main/CONTRIBUTING.md"
+              href="https://github.com/thunder-id/thunder-id/blob/main/CONTRIBUTING.md"
             />
             <CommunityCard
               icon={<IssueIcon />}
@@ -228,7 +228,7 @@ export default function CommunitySection(): JSX.Element {
               title="Report issues"
               description={`Identify bugs and suggest enhancements to make ${productName} better for everyone.`}
               linkLabel="Open an Issue"
-              href="https://github.com/asgardeo/thunder/issues"
+              href="https://github.com/thunder-id/thunder-id/issues"
             />
             <CommunityCard
               icon={<DiscordIcon />}

--- a/frontend/apps/console/package.json
+++ b/frontend/apps/console/package.json
@@ -9,16 +9,16 @@
     "app",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/apps/console#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/apps/console#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/apps/console"
   },
   "scripts": {

--- a/frontend/apps/console/src/features/applications/utils/getConfigurationTypeFromTemplate.ts
+++ b/frontend/apps/console/src/features/applications/utils/getConfigurationTypeFromTemplate.ts
@@ -41,7 +41,7 @@ const getConfigurationTypeFromTemplate = (
   }
 
   // If redirectUris is undefined, null, or empty array, determine what type of configuration is needed
-  // TODO: Remove this once https://github.com/asgardeo/thunder/pulls/924 is merged.
+  // TODO: Remove this once https://github.com/thunder-id/thunder-id/pulls/924 is merged.
   const templateName = templateConfig.defaults?.name?.toLowerCase() ?? '';
 
   // Mobile apps need deep link

--- a/frontend/apps/gate/package.json
+++ b/frontend/apps/gate/package.json
@@ -9,16 +9,16 @@
     "app",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/apps/gate#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/apps/gate#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/apps/gate"
   },
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,13 +6,13 @@
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder"
+    "url": "https://github.com/thunder-id/thunder-id"
   },
   "keywords": [
     "asgardeo",

--- a/frontend/packages/components/package.json
+++ b/frontend/packages/components/package.json
@@ -11,9 +11,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/components#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/components#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/components"
   },
   "scripts": {

--- a/frontend/packages/configure-agent-types/package.json
+++ b/frontend/packages/configure-agent-types/package.json
@@ -10,9 +10,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/configure-agent-types#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/configure-agent-types#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/configure-agent-types"
   },
   "scripts": {

--- a/frontend/packages/configure-organization-units/package.json
+++ b/frontend/packages/configure-organization-units/package.json
@@ -10,9 +10,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/configure-organization-units#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/configure-organization-units#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/configure-organization-units"
   },
   "scripts": {

--- a/frontend/packages/configure-translations/package.json
+++ b/frontend/packages/configure-translations/package.json
@@ -10,9 +10,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/configure-translations#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/configure-translations#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/configure-translations"
   },
   "scripts": {

--- a/frontend/packages/configure-users/package.json
+++ b/frontend/packages/configure-users/package.json
@@ -10,9 +10,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/configure-users#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/configure-users#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/configure-users"
   },
   "scripts": {

--- a/frontend/packages/contexts/package.json
+++ b/frontend/packages/contexts/package.json
@@ -9,9 +9,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/contexts#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/contexts#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/contexts"
   },
   "scripts": {

--- a/frontend/packages/create/package.json
+++ b/frontend/packages/create/package.json
@@ -11,9 +11,9 @@
     "create",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/create#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/create#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/create"
   },
   "scripts": {

--- a/frontend/packages/create/src/templates/feature/package.json.hbs
+++ b/frontend/packages/create/src/templates/feature/package.json.hbs
@@ -10,9 +10,9 @@
     "feature",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/{{featureType}}-{{featureName}}#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/{{featureType}}-{{featureName}}#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/{{featureType}}-{{featureName}}"
   },
   "scripts": {

--- a/frontend/packages/design/package.json
+++ b/frontend/packages/design/package.json
@@ -9,9 +9,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/design#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/design#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/design"
   },
   "scripts": {

--- a/frontend/packages/eslint-plugin/package.json
+++ b/frontend/packages/eslint-plugin/package.json
@@ -11,9 +11,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/eslint-config#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/eslint-config#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/eslint-plugin"
   },
   "nx": {

--- a/frontend/packages/hooks/package.json
+++ b/frontend/packages/hooks/package.json
@@ -9,9 +9,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/hooks#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/hooks#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/hooks"
   },
   "scripts": {

--- a/frontend/packages/logger/package.json
+++ b/frontend/packages/logger/package.json
@@ -9,9 +9,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/logger#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/logger#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/logger"
   },
   "scripts": {

--- a/frontend/packages/prettier-config/package.json
+++ b/frontend/packages/prettier-config/package.json
@@ -9,9 +9,9 @@
     "shareable",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/prettier-config#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/prettier-config#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/prettier-config"
   },
   "nx": {

--- a/frontend/packages/test-utils/package.json
+++ b/frontend/packages/test-utils/package.json
@@ -10,9 +10,9 @@
     "testing-library",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/test-utils#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/test-utils#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -45,7 +45,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/test-utils"
   },
   "scripts": {

--- a/frontend/packages/types/package.json
+++ b/frontend/packages/types/package.json
@@ -9,9 +9,9 @@
     "typescript",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/types#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/types#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/types"
   },
   "scripts": {

--- a/frontend/packages/utils/package.json
+++ b/frontend/packages/utils/package.json
@@ -9,9 +9,9 @@
     "typescript",
     "wso2"
   ],
-  "homepage": "https://github.com/asgardeo/thunder/tree/main/frontend/packages/utils#readme",
+  "homepage": "https://github.com/thunder-id/thunder-id/tree/main/frontend/packages/utils#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunder-id/issues"
   },
   "author": "WSO2",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder",
+    "url": "https://github.com/thunder-id/thunder-id",
     "directory": "frontend/packages/utils"
   },
   "scripts": {

--- a/frontend/scripts/build-docs.js
+++ b/frontend/scripts/build-docs.js
@@ -21,7 +21,7 @@
 /* eslint-disable @thunderid/copyright-header */
 
 // TODO: We can remove this once NX sorts out their current limitations for including folder outside the workspace.
-// Tracker: https://github.com/asgardeo/thunder/issues/1199
+// Tracker: https://github.com/thunder-id/thunder-id/issues/1199
 
 import {spawn} from 'node:child_process';
 import {resolve, join} from 'node:path';


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates all project documentation, configuration, and references to reflect the migration from the `asgardeo/thunder` organization and repository to the new `thunder-id/thunder-id` namespace. The changes ensure that all links, import paths, Docker images, and badges consistently point to the new organization and repository, preventing confusion and ensuring users and contributors access the correct resources.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Update references in:
- docs
- frontend
- `.md` files at the root

### Related Issues
- https://github.com/thunder-id/thunder-id/issues/2466

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
