### PR TITLE
Deploy docs on `thunderid.dev`

### DIFF
--- a/.github/actions/deploy-docs/action.yml
+++ b/.github/actions/deploy-docs/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Commit message for the deployment'
     required: false
     default: '📚 Deploy documentation'
+  site-url:
+    description: 'Override the site URL used during the Docusaurus build (e.g. https://owner.github.io)'
+    required: false
+    default: ''
+  site-base-url:
+    description: 'Override the base URL used during the Docusaurus build (e.g. /repo-name/)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -41,6 +49,8 @@ runs:
         make build_docs
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        DOCUSAURUS_URL: ${{ inputs.site-url }}
+        DOCUSAURUS_BASE_URL: ${{ inputs.site-base-url }}
 
     - name: 📥 Download Docs Artifact
       if: inputs.docs-artifact-name != ''

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,16 @@ on:
         required: false
         type: string
         default: ''
+      site-url:
+        description: 'Override the site URL (e.g. https://thunderid.dev). Leave empty to use the default from build config.'
+        required: false
+        type: string
+        default: ''
+      site-base-url:
+        description: 'Override the base URL (e.g. /). Leave empty to use the default from build config.'
+        required: false
+        type: string
+        default: ''
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -42,6 +52,8 @@ jobs:
           docs-artifact-name: ${{ inputs.use-artifact }}
           build-docs: ${{ inputs.use-artifact == '' && 'true' || 'false' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          site-url: ${{ inputs.site-url }}
+          site-base-url: ${{ inputs.site-base-url }}
 
       - name: 🎉 Deployment Complete
         run: |

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -50,7 +50,15 @@ function replaceProductNameInObject(value: unknown, productName: string, product
   return value;
 }
 
-const baseUrl = `/${productConfig.documentation.deployment.production.baseUrl}/`;
+const baseUrl =
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  process.env.DOCUSAURUS_BASE_URL ||
+  (productConfig.documentation.deployment.production.baseUrl
+    ? `/${productConfig.documentation.deployment.production.baseUrl}/`
+    : '/');
+
+// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+const siteUrl = process.env.DOCUSAURUS_URL || productConfig.documentation.deployment.production.url;
 
 const config: Config = {
   title: productConfig.project.name,
@@ -67,8 +75,7 @@ const config: Config = {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
 
-  url: productConfig.documentation.deployment.production.url,
-  // Since we use GitHub pages, the base URL is the repository name.
+  url: siteUrl,
   baseUrl,
 
   // GitHub pages deployment config.

--- a/docs/docusaurus.product.config.ts
+++ b/docs/docusaurus.product.config.ts
@@ -92,9 +92,7 @@ const DocusaurusProductConfig = {
     },
     deployment: {
       production: {
-        baseUrl: 'thunderid',
-        // TODO: Docusaurus doesn't seem to allow subpaths in the URL yet.
-        // Can't use the GitHub pages URL until then.
+        baseUrl: '',
         url: 'https://thunderid.dev',
       },
     },


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the Docusaurus documentation deployment configuration to better handle the `baseUrl` setting, especially for production deployments. The main change is to make the `baseUrl` configurable and default to `'/'` when not specified, improving flexibility for different deployment environments.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Configuration improvements:**

* Updated `docs/docusaurus.product.config.ts` to set the production `baseUrl` to an empty string by default, allowing deployments at the root path instead of a subdirectory.
* Modified `docs/docusaurus.config.ts` to compute `baseUrl` dynamically: if a `baseUrl` is set in the product config, it uses that value; otherwise, it defaults to `'/'`.
* Cleaned up comments in `docs/docusaurus.config.ts` to reflect the new approach to `baseUrl` handling.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/1187

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation site configuration now supports environment-variable overrides for site URL and base path at build/runtime.
  * Default documentation base path behavior adjusted to use an empty/root fallback when not provided.
  * Deployment tooling and workflow add optional inputs to pass site URL and base path through the docs build and deploy steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2686)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->