### PR TITLE
Update post-release sync workflow to remove branch deletion step

### DIFF
--- a/.github/workflows/post-release-sync.yml
+++ b/.github/workflows/post-release-sync.yml
@@ -1,5 +1,5 @@
 # This workflow merges release back into main after a successful release run.
-# If there are no conflicts, it commits directly and deletes the release branch.
+# If there are no conflicts, it commits directly to main.
 # If there are conflicts, it creates a sync PR for manual resolution.
 # Can also be started manually from the Actions tab.
 
@@ -67,12 +67,6 @@ jobs:
           echo "✅ Successfully merged ${SOURCE_BRANCH} into ${TARGET_BRANCH}."
           echo "conflict_detected=false" >> "$GITHUB_OUTPUT"
           echo "merged=true" >> "$GITHUB_OUTPUT"
-
-      - name: 🗑️ Delete Release Branch
-        if: steps.merge_sync.outputs.merged == 'true'
-        run: |
-          git push origin --delete "${SOURCE_BRANCH}"
-          echo "✅ Deleted '${SOURCE_BRANCH}' branch."
 
       - name: 🔔 Create Sync PR for Conflict Resolution
         if: steps.merge_sync.outputs.conflict_detected == 'true'


### PR DESCRIPTION
### Purpose
This pull request updates the post-release sync workflow to improve branch management after a successful release. The main change is that the workflow no longer deletes the release branch automatically after merging into `main`.

**Workflow behavior changes:**

* [`.github/workflows/post-release-sync.yml`](diffhunk://#diff-ff53de2491564f4f381e566715bc788174444854c34610ac092ede3554675ed2L71-L76): Removed the automatic deletion of the release branch after a successful merge into `main`. Now, the release branch is retained even after merging, which may help with traceability or manual cleanup.
* [`.github/workflows/post-release-sync.yml`](diffhunk://#diff-ff53de2491564f4f381e566715bc788174444854c34610ac092ede3554675ed2L2-R2): Updated the workflow documentation to reflect that the release branch is no longer deleted automatically.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to refine post-release synchronization behavior.

---

**Note:** This release contains no end-user facing changes. The update affects internal release process workflows only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunder-id/pull/2682)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->