### PR TITLE
Revamp application creation wizard step order

### DIFF
--- a/frontend/apps/console/src/features/applications/contexts/ApplicationCreate/ApplicationCreateProvider.tsx
+++ b/frontend/apps/console/src/features/applications/contexts/ApplicationCreate/ApplicationCreateProvider.tsx
@@ -62,7 +62,7 @@ const INITIAL_STATE: {
   hasCompletedOnboarding: boolean;
   error: string | null;
 } = {
-  currentStep: ApplicationCreateFlowStep.NAME,
+  currentStep: ApplicationCreateFlowStep.STACK,
   appName: '',
   ouId: '',
   themeId: null,

--- a/frontend/apps/console/src/features/applications/contexts/ApplicationCreate/__tests__/ApplicationCreateProvider.test.tsx
+++ b/frontend/apps/console/src/features/applications/contexts/ApplicationCreate/__tests__/ApplicationCreateProvider.test.tsx
@@ -130,7 +130,7 @@ describe('ApplicationCreateProvider', () => {
       </ApplicationCreateProvider>,
     );
 
-    expect(screen.getByTestId('current-step')).toHaveTextContent(ApplicationCreateFlowStep.NAME);
+    expect(screen.getByTestId('current-step')).toHaveTextContent(ApplicationCreateFlowStep.STACK);
     expect(screen.getByTestId('app-name')).toHaveTextContent('');
     expect(screen.getByTestId('selected-theme')).toHaveTextContent('null');
     expect(screen.getByTestId('app-logo')).toHaveTextContent('null');
@@ -334,7 +334,7 @@ describe('ApplicationCreateProvider', () => {
     await user.click(screen.getByText('Reset'));
 
     // Verify back to initial state
-    expect(screen.getByTestId('current-step')).toHaveTextContent(ApplicationCreateFlowStep.NAME);
+    expect(screen.getByTestId('current-step')).toHaveTextContent(ApplicationCreateFlowStep.STACK);
     expect(screen.getByTestId('app-name')).toHaveTextContent('');
     expect(screen.getByTestId('error')).toHaveTextContent('null');
     expect(screen.getByTestId('selected-theme')).toHaveTextContent('null');

--- a/frontend/apps/console/src/features/applications/data/application-templates/platform-based/backend.json
+++ b/frontend/apps/console/src/features/applications/data/application-templates/platform-based/backend.json
@@ -2,6 +2,9 @@
   "id": "backend",
   "displayName": "Backend",
   "description": "Machine-to-machine backend service",
+  "creationFlow": {
+    "steps": ["STACK", "NAME", "ORGANIZATION_UNIT", "COMPLETE"]
+  },
   "defaults": {
     "name": "Backend Application",
     "inboundAuthConfig": [

--- a/frontend/apps/console/src/features/applications/models/application-create-flow.ts
+++ b/frontend/apps/console/src/features/applications/models/application-create-flow.ts
@@ -41,12 +41,12 @@
  * @public
  */
 export const ApplicationCreateFlowStep = {
+  STACK: 'STACK',
   NAME: 'NAME',
   ORGANIZATION_UNIT: 'ORGANIZATION_UNIT',
   DESIGN: 'DESIGN',
   OPTIONS: 'OPTIONS',
   EXPERIENCE: 'EXPERIENCE',
-  STACK: 'STACK',
   CONFIGURE: 'CONFIGURE',
   COMPLETE: 'COMPLETE',
 } as const;

--- a/frontend/apps/console/src/features/applications/models/application-templates.ts
+++ b/frontend/apps/console/src/features/applications/models/application-templates.ts
@@ -17,6 +17,7 @@
  */
 
 import type {JSX} from 'react';
+import type {CreationFlow} from './creation-flow';
 import type {InboundAuthConfig} from './inbound-auth';
 import type {OAuth2Config} from './oauth';
 
@@ -165,6 +166,11 @@ export interface ApplicationTemplate {
    * @example 'React', 'Next.js', 'Browser'
    */
   displayName?: string;
+  /**
+   * Inline creation flow declaring the wizard step sequence for this template.
+   * Templates without a `creationFlow` use the default user-facing flow.
+   */
+  creationFlow?: CreationFlow;
   /**
    * Description of the template
    */

--- a/frontend/apps/console/src/features/applications/models/creation-flow.ts
+++ b/frontend/apps/console/src/features/applications/models/creation-flow.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ApplicationCreateFlowStep} from './application-create-flow';
+
+/**
+ * Wizard step ordering for creating an application.
+ *
+ * Each application template declares its own creation flow inline via
+ * `ApplicationTemplate.creationFlow`. Templates without an explicit flow
+ * default to the user-facing flow (see `resolveCreationFlow`).
+ *
+ * @public
+ */
+export interface CreationFlow {
+  /** Ordered list of wizard steps for this flow. */
+  steps: ApplicationCreateFlowStep[];
+}

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -61,6 +61,7 @@ import {
 import type {OAuth2Config} from '../models/oauth';
 import type {CreateApplicationRequest} from '../models/requests';
 import getConfigurationTypeFromTemplate from '../utils/getConfigurationTypeFromTemplate';
+import resolveCreationFlow from '../utils/resolveCreationFlow';
 import GatePreview from '@/components/GatePreview/GatePreview';
 import buildPreviewMock from '@/components/GatePreview/mocks/buildPreviewMock';
 
@@ -100,12 +101,12 @@ export default function ApplicationCreatePage(): JSX.Element {
 
   const steps: Record<ApplicationCreateFlowStep, {label: string; order: number}> = useMemo(
     () => ({
-      NAME: {label: t('applications:onboarding.steps.name'), order: 1},
-      ORGANIZATION_UNIT: {label: t('applications:onboarding.steps.organizationUnit'), order: 2},
-      DESIGN: {label: t('applications:onboarding.steps.design'), order: 3},
-      OPTIONS: {label: t('applications:onboarding.steps.options'), order: 4},
-      EXPERIENCE: {label: t('applications:onboarding.steps.experience'), order: 5},
-      STACK: {label: t('applications:onboarding.steps.stack'), order: 6},
+      STACK: {label: t('applications:onboarding.steps.stack'), order: 1},
+      NAME: {label: t('applications:onboarding.steps.name'), order: 2},
+      ORGANIZATION_UNIT: {label: t('applications:onboarding.steps.organizationUnit'), order: 3},
+      DESIGN: {label: t('applications:onboarding.steps.design'), order: 4},
+      OPTIONS: {label: t('applications:onboarding.steps.options'), order: 5},
+      EXPERIENCE: {label: t('applications:onboarding.steps.experience'), order: 6},
       CONFIGURE: {label: t('applications:onboarding.steps.configure'), order: 7},
       COMPLETE: {label: t('applications:onboarding.steps.complete'), order: 8},
     }),
@@ -124,12 +125,12 @@ export default function ApplicationCreatePage(): JSX.Element {
   const {data: idpData} = useIdentityProviders();
 
   const [stepReady, setStepReady] = useState<Record<ApplicationCreateFlowStep, boolean>>({
+    STACK: true,
     NAME: false,
     ORGANIZATION_UNIT: false,
     DESIGN: true,
     OPTIONS: true,
     EXPERIENCE: true,
-    STACK: true,
     CONFIGURE: true,
     COMPLETE: true,
   });
@@ -141,6 +142,31 @@ export default function ApplicationCreatePage(): JSX.Element {
       oauthConfig && callbackUrlFromConfig ? {...oauthConfig, redirectUris: [callbackUrlFromConfig]} : oauthConfig,
     [oauthConfig, callbackUrlFromConfig],
   );
+
+  const creationFlow = useMemo(() => resolveCreationFlow(selectedTemplateConfig), [selectedTemplateConfig]);
+
+  const needsConfigure = useMemo((): boolean => {
+    const isPasskeyEnabled = !selectedAuthFlow && (integrations[AuthenticatorTypes.PASSKEY] ?? false);
+    if (signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED) {
+      return isPasskeyEnabled;
+    }
+    return (
+      getConfigurationTypeFromTemplate(selectedTemplateConfig) !== ApplicationCreateFlowConfiguration.NONE ||
+      isPasskeyEnabled
+    );
+  }, [selectedTemplateConfig, integrations, signInApproach, selectedAuthFlow]);
+
+  const visibleSteps = useMemo((): ApplicationCreateFlowStep[] => {
+    return creationFlow.steps.filter((step) => {
+      if (step === ApplicationCreateFlowStep.ORGANIZATION_UNIT) return hasMultipleOUs;
+      if (step === ApplicationCreateFlowStep.CONFIGURE) return needsConfigure;
+      // COMPLETE step is dynamic — only shown when an app with a client secret is created.
+      // It's filtered out of visibleSteps here and is only set explicitly via setCurrentStep
+      // when the creation succeeds with a client secret.
+      if (step === ApplicationCreateFlowStep.COMPLETE) return false;
+      return true;
+    });
+  }, [creationFlow, hasMultipleOUs, needsConfigure]);
 
   const handleClose = (): void => {
     (async () => {
@@ -162,57 +188,49 @@ export default function ApplicationCreatePage(): JSX.Element {
   const handleCreateApplication = (skipOAuthConfig = false, overrideFlowId?: string): void => {
     setError(null);
 
+    const includesOptions = creationFlow.steps.includes(ApplicationCreateFlowStep.OPTIONS);
+    const includesDesign = creationFlow.steps.includes(ApplicationCreateFlowStep.DESIGN);
+    const includesExperience = creationFlow.steps.includes(ApplicationCreateFlowStep.EXPERIENCE);
+
     const authFlowId: string | undefined = overrideFlowId ?? selectedAuthFlow?.id;
 
-    // Validate that we have a valid flow selected
-    if (!authFlowId) {
+    // authFlowId is only required when the flow has user-facing sign-in steps
+    if (includesOptions && !authFlowId) {
       setError(t('onboarding.configure.SignInOptions.noFlowFound'));
-
       return;
     }
 
     const userTypes = userTypesData?.schemas ?? [];
     const allowedUserTypes = (() => {
-      // If there's exactly 1 user type, automatically include it
-      if (userTypes.length === 1) {
-        return [userTypes[0].name];
-      }
-
-      // If there are multiple user types, use the selected ones
-      if (userTypes.length > 1) {
-        return selectedUserTypes.length > 0 ? selectedUserTypes : undefined;
-      }
-
-      // If there are no user types, don't include the field
+      if (userTypes.length === 1) return [userTypes[0].name];
+      if (userTypes.length > 1) return selectedUserTypes.length > 0 ? selectedUserTypes : undefined;
       return undefined;
     })();
 
     const effectiveOuId = hasMultipleOUs ? ouId : ouList[0]?.id;
 
+    const templateId = selectedTemplateConfig?.id;
+    const finalTemplateId =
+      templateId && includesExperience && signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED
+        ? `${templateId}${TemplateConstants.EMBEDDED_SUFFIX}`
+        : templateId;
+
     const applicationData: CreateApplicationRequest = {
       name: appName,
-      logoUrl: appLogo ?? undefined,
-      authFlowId,
-      userAttributes: ['given_name', 'family_name', 'email', 'groups'],
-      ...(themeId && {themeId}),
-      isRegistrationFlowEnabled: true,
-      ...(allowedUserTypes && {allowedUserTypes}),
+      ...(authFlowId && {authFlowId}),
       ...(effectiveOuId && {ouId: effectiveOuId}),
-      // Include template if available, append '-embedded' suffix for CUSTOM approach
-      ...(selectedTemplateConfig?.id && {
-        template:
-          signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED
-            ? `${selectedTemplateConfig.id}${TemplateConstants.EMBEDDED_SUFFIX}`
-            : selectedTemplateConfig.id,
+      ...(finalTemplateId && {template: finalTemplateId}),
+      ...(includesDesign && {
+        logoUrl: appLogo ?? undefined,
+        ...(themeId && {themeId}),
       }),
-      // Only include OAuth config if not skipping
+      ...(includesOptions && {
+        userAttributes: ['given_name', 'family_name', 'email', 'groups'],
+        isRegistrationFlowEnabled: true,
+      }),
+      ...(includesExperience && allowedUserTypes && {allowedUserTypes}),
       ...(!skipOAuthConfig && {
-        inboundAuthConfig: [
-          {
-            type: 'oauth2',
-            config: effectiveOauthConfig,
-          },
-        ],
+        inboundAuthConfig: [{type: 'oauth2', config: effectiveOauthConfig}],
       }),
     };
 
@@ -223,11 +241,9 @@ export default function ApplicationCreatePage(): JSX.Element {
         );
 
         if (hasClientSecret) {
-          // Store the application and show the COMPLETE step
           setCreatedApplication(createdApp);
           setCurrentStep(ApplicationCreateFlowStep.COMPLETE);
         } else {
-          // No client secret, navigate directly to the application details page
           (async () => {
             await navigate(`/applications/${createdApp.id}`);
           })().catch((_error: unknown) => {
@@ -285,110 +301,49 @@ export default function ApplicationCreatePage(): JSX.Element {
   };
 
   const handleNextStep = (): void => {
-    switch (currentStep) {
-      case ApplicationCreateFlowStep.NAME:
-        if (isOuLoading) return;
-        if (hasMultipleOUs) {
-          setCurrentStep(ApplicationCreateFlowStep.ORGANIZATION_UNIT);
-        } else {
-          setCurrentStep(ApplicationCreateFlowStep.DESIGN);
-        }
-        break;
-      case ApplicationCreateFlowStep.ORGANIZATION_UNIT:
-        setCurrentStep(ApplicationCreateFlowStep.DESIGN);
-        break;
-      case ApplicationCreateFlowStep.DESIGN:
-        setCurrentStep(ApplicationCreateFlowStep.OPTIONS);
-        break;
-      case ApplicationCreateFlowStep.OPTIONS:
-        setCurrentStep(ApplicationCreateFlowStep.EXPERIENCE);
-        break;
-      case ApplicationCreateFlowStep.EXPERIENCE:
-        // Always go to technology selection to set selectedTemplateConfig
-        setCurrentStep(ApplicationCreateFlowStep.STACK);
-        break;
-      case ApplicationCreateFlowStep.STACK: {
-        // For INBUILT approach and EMBEDDED approach, check if passkey configuration is needed
-        const isPasskeyConfigEnabled: boolean =
-          !selectedAuthFlow && (integrations[AuthenticatorTypes.PASSKEY] ?? false);
-
-        // For CUSTOM approach, create app immediately after technology selection, unless passkey config is needed
-        if (signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED) {
-          if (isPasskeyConfigEnabled) {
-            setCurrentStep(ApplicationCreateFlowStep.CONFIGURE);
-          } else {
-            ensureFlowAndCreateApplication(true); // Skip OAuth for custom
-          }
-          break;
-        }
-
-        const configurationType: ApplicationCreateFlowConfiguration =
-          getConfigurationTypeFromTemplate(selectedTemplateConfig);
-
-        const needsConfiguration: boolean =
-          configurationType !== ApplicationCreateFlowConfiguration.NONE || isPasskeyConfigEnabled;
-
-        if (needsConfiguration) {
-          setCurrentStep(ApplicationCreateFlowStep.CONFIGURE);
-        } else {
-          // Skip configure step for technologies/platforms that don't need it
-          ensureFlowAndCreateApplication(false);
-        }
-        break;
-      }
-      case ApplicationCreateFlowStep.CONFIGURE:
-        // Configuration complete, create application
-        if (signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED) {
-          ensureFlowAndCreateApplication(true);
-        } else {
-          ensureFlowAndCreateApplication(false);
-        }
-        break;
-      case ApplicationCreateFlowStep.COMPLETE:
-        // Navigate to the application details page
-        if (createdApplication) {
-          (async () => {
-            await navigate(`/applications/${createdApplication.id}`);
-          })().catch((_error: unknown) => {
-            logger.error('Failed to navigate to application details', {
-              error: _error,
-              applicationId: createdApplication.id,
-            });
+    // COMPLETE is a terminal step after creation — handled separately
+    if (currentStep === ApplicationCreateFlowStep.COMPLETE) {
+      if (createdApplication) {
+        (async () => {
+          await navigate(`/applications/${createdApplication.id}`);
+        })().catch((_error: unknown) => {
+          logger.error('Failed to navigate to application details', {
+            error: _error,
+            applicationId: createdApplication.id,
           });
-        }
-        break;
-      default:
-        break;
+        });
+      }
+      return;
+    }
+
+    // NAME has a special wait condition for OU loading
+    if (currentStep === ApplicationCreateFlowStep.NAME && isOuLoading) return;
+
+    const idx = visibleSteps.indexOf(currentStep);
+    const next = visibleSteps[idx + 1];
+
+    if (next === undefined) {
+      // No more visible steps → create the application
+      const includesOptions = creationFlow.steps.includes(ApplicationCreateFlowStep.OPTIONS);
+      const includesExperience = creationFlow.steps.includes(ApplicationCreateFlowStep.EXPERIENCE);
+      const skipOAuth = includesExperience && signInApproach === ApplicationCreateFlowSignInApproach.EMBEDDED;
+
+      if (includesOptions) {
+        // user-facing flow → may need to generate the auth flow from integrations
+        ensureFlowAndCreateApplication(skipOAuth);
+      } else {
+        // m2m flow → no integrations; server assigns default flow
+        handleCreateApplication(false);
+      }
+    } else {
+      setCurrentStep(next);
     }
   };
 
   const handlePrevStep = (): void => {
-    switch (currentStep) {
-      case ApplicationCreateFlowStep.ORGANIZATION_UNIT:
-        setCurrentStep(ApplicationCreateFlowStep.NAME);
-        break;
-      case ApplicationCreateFlowStep.DESIGN:
-        if (hasMultipleOUs) {
-          setCurrentStep(ApplicationCreateFlowStep.ORGANIZATION_UNIT);
-        } else {
-          setCurrentStep(ApplicationCreateFlowStep.NAME);
-        }
-        break;
-      case ApplicationCreateFlowStep.OPTIONS:
-        setCurrentStep(ApplicationCreateFlowStep.DESIGN);
-        break;
-      case ApplicationCreateFlowStep.EXPERIENCE:
-        setCurrentStep(ApplicationCreateFlowStep.OPTIONS);
-        break;
-      case ApplicationCreateFlowStep.STACK:
-        setCurrentStep(ApplicationCreateFlowStep.EXPERIENCE);
-        break;
-      case ApplicationCreateFlowStep.CONFIGURE:
-        setCurrentStep(ApplicationCreateFlowStep.STACK);
-        break;
-      default:
-        break;
-    }
+    const idx = visibleSteps.indexOf(currentStep);
+    const prev = visibleSteps[idx - 1];
+    if (prev) setCurrentStep(prev);
   };
 
   const handleStepReadyChange = useCallback((step: ApplicationCreateFlowStep, isReady: boolean): void => {
@@ -546,33 +501,9 @@ export default function ApplicationCreatePage(): JSX.Element {
   };
 
   const getBreadcrumbSteps = (): ApplicationCreateFlowStep[] => {
-    const allSteps: ApplicationCreateFlowStep[] = [ApplicationCreateFlowStep.NAME];
-
-    if (hasMultipleOUs) {
-      allSteps.push(ApplicationCreateFlowStep.ORGANIZATION_UNIT);
-    }
-
-    allSteps.push(
-      ApplicationCreateFlowStep.DESIGN,
-      ApplicationCreateFlowStep.OPTIONS,
-      ApplicationCreateFlowStep.EXPERIENCE,
-    );
-
-    // Only show technology and configure steps for inbuilt approach
-    if (signInApproach === ApplicationCreateFlowSignInApproach.INBUILT) {
-      allSteps.push(ApplicationCreateFlowStep.STACK);
-
-      // Show configure step if template requires configuration (has empty redirectUris)
-      const needsConfiguration: boolean =
-        getConfigurationTypeFromTemplate(selectedTemplateConfig) !== ApplicationCreateFlowConfiguration.NONE;
-
-      if (needsConfiguration) {
-        allSteps.push(ApplicationCreateFlowStep.CONFIGURE);
-      }
-    }
-
-    const currentIndex = allSteps.indexOf(currentStep);
-    return allSteps.slice(0, currentIndex + 1);
+    const idx = visibleSteps.indexOf(currentStep);
+    if (idx < 0) return visibleSteps;
+    return visibleSteps.slice(0, idx + 1);
   };
 
   return (
@@ -584,6 +515,7 @@ export default function ApplicationCreatePage(): JSX.Element {
         <Box
           sx={{
             flex:
+              currentStep === ApplicationCreateFlowStep.STACK ||
               currentStep === ApplicationCreateFlowStep.NAME ||
               currentStep === ApplicationCreateFlowStep.ORGANIZATION_UNIT ||
               currentStep === ApplicationCreateFlowStep.COMPLETE
@@ -636,6 +568,7 @@ export default function ApplicationCreatePage(): JSX.Element {
                 py: 8,
                 px: 20,
                 mx:
+                  currentStep === ApplicationCreateFlowStep.STACK ||
                   currentStep === ApplicationCreateFlowStep.NAME ||
                   currentStep === ApplicationCreateFlowStep.ORGANIZATION_UNIT
                     ? 'auto'
@@ -665,21 +598,20 @@ export default function ApplicationCreatePage(): JSX.Element {
                   sx={{
                     mt: 4,
                     display: 'flex',
-                    justifyContent: currentStep === ApplicationCreateFlowStep.NAME ? 'flex-end' : 'space-between',
+                    justifyContent: visibleSteps.indexOf(currentStep) === 0 ? 'flex-end' : 'space-between',
                     gap: 2,
                   }}
                 >
-                  {currentStep !== ApplicationCreateFlowStep.NAME &&
-                    currentStep !== ApplicationCreateFlowStep.COMPLETE && (
-                      <Button
-                        variant="outlined"
-                        onClick={handlePrevStep}
-                        sx={{minWidth: 100}}
-                        disabled={createApplication.isPending}
-                      >
-                        {t('common:actions.back')}
-                      </Button>
-                    )}
+                  {visibleSteps.indexOf(currentStep) !== 0 && currentStep !== ApplicationCreateFlowStep.COMPLETE && (
+                    <Button
+                      variant="outlined"
+                      onClick={handlePrevStep}
+                      sx={{minWidth: 100}}
+                      disabled={createApplication.isPending}
+                    >
+                      {t('common:actions.back')}
+                    </Button>
+                  )}
 
                   {currentStep !== ApplicationCreateFlowStep.COMPLETE && (
                     <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
@@ -705,7 +637,8 @@ export default function ApplicationCreatePage(): JSX.Element {
           </Box>
         </Box>
         {/* Right side - Preview (show from design step onwards, but hide on complete step) */}
-        {currentStep !== ApplicationCreateFlowStep.NAME &&
+        {currentStep !== ApplicationCreateFlowStep.STACK &&
+          currentStep !== ApplicationCreateFlowStep.NAME &&
           currentStep !== ApplicationCreateFlowStep.ORGANIZATION_UNIT &&
           currentStep !== ApplicationCreateFlowStep.COMPLETE && (
             <Box sx={{flex: '0 0 50%', display: 'flex', flexDirection: 'column', p: 5}}>

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -257,12 +257,36 @@ vi.mock('../../components/create-application/ConfigureExperience', () => ({
   },
 }));
 
-vi.mock('../../components/create-application/ConfigureStack', () => ({
-  default: ({onReadyChange}: {onReadyChange: (ready: boolean) => void}) => {
-    setTimeout(() => onReadyChange(true), 0);
-    return <div data-testid="application-configure-stack">Configure Stack</div>;
-  },
-}));
+vi.mock('../../components/create-application/ConfigureStack', async () => {
+  const useApplicationCreateContextModule = await import('../../hooks/useApplicationCreateContext');
+
+  return {
+    default: ({onReadyChange}: {onReadyChange: (ready: boolean) => void}) => {
+      const {setSelectedPlatform, setSelectedTemplateConfig} = useApplicationCreateContextModule.default();
+
+      setTimeout(() => onReadyChange(true), 0);
+
+      const handleSelectBackend = () => {
+        setSelectedPlatform('BACKEND');
+        setSelectedTemplateConfig({
+          id: 'backend',
+          creationFlow: {
+            steps: ['STACK', 'NAME', 'ORGANIZATION_UNIT', 'COMPLETE'],
+          },
+        });
+      };
+
+      return (
+        <div data-testid="application-configure-stack">
+          Configure Stack
+          <button type="button" data-testid="select-backend-platform" onClick={handleSelectBackend}>
+            Select Backend
+          </button>
+        </div>
+      );
+    },
+  };
+});
 
 vi.mock('../../components/create-application/ConfigureDetails', () => ({
   default: ({
@@ -336,11 +360,11 @@ describe('ApplicationCreatePage', () => {
   });
 
   describe('Initial Rendering', () => {
-    it('should render the name step by default', () => {
+    it('should render the stack step by default', () => {
       renderWithProviders();
 
-      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
-      expect(screen.queryByTestId('application-configure-design')).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-name')).not.toBeInTheDocument();
     });
 
     it('should not show preview on first step', () => {
@@ -359,20 +383,27 @@ describe('ApplicationCreatePage', () => {
     it('should show breadcrumb with current step', () => {
       renderWithProviders();
 
-      expect(screen.getByText('Create an Application')).toBeInTheDocument();
+      expect(screen.getByText('Technology Stack')).toBeInTheDocument();
     });
   });
 
   describe('Step Navigation', () => {
-    it('should disable Continue button when name is empty', () => {
+    it('should disable Continue button when name is empty', async () => {
       renderWithProviders();
 
+      // Navigate from STACK to NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
       const continueButton = screen.getByRole('button', {name: /continue/i});
       expect(continueButton).toBeDisabled();
     });
 
     it('should enable Continue button when name is entered', async () => {
       renderWithProviders();
+
+      // Navigate from STACK to NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
 
       const nameInput = screen.getByTestId('app-name-input');
       await user.type(nameInput, 'My App');
@@ -384,11 +415,14 @@ describe('ApplicationCreatePage', () => {
     it('should navigate to design step from name step', async () => {
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
       const nameInput = screen.getByTestId('app-name-input');
       await user.type(nameInput, 'My App');
 
-      const continueButton = screen.getByRole('button', {name: /continue/i});
-      await user.click(continueButton);
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
 
       expect(screen.getByTestId('application-configure-design')).toBeInTheDocument();
       expect(screen.queryByTestId('application-configure-name')).not.toBeInTheDocument();
@@ -397,8 +431,13 @@ describe('ApplicationCreatePage', () => {
     it('should show preview from design step onwards', async () => {
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
       const nameInput = screen.getByTestId('app-name-input');
       await user.type(nameInput, 'My App');
+
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       expect(screen.getByTestId('preview')).toBeInTheDocument();
@@ -407,29 +446,27 @@ describe('ApplicationCreatePage', () => {
     it('should navigate through all steps', async () => {
       renderWithProviders();
 
-      // Step 1: Name
+      // Step 1: Stack
+      expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      // Step 2: Name
       await user.type(screen.getByTestId('app-name-input'), 'My App');
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      // Step 2: Design
+      // Step 3: Design
       expect(screen.getByTestId('application-configure-design')).toBeInTheDocument();
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      // Step 3: Sign In Options
+      // Step 4: Sign In Options
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      // Step 4: Experience
+      // Step 5: Experience
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
-      });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      // Step 5: Stack
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
       });
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
@@ -439,10 +476,10 @@ describe('ApplicationCreatePage', () => {
       });
     });
 
-    it('should show Back button from design step onwards', async () => {
+    it('should show Back button from name step onwards', async () => {
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       expect(screen.getByRole('button', {name: /back/i})).toBeInTheDocument();
@@ -451,12 +488,13 @@ describe('ApplicationCreatePage', () => {
     it('should navigate back to previous step', async () => {
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      // NAME → STACK (back)
       await user.click(screen.getByRole('button', {name: /back/i}));
 
-      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
-      expect(screen.queryByTestId('application-configure-design')).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-name')).not.toBeInTheDocument();
     });
   });
 
@@ -464,13 +502,19 @@ describe('ApplicationCreatePage', () => {
     it('should update breadcrumb as user progresses', async () => {
       renderWithProviders();
 
+      expect(screen.getByText('Technology Stack')).toBeInTheDocument();
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       expect(screen.getByText('Create an Application')).toBeInTheDocument();
 
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       expect(screen.getByText('Design')).toBeInTheDocument();
 
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       expect(screen.getByText('Sign In Options')).toBeInTheDocument();
@@ -479,14 +523,18 @@ describe('ApplicationCreatePage', () => {
     it('should allow clicking on previous breadcrumb steps', async () => {
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      const firstBreadcrumb = screen.getByText('Create an Application');
+      const firstBreadcrumb = screen.getByText('Technology Stack');
       await user.click(firstBreadcrumb);
 
-      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+      expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
     });
   });
 
@@ -508,6 +556,9 @@ describe('ApplicationCreatePage', () => {
     it('should update app name state', async () => {
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
       const nameInput = screen.getByTestId('app-name-input');
       await user.type(nameInput, 'Test App');
 
@@ -517,10 +568,15 @@ describe('ApplicationCreatePage', () => {
     it('should preserve app name when navigating between steps', async () => {
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
       const nameInput = screen.getByTestId('app-name-input');
       await user.type(nameInput, 'My App');
 
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → NAME (back)
       await user.click(screen.getByRole('button', {name: /back/i}));
 
       expect(screen.getByTestId('app-name-input')).toHaveValue('My App');
@@ -529,7 +585,10 @@ describe('ApplicationCreatePage', () => {
     it('should update logo in state', async () => {
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       const logoButton = screen.getByTestId('logo-select-btn');
@@ -548,28 +607,30 @@ describe('ApplicationCreatePage', () => {
       renderWithProviders();
 
       // Navigate through all steps
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -591,28 +652,30 @@ describe('ApplicationCreatePage', () => {
       renderWithProviders();
 
       // Navigate through all steps
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -632,14 +695,18 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      // Navigate to experience step
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Select embedded approach
@@ -648,12 +715,7 @@ describe('ApplicationCreatePage', () => {
       });
       const selectEmbeddedBtn = screen.getByTestId('select-embedded-approach');
       await user.click(selectEmbeddedBtn);
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      // Continue from stack - should create app immediately
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → Create (embedded skips configure)
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -675,24 +737,25 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
       await user.click(screen.getByTestId('select-embedded-approach'));
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → Create (embedded skips configure)
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should NOT show configure details step
@@ -711,28 +774,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(
@@ -750,28 +815,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(
@@ -798,33 +865,35 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Select a theme
       const selectThemeBtn = screen.getByTestId('select-theme-btn');
       await user.click(selectThemeBtn);
 
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -841,8 +910,12 @@ describe('ApplicationCreatePage', () => {
     it('should allow toggling integrations', async () => {
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -860,23 +933,24 @@ describe('ApplicationCreatePage', () => {
     it('should update OAuth config when callback URL changes', async () => {
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
@@ -911,28 +985,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step with client secret
@@ -955,28 +1031,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should navigate directly to application details page
@@ -1008,28 +1086,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
@@ -1067,28 +1147,30 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
-      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // STACK → NAME
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
@@ -1120,7 +1202,10 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Preview should be visible on DESIGN step
@@ -1128,26 +1213,25 @@ describe('ApplicationCreatePage', () => {
         expect(screen.getByTestId('preview')).toBeInTheDocument();
       });
 
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
       });
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
       });
-      await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('application-configure-stack')).toBeInTheDocument();
-      });
+      // EXPERIENCE → CONFIGURE
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
       });
+      // CONFIGURE → Create
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Should show COMPLETE step
@@ -1157,6 +1241,187 @@ describe('ApplicationCreatePage', () => {
 
       // Preview should not be visible on COMPLETE step
       expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Backend Platform (BACKEND / M2M) Flow', () => {
+    it('should skip DESIGN, OPTIONS, EXPERIENCE and create app directly from NAME step', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-1', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      // Select BACKEND platform in STACK step
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      // Enter app name
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → [create immediately]
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      // Should not have visited DESIGN, OPTIONS or EXPERIENCE
+      expect(screen.queryByTestId('application-configure-design')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-sign-in')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('application-configure-experience')).not.toBeInTheDocument();
+    });
+
+    it('should create backend app without userAttributes, isRegistrationFlowEnabled, or themeId', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-2', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.userAttributes).toBeUndefined();
+      expect(createAppCall.isRegistrationFlowEnabled).toBeUndefined();
+      expect(createAppCall.themeId).toBeUndefined();
+      expect(createAppCall.logoUrl).toBeUndefined();
+    });
+
+    it('should include the backend template id in the create request', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-3', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.template).toBe('backend');
+    });
+
+    it('should include inboundAuthConfig (OAuth) in the backend create request', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-4', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.inboundAuthConfig).toBeDefined();
+    });
+
+    it('should show COMPLETE step with client secret after backend app creation', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({
+          id: 'backend-app-5',
+          name: 'My Backend App',
+          inboundAuthConfig: [
+            {
+              type: 'oauth2',
+              config: {
+                clientId: 'backend-client-id',
+                clientSecret: 'backend_secret_xyz',
+                redirectUris: [] as string[],
+              },
+            },
+          ],
+        } as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create → COMPLETE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-show-client-secret')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('application-client-secret-value')).toHaveTextContent('backend_secret_xyz');
+    });
+
+    it('should show only STACK and NAME in breadcrumb for backend platform', async () => {
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      // On NAME step breadcrumb should show STACK (clickable) and NAME (current)
+      expect(screen.getByText('Technology Stack')).toBeInTheDocument();
+      expect(screen.getByText('Create an Application')).toBeInTheDocument();
+      // Design/Options/Experience should NOT appear in breadcrumb
+      expect(screen.queryByText('Design')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sign In Options')).not.toBeInTheDocument();
+    });
+
+    it('should not show a flow-not-found error when creating a backend app without a selected auth flow', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-6', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create (no auth flow selected)
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      expect(screen.queryByText(/no.*flow/i)).not.toBeInTheDocument();
     });
   });
 
@@ -1206,9 +1471,13 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       // Navigate to options step
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // At Options step
@@ -1219,12 +1488,12 @@ describe('ApplicationCreatePage', () => {
       // Trigger setup
       await user.click(screen.getByTestId('setup-flow-generation'));
 
+      // OPTIONS → EXPERIENCE
       await user.click(screen.getByRole('button', {name: /continue/i}));
-
-      // Experience -> Stack -> Configure
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Experience
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Stack
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Configure Details
+      // EXPERIENCE → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // CONFIGURE → Create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Verify generateFlowGraph called
       await waitFor(() => {
@@ -1272,10 +1541,14 @@ describe('ApplicationCreatePage', () => {
 
       renderWithProviders();
 
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
       // Navigate to trigger point
       await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
       await user.click(screen.getByRole('button', {name: /continue/i}));
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Design
+      // DESIGN → OPTIONS
+      await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Options step
       await waitFor(() => {
@@ -1285,10 +1558,12 @@ describe('ApplicationCreatePage', () => {
       // Trigger setup
       await user.click(screen.getByTestId('setup-flow-generation-error'));
 
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Options -> Experience
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Experience -> Stack
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Stack -> Configure
-      await user.click(screen.getByRole('button', {name: /continue/i})); // Configure -> Create
+      // OPTIONS → EXPERIENCE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // EXPERIENCE → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // CONFIGURE → Create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
 
       await waitFor(() => {
         expect(screen.getByText('Flow generation failed')).toBeInTheDocument();

--- a/frontend/apps/console/src/features/applications/utils/__tests__/resolveCreationFlow.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/resolveCreationFlow.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {ApplicationCreateFlowStep} from '../../models/application-create-flow';
+import resolveCreationFlow from '../resolveCreationFlow';
+
+describe('resolveCreationFlow', () => {
+  it('returns the default user-facing flow (8 steps) when template is null', () => {
+    const flow = resolveCreationFlow(null);
+    expect(flow.steps).toEqual([
+      ApplicationCreateFlowStep.STACK,
+      ApplicationCreateFlowStep.NAME,
+      ApplicationCreateFlowStep.ORGANIZATION_UNIT,
+      ApplicationCreateFlowStep.DESIGN,
+      ApplicationCreateFlowStep.OPTIONS,
+      ApplicationCreateFlowStep.EXPERIENCE,
+      ApplicationCreateFlowStep.CONFIGURE,
+      ApplicationCreateFlowStep.COMPLETE,
+    ]);
+  });
+
+  it('returns the default user-facing flow when the template has no creationFlow field', () => {
+    const flow = resolveCreationFlow({id: 'react', displayName: 'React'});
+    expect(flow.steps).toEqual([
+      ApplicationCreateFlowStep.STACK,
+      ApplicationCreateFlowStep.NAME,
+      ApplicationCreateFlowStep.ORGANIZATION_UNIT,
+      ApplicationCreateFlowStep.DESIGN,
+      ApplicationCreateFlowStep.OPTIONS,
+      ApplicationCreateFlowStep.EXPERIENCE,
+      ApplicationCreateFlowStep.CONFIGURE,
+      ApplicationCreateFlowStep.COMPLETE,
+    ]);
+  });
+
+  it('returns the inline creationFlow from the template when present', () => {
+    const flow = resolveCreationFlow({
+      id: 'backend',
+      creationFlow: {
+        steps: [ApplicationCreateFlowStep.STACK, ApplicationCreateFlowStep.NAME, ApplicationCreateFlowStep.COMPLETE],
+      },
+    });
+    expect(flow.steps).toEqual([
+      ApplicationCreateFlowStep.STACK,
+      ApplicationCreateFlowStep.NAME,
+      ApplicationCreateFlowStep.COMPLETE,
+    ]);
+  });
+});

--- a/frontend/apps/console/src/features/applications/utils/resolveCreationFlow.ts
+++ b/frontend/apps/console/src/features/applications/utils/resolveCreationFlow.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {ApplicationCreateFlowStep} from '../models/application-create-flow';
+import type {ApplicationTemplate} from '../models/application-templates';
+import type {CreationFlow} from '../models/creation-flow';
+
+const DEFAULT_USER_FACING_FLOW: CreationFlow = {
+  steps: [
+    ApplicationCreateFlowStep.STACK,
+    ApplicationCreateFlowStep.NAME,
+    ApplicationCreateFlowStep.ORGANIZATION_UNIT,
+    ApplicationCreateFlowStep.DESIGN,
+    ApplicationCreateFlowStep.OPTIONS,
+    ApplicationCreateFlowStep.EXPERIENCE,
+    ApplicationCreateFlowStep.CONFIGURE,
+    ApplicationCreateFlowStep.COMPLETE,
+  ],
+};
+
+/**
+ * Resolve the creation flow for the given template. Templates that don't declare a
+ * `creationFlow` fall back to the default user-facing flow.
+ */
+export default function resolveCreationFlow(template: ApplicationTemplate | null): CreationFlow {
+  return template?.creationFlow ?? DEFAULT_USER_FACING_FLOW;
+}

--- a/tests/e2e/tests/applications/application-onboarding.spec.ts
+++ b/tests/e2e/tests/applications/application-onboarding.spec.ts
@@ -93,40 +93,40 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.screenshot("tc002-wizard-opened");
       });
 
-      await test.step("Step 1 [configure-name]: Fill app name and click Next", async () => {
+      await test.step("Step 1 [configure-stack]: Skip and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-stack");
+        console.log("Step 1 (configure-stack) visible - skipping");
+        await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc002-step1-done");
+      });
+
+      await test.step("Step 2 [configure-name]: Fill app name and click Next", async () => {
         await applicationsPage.waitForStep("application-configure-name");
-        console.log("Step 1 visible - filling app name:", appData.name);
+        console.log("Step 2 visible - filling app name:", appData.name);
         await applicationsPage.fillAppName(appData.name);
         await applicationsPage.clickNext();
-        console.log("Clicked Next on Step 1");
-        await applicationsPage.screenshot("tc002-step1-done");
+        console.log("Clicked Next on Step 2");
+        await applicationsPage.screenshot("tc002-step2-done");
         await applicationsPage.handleOptionalOuStep();
       });
 
-      await test.step("Step 3 [configure-design]: Skip and click Next", async () => {
+      await test.step("Step 4 [configure-design]: Skip and click Next", async () => {
         await applicationsPage.waitForStep("application-configure-design");
-        console.log("Step 3 (configure-design) visible - skipping");
-        await applicationsPage.clickNext();
-        await applicationsPage.screenshot("tc002-step3-done");
-      });
-
-      await test.step("Step 4 [configure-sign-in]: Skip and click Next", async () => {
-        await applicationsPage.waitForStep("application-configure-sign-in");
-        console.log("Step 4 (configure-sign-in) visible - skipping");
+        console.log("Step 4 (configure-design) visible - skipping");
         await applicationsPage.clickNext();
         await applicationsPage.screenshot("tc002-step4-done");
       });
 
-      await test.step("Step 5 [configure-experience]: Verify INBUILT is default and click Next", async () => {
-        await applicationsPage.waitForStep("application-configure-experience");
-        console.log("Step 5 (configure-experience) visible - INBUILT is default, clicking Next");
+      await test.step("Step 5 [configure-sign-in]: Skip and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-sign-in");
+        console.log("Step 5 (configure-sign-in) visible - skipping");
         await applicationsPage.clickNext();
         await applicationsPage.screenshot("tc002-step5-done");
       });
 
-      await test.step("Step 6 [configure-stack]: Skip and click Next", async () => {
-        await applicationsPage.waitForStep("application-configure-stack");
-        console.log("Step 6 (configure-stack) visible - skipping");
+      await test.step("Step 6 [configure-experience]: Verify INBUILT is default and click Next", async () => {
+        await applicationsPage.waitForStep("application-configure-experience");
+        console.log("Step 6 (configure-experience) visible - INBUILT is default, clicking Next");
         await applicationsPage.clickNext();
         await applicationsPage.screenshot("tc002-step6-done");
       });
@@ -152,8 +152,10 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.goto();
         await applicationsPage.verifyPageLoaded();
         await applicationsPage.clickAddApplication();
+        await applicationsPage.waitForStep("application-configure-stack");
+        await applicationsPage.clickNext();
         await applicationsPage.waitForStep("application-configure-name");
-        console.log("Step 1 visible with empty name input");
+        console.log("Step 2 visible with empty name input");
         await applicationsPage.screenshot("tc003-empty-name");
       });
 
@@ -180,32 +182,32 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.clickAddApplication();
       });
 
-      await test.step("Step 1: Fill name and advance", async () => {
+      await test.step("Step 1: Skip stack and advance", async () => {
+        await applicationsPage.waitForStep("application-configure-stack");
+        await applicationsPage.clickNext();
+      });
+
+      await test.step("Step 2: Fill name and advance", async () => {
         await applicationsPage.waitForStep("application-configure-name");
         await applicationsPage.fillAppName(appData.name);
         await applicationsPage.clickNext();
         await applicationsPage.handleOptionalOuStep();
       });
 
-      await test.step("Steps 3 & 4: Skip design and sign-in", async () => {
+      await test.step("Steps 4 & 5: Skip design and sign-in", async () => {
         await applicationsPage.waitForStep("application-configure-design");
         await applicationsPage.clickNext();
         await applicationsPage.waitForStep("application-configure-sign-in");
         await applicationsPage.clickNext();
       });
 
-      await test.step("Step 5: Select EMBEDDED and advance", async () => {
+      await test.step("Step 6: Select EMBEDDED and verify configure-details is skipped", async () => {
         await applicationsPage.waitForStep("application-configure-experience");
         console.log("Selecting EMBEDDED experience");
         await applicationsPage.selectEmbeddedExperience();
-        await applicationsPage.clickNext();
-        await applicationsPage.screenshot("tc004-embedded-selected");
-      });
-
-      await test.step("Step 6: Skip configure-stack and verify configure-details is skipped", async () => {
-        await applicationsPage.waitForStep("application-configure-stack");
         await expect(applicationsPage.configureDetailsStep).not.toBeVisible();
         await applicationsPage.clickNext();
+        await applicationsPage.screenshot("tc004-embedded-selected");
         console.log("configure-details was never shown - correct EMBEDDED behaviour");
         // EMBEDDED without passkey creates app directly and navigates to edit page
         await applicationsPage.page.waitForURL(/\/console\/applications\/(?!create)[^/]+$/, { timeout: 30000 });
@@ -225,6 +227,9 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.verifyPageLoaded();
         await applicationsPage.clickAddApplication();
 
+        await applicationsPage.waitForStep("application-configure-stack");
+        await applicationsPage.clickNext();
+
         await applicationsPage.waitForStep("application-configure-name");
         await applicationsPage.fillAppName(appData.name);
         await applicationsPage.clickNext();
@@ -235,8 +240,6 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.waitForStep("application-configure-sign-in");
         await applicationsPage.clickNext();
         await applicationsPage.waitForStep("application-configure-experience");
-        await applicationsPage.clickNext();
-        await applicationsPage.waitForStep("application-configure-stack");
         await applicationsPage.clickNext();
 
         createdAppUrl = await applicationsPage.completeWizardCreation();


### PR DESCRIPTION
### Purpose
Revamp application creation wizard step order and skip sign-in steps for backend apps

Move the STACK (technology/platform) step to the first position in the wizard, followed by NAME and the remaining steps. For backend service apps (client_credentials), skip DESIGN, OPTIONS, and EXPERIENCE steps since they configure user-facing sign-in which is not applicable to machine-to-machine applications.

### Related Issue(s)
- https://github.com/thunder-id/thunder-id/issues/2093


https://github.com/user-attachments/assets/3c1850b4-2a79-4bf2-831b-801f611f97d3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application creation wizard now begins with platform/stack selection instead of app name entry, providing a more logical onboarding sequence.
  * Application templates can now define custom creation flow steps, enabling template-specific wizard configurations.

* **Bug Fixes**
  * Improved conditional logic for required fields in the creation request based on selected wizard steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunder-id/pull/2659)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->